### PR TITLE
Delimiter-aware RegEx in Attributes

### DIFF
--- a/Generator/TechTalk.SpecFlow.Generator.csproj
+++ b/Generator/TechTalk.SpecFlow.Generator.csproj
@@ -10,10 +10,11 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>TechTalk.SpecFlow.Generator</RootNamespace>
     <AssemblyName>TechTalk.SpecFlow.Generator</AssemblyName>
-    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\specflow.snk</AssemblyOriginatorKeyFile>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/Generator/TechTalk.SpecFlow.Generator.csproj
+++ b/Generator/TechTalk.SpecFlow.Generator.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>TechTalk.SpecFlow.Generator</RootNamespace>
     <AssemblyName>TechTalk.SpecFlow.Generator</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\specflow.snk</AssemblyOriginatorKeyFile>

--- a/Generator/TechTalk.SpecFlow.Generator.csproj
+++ b/Generator/TechTalk.SpecFlow.Generator.csproj
@@ -14,7 +14,6 @@
     <FileAlignment>512</FileAlignment>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\specflow.snk</AssemblyOriginatorKeyFile>
-    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/Runtime/BindingSkeletons/StepTextAnalyzer.cs
+++ b/Runtime/BindingSkeletons/StepTextAnalyzer.cs
@@ -46,34 +46,57 @@ namespace TechTalk.SpecFlow.BindingSkeletons
                 if (paramMatch.Index < textIndex)
                     continue;
 
-                result.TextParts.Add(stepText.Substring(textIndex, paramMatch.Index - textIndex));
-                result.Parameters.Add(AnalyzeParameter(paramMatch.Value, bindingCulture, result.Parameters.Count));
-                textIndex = paramMatch.Index + paramMatch.Length;
+                const string singleQuoteRegexPattern = "[^']*";
+                const string doubleQuoteRegexPattern = "[^\"\"]*";
+                const string defaultRegexPattern = ".*";
+
+                // Choose RegEx pattern based on quotation type
+                string regexPattern = defaultRegexPattern;
+                string value = paramMatch.Value;
+                int index = paramMatch.Index;
+
+                switch (value.Substring(0, 1))
+                {
+                    case "\"":
+                        regexPattern = doubleQuoteRegexPattern;
+                        value = value.Substring(1, value.Length - 2);
+                        index++;
+                        break;
+                    case "'":
+                        regexPattern = singleQuoteRegexPattern;
+                        value = value.Substring(1, value.Length - 2);
+                        index++;
+                        break;
+                }
+
+                result.TextParts.Add(stepText.Substring(textIndex, index - textIndex));
+                result.Parameters.Add(AnalyzeParameter(value, bindingCulture, result.Parameters.Count, regexPattern));
+                textIndex = index + value.Length;
             }
 
             result.TextParts.Add(stepText.Substring(textIndex));
             return result;
         }
 
-        private static AnalyzedStepParameter AnalyzeParameter(string value, CultureInfo bindingCulture, int paramIndex)
+        private static AnalyzedStepParameter AnalyzeParameter(string value, CultureInfo bindingCulture, int paramIndex, string regexPattern)
         {
             string paramName = "p" + paramIndex;
 
             int intParamValue;
             if (int.TryParse(value, NumberStyles.Integer, bindingCulture, out intParamValue))
-                return new AnalyzedStepParameter("Int32", paramName, ".*");
+                return new AnalyzedStepParameter("Int32", paramName, regexPattern);
 
             decimal decimalParamValue;
             if (decimal.TryParse(value, NumberStyles.Number, bindingCulture, out decimalParamValue))
-                return new AnalyzedStepParameter("Decimal", paramName, ".*");
+                return new AnalyzedStepParameter("Decimal", paramName, regexPattern);
 
-            return new AnalyzedStepParameter("String", paramName, ".*");
+            return new AnalyzedStepParameter("String", paramName, regexPattern);
         }
 
         private static readonly Regex quotesRe = new Regex(@"""+(?<param>.*?)""+|'+(?<param>.*?)'+|(?<param>\<.*?\>)");
-        private IEnumerable<Capture> RecognizeQuotedTexts(string stepText)
+        private IEnumerable<Match> RecognizeQuotedTexts(string stepText)
         {
-            return quotesRe.Matches(stepText).Cast<Match>().Select(m => (Capture)m.Groups["param"]);
+            return quotesRe.Matches(stepText).Cast<Match>();
         }
 
         private static readonly Regex intRe = new Regex(@"-?\d+");


### PR DESCRIPTION
See https://github.com/techtalk/SpecFlow/issues/309

I have used the * based RegEx patterns for single and double quotes as they most closely match the default pattern.

This should be a good solution for Issue 309 - although it may not be the most graceful version of the fix. I'm happy to be led in this respect as this is my first commit to SpecFlow. I am also having to force things to work on my machine, which won't let me install some of the developer dependencies as I have newer versions installed - I'm also working in "Target 4.0" mode and reverting to "Target 3.5" for check ins.

All tests in "RuntimeTests" pass.