### PR TITLE
NUnit generator: tags are added as categories to outline examples

### DIFF
--- a/Generator/UnitTestProvider/NUnitTestGeneratorProvider.cs
+++ b/Generator/UnitTestProvider/NUnitTestGeneratorProvider.cs
@@ -100,13 +100,17 @@ namespace TechTalk.SpecFlow.Generator.UnitTestProvider
             var args = arguments.Select(
               arg => new CodeAttributeArgument(new CodePrimitiveExpression(arg))).ToList();
 
-            // addressing ReSharper bug: TestCase attribute with empty string[] param causes inconclusive result - https://github.com/techtalk/SpecFlow/issues/116            
-            if (tags.Any())
-            {
-                var exampleTagExpressionList = tags.Select(t => new CodePrimitiveExpression(t)).ToArray();
-                CodeExpression exampleTagsExpression = new CodeArrayCreateExpression(typeof(string[]), exampleTagExpressionList);
-                args.Add(new CodeAttributeArgument(exampleTagsExpression));
+            // addressing ReSharper bug: TestCase attribute with empty string[] param causes inconclusive result - https://github.com/techtalk/SpecFlow/issues/116
+            bool hasExampleTags = tags.Any();
+            var exampleTagExpressionList = tags.Select(t => new CodePrimitiveExpression(t));
+            CodeExpression exampleTagsExpression = hasExampleTags ?
+                (CodeExpression)new CodePrimitiveExpression(null) :
+                new CodeArrayCreateExpression(typeof(string[]), exampleTagExpressionList.ToArray());
+            args.Add(new CodeAttributeArgument(exampleTagsExpression));
 
+            // adds 'Category' named parameter so that NUnit also understands that this test case belongs to the given categories
+            if (hasExampleTags)
+            {
                 CodeExpression exampleTagsStringExpr = new CodePrimitiveExpression(string.Join(",", tags.ToArray()));
                 args.Add(new CodeAttributeArgument("Category", exampleTagsStringExpr));
             }

--- a/Generator/UnitTestProvider/NUnitTestGeneratorProvider.cs
+++ b/Generator/UnitTestProvider/NUnitTestGeneratorProvider.cs
@@ -100,12 +100,16 @@ namespace TechTalk.SpecFlow.Generator.UnitTestProvider
             var args = arguments.Select(
               arg => new CodeAttributeArgument(new CodePrimitiveExpression(arg))).ToList();
 
-            // addressing ReSharper bug: TestCase attribute with empty string[] param causes inconclusive result - https://github.com/techtalk/SpecFlow/issues/116
-            var exampleTagExpressionList = tags.Select(t => new CodePrimitiveExpression(t)).ToArray();
-            CodeExpression exampleTagsExpression = exampleTagExpressionList.Length == 0 ?
-                (CodeExpression)new CodePrimitiveExpression(null) :
-                new CodeArrayCreateExpression(typeof(string[]), exampleTagExpressionList);
-            args.Add(new CodeAttributeArgument(exampleTagsExpression));
+            // addressing ReSharper bug: TestCase attribute with empty string[] param causes inconclusive result - https://github.com/techtalk/SpecFlow/issues/116            
+            if (tags.Any())
+            {
+                var exampleTagExpressionList = tags.Select(t => new CodePrimitiveExpression(t)).ToArray();
+                CodeExpression exampleTagsExpression = new CodeArrayCreateExpression(typeof(string[]), exampleTagExpressionList);
+                args.Add(new CodeAttributeArgument(exampleTagsExpression));
+
+                CodeExpression exampleTagsStringExpr = new CodePrimitiveExpression(string.Join(",", tags.ToArray()));
+                args.Add(new CodeAttributeArgument("Category", exampleTagsStringExpr));
+            }
 
             if (isIgnored)
                 args.Add(new CodeAttributeArgument("Ignored", new CodePrimitiveExpression(true)));

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,7 @@
+1.9.4 - 2015/01/14 (NUnit Generator)
++ NUnit generator adds tags to TestCase attributes generated from outline examples
+  This way the NUnit test adapter will display the tags
+
 1.9.3 - 2014/06/22 (Specflow Ms Test Report)
 New Features:
 + Specflow Test Execution report now includes the "tags" in the Nunit Report which can be displayed through a custom XSLT by the users.


### PR DESCRIPTION
NUnit supports categories even for TestCases, which are generated from examples. The code looks like this:

```cs
[Test]
[TestCase(42, Category="comma, separated, list")]
public void MyTest(int number)
```

the following change to NUnitTestGeneratorProvider adds the "Category" named parameter to the TestCase attribute. This way the tags appear in the unit tests explorer in Visual Studio and one can use them when excluding/including tests to be run on CI server (TeamCity, ...)