### PR TITLE
Allow to map table columns to List<T> properties

### DIFF
--- a/Runtime/Assist/TEHelpers.cs
+++ b/Runtime/Assist/TEHelpers.cs
@@ -95,7 +95,19 @@ namespace TechTalk.SpecFlow.Assist
                 return true;
             if (property.PropertyType.IsGenericType && property.PropertyType.GetGenericTypeDefinition() == typeof(Nullable<>))
                 return key.IsAssignableFrom(property.PropertyType.GetGenericArguments()[0]);
+
+            if (GetGenericTypeDefinition(key) == GetGenericTypeDefinition(property.PropertyType))
+                return true; 
+
             return false;
+        }
+
+        static Type GetGenericTypeDefinition(Type type)
+        {
+            if (type.IsGenericType)
+                return type.GetGenericTypeDefinition();
+
+            return type;
         }
 
         internal static Dictionary<Type, Func<TableRow, object>> GetTypeHandlersForFieldValuePairs<T>()
@@ -134,6 +146,7 @@ namespace TechTalk.SpecFlow.Assist
                            {typeof (Guid), (TableRow row) => new GuidValueRetriever().GetValue(row[1])},
                            {typeof (Guid?), (TableRow row) => new NullableGuidValueRetriever(v => new GuidValueRetriever().GetValue(v)).GetValue(row[1])},
                            {typeof (Enum), (TableRow row) => new EnumValueRetriever().GetValue(row[1], typeof (T).GetProperties().First(x => x.Name.MatchesThisColumnName(row[0])).PropertyType)},
+                           {typeof (List<>), (TableRow row) => new ListValueRetriever().GetValue(row[1], typeof (T).GetProperties().First(x => x.Name.MatchesThisColumnName(row[0])).PropertyType)},
                        };
         }
 

--- a/Runtime/Assist/ValueRetrievers/ListValueRetriever.cs
+++ b/Runtime/Assist/ValueRetrievers/ListValueRetriever.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace TechTalk.SpecFlow.Assist.ValueRetrievers
+{
+    public class ListValueRetriever
+    {
+        internal object GetValue(string values, Type listType)
+        {
+            var elementType = listType.GetGenericArguments().Single();
+
+            object list = Activator.CreateInstance(listType);
+            var add = listType.GetMethod("Add");
+            foreach (var value in values.Split(new[] { "," }, StringSplitOptions.None).Select(v => v.Trim()).Select(v => Convert.ChangeType(v, elementType)))
+                add.Invoke(list, new[] { value });
+
+            return list;
+        }
+    }
+}

--- a/Runtime/Assist/ValueRetrievers/ListValueRetriever.cs
+++ b/Runtime/Assist/ValueRetrievers/ListValueRetriever.cs
@@ -13,8 +13,15 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
 
             object list = Activator.CreateInstance(listType);
             var add = listType.GetMethod("Add");
-            foreach (var value in values.Split(new[] { "," }, StringSplitOptions.None).Select(v => v.Trim()).Select(v => Convert.ChangeType(v, elementType)))
+
+            foreach (var value in values
+                .Split(new[] { "," }, StringSplitOptions.None)
+                .Select(v => v.Trim())
+                .Where(v => !string.IsNullOrEmpty(v))
+                .Select(v => Convert.ChangeType(v, elementType)))
+            {
                 add.Invoke(list, new[] { value });
+            }
 
             return list;
         }

--- a/Runtime/TechTalk.SpecFlow.csproj
+++ b/Runtime/TechTalk.SpecFlow.csproj
@@ -79,6 +79,7 @@
     <Compile Include="Assist\ValueRetrievers\BoolValueRetriever.cs" />
     <Compile Include="Assist\ValueRetrievers\ByteValueRetriever.cs" />
     <Compile Include="Assist\ValueRetrievers\CharValueRetriever.cs" />
+    <Compile Include="Assist\ValueRetrievers\ListValueRetriever.cs" />
     <Compile Include="Assist\ValueRetrievers\LongValueRetriever.cs" />
     <Compile Include="Assist\ValueRetrievers\NullableByteValueRetriever.cs" />
     <Compile Include="Assist\ValueRetrievers\NullableLongValueRetriever.cs" />

