### PR TITLE
Added additional line pragmas to link the generated tests back to the sc...

### DIFF
--- a/Generator/UnitTestFeatureGenerator.cs
+++ b/Generator/UnitTestFeatureGenerator.cs
@@ -464,9 +464,11 @@ namespace TechTalk.SpecFlow.Generator
                 ? string.Format("{0}_{1}", testMethod.Name, variantNameIdentifier)
                 : string.Format("{0}_{1}_{2}", testMethod.Name, exampleSetIdentifier, variantNameIdentifier);
 
+            
+            AddLineDirective(testMethod.Statements, row.FilePosition);
             //call test implementation with the params
             List<CodeExpression> argumentExpressions = row.Cells.Select(paramCell => new CodePrimitiveExpression(paramCell.Value)).Cast<CodeExpression>().ToList();
-
+            
             argumentExpressions.Add(GetStringArrayExpression(exampleSetTags));
 
             testMethod.Statements.Add(
@@ -474,7 +476,7 @@ namespace TechTalk.SpecFlow.Generator
                     new CodeThisReferenceExpression(),
                     scenatioOutlineTestMethod.Name,
                     argumentExpressions.ToArray()));
-
+            AddLineDirectiveHidden(testMethod.Statements);
             var arguments = paramToIdentifier.Select((p2i, paramIndex) => new KeyValuePair<string, string>(p2i.Key, row.Cells[paramIndex].Value)).ToList();
             testGeneratorProvider.SetTestMethodAsRow(generationContext, testMethod, scenarioOutline.Title, exampleSetTitle, variantName, arguments);
         }


### PR DESCRIPTION
...enario outline examples so that code coverage for the scenario examples works correctly in NCrunch.

I'm not sure if I have done this on the correct branch or not. I wasn't able to get the master branch to build, but got things working on here and the fix seems simple enough so merging into the correct branch should be fairly simple. If there is a more appropriate branch which is the current 'tip' of development then let me know and I'll redo the changes there.

Before, impossible to know which scenario was failing:
![image](https://cloud.githubusercontent.com/assets/2073290/4545773/be2fcac6-4e3d-11e4-92fe-da7c4db52c20.png)

After, clear which scenario is failing

![image](https://cloud.githubusercontent.com/assets/2073290/4545794/d8d005b2-4e3d-11e4-8c76-da94423015ce.png)

This will work for any test runners which generate the scenario examples WITHOUT using the [DataRow] attribute.  I'm not sure how it could be made to work for  test runners that use the [DataRow] attribute