### PR TITLE
Include category breakdown in execution report

### DIFF
--- a/Reporting/MsTestExecutionReport/MsTestToNUnit.xslt
+++ b/Reporting/MsTestExecutionReport/MsTestToNUnit.xslt
@@ -190,7 +190,23 @@
       <xsl:variable name="id" select="@id" />
       <!--<xsl:variable name="testResult" select="/mstest:TestRun/mstest:Results/mstest:UnitTestResult[@testId=$id]" />-->
       <xsl:variable name="testResult" select="key('unit-test-result', $id)" />
-      
+      <xsl:variable name="resultCategory" >
+        <xsl:choose>
+          <xsl:when test="$testResult/@outcome='Failed'">
+            <xsl:text>_FailedTests</xsl:text>
+          </xsl:when>
+          <xsl:when test="$testResult/@outcome='Inconclusive'">
+            <xsl:text>_InconclusiveTests</xsl:text>
+          </xsl:when>
+          <xsl:when test="$testResult/@outcome='Passed'">
+            <xsl:text>_SucceededTests</xsl:text>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:text>_UnknownTests</xsl:text>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:variable>
+
       <xsl:attribute name="name">
         <xsl:value-of select="substring-before(mstest:TestMethod/@className, ',')"/>.<xsl:value-of select="@name"></xsl:value-of>
       </xsl:attribute>
@@ -252,7 +268,14 @@
           </nunit:message>
         </nunit:reason>
       </xsl:if>
-      
+
+      <nunit:categories>
+        <nunit:category name="{$resultCategory}" />
+        <xsl:for-each select="mstest:TestCategory/mstest:TestCategoryItem">
+          <nunit:category name="{@TestCategory}" />
+        </xsl:for-each>
+      </nunit:categories>
+
       <xsl:if test="$testResult/@outcome='Failed'">
         <nunit:failure>
           <nunit:message>

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,9 @@
+Proposed In Pull Request
+
+New features:
++ Report includes breakdown of test results by category
+
+
 1.9.1 - 2012/10/12 (Visual Studio Integration update)
 
 Fixed issues:


### PR DESCRIPTION
I wanted to get a nice graphical view of the @-tags in the execution report.

I didn't have much luck trying to use an external XSLT on the command line, instead I had to update the inbuilt-ones & hence this pull-request in case others think it useful.
I use MS-Test, so MsTestToNUnit.xslt is updated to port the category information across to the NUnit schema, then NUnitExecutionReport.xslt is extended to actually display the results by category.  Hence it might also work for NUnit, but I don't know.

Additionally, I've added three virtual-categories of Succeeded/Failed/Inconclusive tests so they can be all seen together.

TODOs would be to make this optional (how best to?) and possibly switch the UI from "Category" to "Tag" if that fits the SpecFlow lingo more.  Please advise if you want me to do them!

Tristan.
