### PR TITLE
StepArgumentTransformation improvement

### DIFF
--- a/Runtime/Bindings/SimpleConverter.cs
+++ b/Runtime/Bindings/SimpleConverter.cs
@@ -25,8 +25,28 @@ namespace TechTalk.SpecFlow.Bindings
 
         public bool CanConvert(object value, IBindingType typeToConvertTo, CultureInfo cultureInfo)
         {
-            if (!(typeToConvertTo is RuntimeBindingType))
+            var runtimeType = typeToConvertTo as RuntimeBindingType;
+
+            if (runtimeType == null)
+            {
                 return false;
+            }
+
+            var targetType = runtimeType.Type;
+
+            if (value == null)
+            {
+                return !targetType.IsValueType;
+            }
+
+            if (!targetType.IsEnum || targetType != typeof(Guid) || targetType != typeof(Guid?))
+            {
+                var convertible = value as IConvertible;
+                if (convertible == null)
+                {
+                    return value.GetType() == targetType;
+                }
+            }
 
             try
             {


### PR DESCRIPTION
Hi,

Here's a change to use a `StepArgumentTransformation` only when the input arguments can be converted to the corresponding parameter types.

Currently, the `StepArgumentTransformationConverter` would consider a `StepArgumentTransformation` valid based only on the arguments count. This could cause failure if the `StepArgumentTransformation` was used with arguments that couldn't be converted to the correct parameter type.

With this change, the `StepArgumentTransformationConverter` will check the arguments count as well as the ability to convert these arguments.