--- a/Tests/RuntimeTests/AssistTests/CreateInstanceHelperMethodTests.cs
+++ b/Tests/RuntimeTests/AssistTests/CreateInstanceHelperMethodTests.cs
@@ -38,12 +38,30 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests
         }
 
         [Test]
-        public void Create_instance_will_parse_and_set_list_properties()
+        public void Create_instance_will_parse_and_set_empty_list()
+        {
+            var table = new Table("Holidays");
+            table.AddRow("");
+            var person = table.CreateInstance<Person>();
+            person.Holidays.ShouldBeEmpty();
+        }
+
+        [Test]
+        public void Create_instance_will_parse_and_set_list_of_dates()
         {
             var table = new Table("Holidays");
             table.AddRow("2 September 2012, 3 November 2013, 2014-01-15");
             var person = table.CreateInstance<Person>();
             person.Holidays.ShouldEqual(new[] { new DateTime(2012, 9, 2), new DateTime(2013, 11, 3), new DateTime(2014, 1, 15) }.ToList());
+        }
+
+        [Test]
+        public void Create_instance_will_parse_and_set_list_of_numbers()
+        {
+            var table = new Table("FavoriteNumbers");
+            table.AddRow("1,7,42");
+            var person = table.CreateInstance<Person>();
+            person.FavoriteNumbers.ShouldEqual(new[] { 1,7,42 }.ToList());
         }
 
         [Test]

--- a/Tests/RuntimeTests/AssistTests/CreateInstanceHelperMethodTests.cs
+++ b/Tests/RuntimeTests/AssistTests/CreateInstanceHelperMethodTests.cs
@@ -5,6 +5,7 @@ using NUnit.Framework;
 using Should;
 using TechTalk.SpecFlow.Assist;
 using TechTalk.SpecFlow.RuntimeTests.AssistTests.ExampleEntities;
+using System.Linq;
 
 namespace TechTalk.SpecFlow.RuntimeTests.AssistTests
 {
@@ -34,6 +35,15 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests
             var person = table.CreateInstance<Person>();
 
             person.FirstName.ShouldEqual("Howard");
+        }
+
+        [Test]
+        public void Create_instance_will_parse_and_set_list_properties()
+        {
+            var table = new Table("Holidays");
+            table.AddRow("2 September 2012, 3 November 2013, 2014-01-15");
+            var person = table.CreateInstance<Person>();
+            person.Holidays.ShouldEqual(new[] { new DateTime(2012, 9, 2), new DateTime(2013, 11, 3), new DateTime(2014, 1, 15) }.ToList());
         }
 
         [Test]

--- a/Tests/RuntimeTests/AssistTests/ExampleEntities/Person.cs
+++ b/Tests/RuntimeTests/AssistTests/ExampleEntities/Person.cs
@@ -1,9 +1,12 @@
 ﻿using System;
+using System.Collections.Generic;
 
 namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.ExampleEntities
 {
     public class Person
     {
+        public List<DateTime> Holidays { get; set; }
+
         public Sex Sex { get; set; }
         public string FirstName { get; set; }
         public char MiddleInitial { get; set; }

--- a/Tests/RuntimeTests/AssistTests/ExampleEntities/Person.cs
+++ b/Tests/RuntimeTests/AssistTests/ExampleEntities/Person.cs
@@ -6,6 +6,7 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.ExampleEntities
     public class Person
     {
         public List<DateTime> Holidays { get; set; }
+        public List<int> FavoriteNumbers { get; set; }
 
         public Sex Sex { get; set; }
         public string FirstName { get; set; }


### PR DESCRIPTION
If we have a class with `List<T>` property

``` c#
class TestData
{
    public List<int> Values { get; set; }
}
```

and SpecFlow feature

```
Given data
    | Field  | Value |
    | Values | 1,5,7 |
```

then `table.CreateInstance` will populate `Values` list:

``` c#
[Given("data")]
public void GivenValue(Table table)
{
    var data = table.CreateInstance<TestClass>();
    // data.Values will contain { 1, 5, 7 }
}
```
