### PR TITLE
Support nullable value types on properties when converting tables.

### DIFF
--- a/Runtime/Bindings/SimpleConverter.cs
+++ b/Runtime/Bindings/SimpleConverter.cs
@@ -20,6 +20,19 @@ namespace TechTalk.SpecFlow.Bindings
             if (runtimeType.Type == typeof(Guid) || runtimeType.Type == typeof(Guid?))
                 return new GuidValueRetriever().GetValue(value as string);
 
+            var targetNullableType = Nullable.GetUnderlyingType(runtimeType.Type);
+            // if property is nullable type
+            if (targetNullableType != null)
+            {
+                var stringVal = value as string;
+
+                // When .NET 4.0 or higher use string.IsNullOrWhiteSpace instead
+                if (string.IsNullOrEmpty(stringVal) || stringVal.Trim() == string.Empty)
+                    return null;
+
+                return System.Convert.ChangeType(stringVal, targetNullableType, cultureInfo);
+            }
+
             return System.Convert.ChangeType(value, runtimeType.Type, cultureInfo);
         }
 

--- a/Tests/RuntimeTests/TableConverterTests.cs
+++ b/Tests/RuntimeTests/TableConverterTests.cs
@@ -227,6 +227,32 @@ namespace TechTalk.SpecFlow.RuntimeTests
         }
 
         [Test]
+        public void Table_converters_will_support_nullable_types_as_property()
+        {
+            var table = new Table("FirstName", "MiddleInitial", "LastName", "NullableDouble");
+            table.AddRow("Homer", "J", "Simpson", null);
+            table.AddRow("Mona", "J", "Simpson", string.Empty);
+            table.AddRow("Mona", "J", "Simpson", "  ");
+            table.AddRow("Bart", "J", "Simpson", "3.1");
+
+            var result = PersonArrayConversionTest(table, true);
+            result.ShouldNotBeNull();
+            result.Length.ShouldEqual(4);
+            // null value
+            result[0].ShouldNotBeNull();
+            result[0].NullableDouble.ShouldBeNull();
+            //// empty string
+            result[1].ShouldNotBeNull();
+            result[1].NullableDouble.ShouldBeNull();
+            //// only white spaces
+            result[2].ShouldNotBeNull();
+            result[2].NullableDouble.ShouldBeNull();
+            //// double value
+            result[3].ShouldNotBeNull();
+            result[3].NullableDouble.ShouldEqual(3.1);
+        }
+
+        [Test]
         public void Table_converters_will_successfully_convert_an_horizontal_table_to_an_IEnumerable()
         {
             var table = new Table("Name");

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,8 @@
 1.9.3 - 2014/06/22 (Specflow Ms Test Report)
+
 New Features:
 + Specflow Test Execution report now includes the "tags" in the Nunit Report which can be displayed through a custom XSLT by the users.
++ Support nullable value types on properties when converting tables (SimpleConverter.cs).
 
 
 1.9.2 - 2013/03/25 (Visual Studio Integration update)


### PR DESCRIPTION
When converting table to objects with nullable value types as properties is now supported.
