### PR TITLE
Issue 193: Adding a new value retriever for DateTimeOffsets

### DIFF
--- a/Runtime/Assist/TEHelpers.cs
+++ b/Runtime/Assist/TEHelpers.cs
@@ -149,6 +149,8 @@ namespace TechTalk.SpecFlow.Assist
                            {typeof (bool?), (TableRow row) => new NullableBoolValueRetriever(v => new BoolValueRetriever().GetValue(v)).GetValue(row[1])},
                            {typeof (DateTime), (TableRow row) => new DateTimeValueRetriever().GetValue(row[1])},
                            {typeof (DateTime?), (TableRow row) => new NullableDateTimeValueRetriever(v => new DateTimeValueRetriever().GetValue(v)).GetValue(row[1])},
+                           {typeof (DateTimeOffset), (TableRow row) => new DateTimeOffsetValueRetriever().GetValue(row[1])},
+                           {typeof (DateTimeOffset?), (TableRow row) => new NullableDateTimeOffsetValueRetriever(v => new DateTimeOffsetValueRetriever().GetValue(v)).GetValue(row[1])},
                            {typeof (Guid), (TableRow row) => new GuidValueRetriever().GetValue(row[1])},
                            {typeof (Guid?), (TableRow row) => new NullableGuidValueRetriever(v => new GuidValueRetriever().GetValue(v)).GetValue(row[1])},
                            {typeof (Enum), (TableRow row) => new EnumValueRetriever().GetValue(row[1], type.GetProperties().First(x => x.Name.MatchesThisColumnName(row[0])).PropertyType)},

--- a/Runtime/Assist/ValueRetrievers/DateTimeOffsetValueRetriever.cs
+++ b/Runtime/Assist/ValueRetrievers/DateTimeOffsetValueRetriever.cs
@@ -1,0 +1,14 @@
+﻿using System;
+
+namespace TechTalk.SpecFlow.Assist.ValueRetrievers
+{
+    internal class DateTimeOffsetValueRetriever
+    {
+        public virtual DateTimeOffset GetValue(string value)
+        {
+            var returnValue = DateTimeOffset.MinValue;
+            DateTimeOffset.TryParse(value, out returnValue);
+            return returnValue;
+        }
+    }
+}

--- a/Runtime/Assist/ValueRetrievers/NullableDateTimeOffsetValueRetriever.cs
+++ b/Runtime/Assist/ValueRetrievers/NullableDateTimeOffsetValueRetriever.cs
@@ -1,0 +1,20 @@
+﻿using System;
+
+namespace TechTalk.SpecFlow.Assist.ValueRetrievers
+{
+    internal class NullableDateTimeOffsetValueRetriever
+    {
+        private readonly Func<string, DateTimeOffset> dateTimeOffsetValueRetriever;
+
+        public NullableDateTimeOffsetValueRetriever(Func<string, DateTimeOffset> dateTimeOffsetValueRetriever)
+        {
+            this.dateTimeOffsetValueRetriever = dateTimeOffsetValueRetriever;
+        }
+
+        public DateTimeOffset? GetValue(string value)
+        {
+            if (string.IsNullOrEmpty(value)) return null;
+            return dateTimeOffsetValueRetriever(value);
+        }
+    }
+}

--- a/Runtime/TechTalk.SpecFlow.csproj
+++ b/Runtime/TechTalk.SpecFlow.csproj
@@ -80,8 +80,10 @@
     <Compile Include="Assist\ValueRetrievers\BoolValueRetriever.cs" />
     <Compile Include="Assist\ValueRetrievers\ByteValueRetriever.cs" />
     <Compile Include="Assist\ValueRetrievers\CharValueRetriever.cs" />
+    <Compile Include="Assist\ValueRetrievers\DateTimeOffsetValueRetriever.cs" />
     <Compile Include="Assist\ValueRetrievers\LongValueRetriever.cs" />
     <Compile Include="Assist\ValueRetrievers\NullableByteValueRetriever.cs" />
+    <Compile Include="Assist\ValueRetrievers\NullableDateTimeOffsetValueRetriever.cs" />
     <Compile Include="Assist\ValueRetrievers\NullableLongValueRetriever.cs" />
     <Compile Include="Assist\ValueRetrievers\NullableSByteValueRetriever.cs" />
     <Compile Include="Assist\ValueRetrievers\NullableFloatValueRetriever.cs" />

--- a/Tests/RuntimeTests/AssistTests/ValueRetrieverTests/DateTimeOffsetValueRetrieverTests.cs
+++ b/Tests/RuntimeTests/AssistTests/ValueRetrieverTests/DateTimeOffsetValueRetrieverTests.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using NUnit.Framework;
+using Should;
+using TechTalk.SpecFlow.Assist.ValueRetrievers;
+
+namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.ValueRetrieverTests
+{
+    [TestFixture, SetCulture("en-US")]
+    public class DateTimeOffsetValueRetrieverTests
+    {
+        [Test]
+        public void Returns_MinValue_when_the_value_is_null()
+        {
+            var retriever = new DateTimeOffsetValueRetriever();
+            retriever.GetValue(null).ShouldEqual(DateTimeOffset.MinValue);
+        }
+
+        [Test]
+        public void Returns_MinValue_when_the_value_is_empty()
+        {
+            var retriever = new DateTimeOffsetValueRetriever();
+            retriever.GetValue(string.Empty).ShouldEqual(DateTimeOffset.MinValue);
+        }
+
+        [Test]
+        public void Returns_the_date_when_value_represents_a_valid_date()
+        {
+            var retriever = new DateTimeOffsetValueRetriever();
+            var date1 = new DateTime(2011, 1, 1);
+            retriever.GetValue("2011-01-01").ShouldEqual(new DateTimeOffset(2011, 1, 1, 0, 0, 0, TimeZone.CurrentTimeZone.GetUtcOffset(date1)));
+            var date2 = new DateTime(2013, 12, 5);
+            retriever.GetValue("2013-12-05").ShouldEqual(new DateTimeOffset(2013, 12, 5, 0, 0, 0, TimeZone.CurrentTimeZone.GetUtcOffset(date2)));
+        }
+
+        [Test]
+        public void Returns_the_date_and_time_when_value_represents_a_valid_datetime()
+        {
+            var retriever = new DateTimeOffsetValueRetriever();
+            var date1 = new DateTime(2011, 1, 1);
+            retriever.GetValue("2011-01-01 15:16:17").ShouldEqual(new DateTimeOffset(2011, 1, 1, 15, 16, 17, TimeZone.CurrentTimeZone.GetUtcOffset(date1)));
+            var date2 = new DateTime(2011, 1, 1);
+            retriever.GetValue("2011-01-01 5:6:7").ShouldEqual(new DateTimeOffset(2011, 1, 1, 5, 6, 7, TimeZone.CurrentTimeZone.GetUtcOffset(date2)));
+        }
+
+        [Test]
+        public void Returns_MinValue_when_the_value_is_not_a_valid_datetime()
+        {
+            var retriever = new DateTimeOffsetValueRetriever();
+            retriever.GetValue("xxxx").ShouldEqual(DateTimeOffset.MinValue);
+            retriever.GetValue("this is not a date").ShouldEqual(DateTimeOffset.MinValue);
+            retriever.GetValue("Thursday").ShouldEqual(DateTimeOffset.MinValue);
+        }
+    }
+}

--- a/Tests/RuntimeTests/AssistTests/ValueRetrieverTests/NullableDateTimeOffsetValueRetriever.cs
+++ b/Tests/RuntimeTests/AssistTests/ValueRetrieverTests/NullableDateTimeOffsetValueRetriever.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using NUnit.Framework;
+using Should;
+using TechTalk.SpecFlow.Assist.ValueRetrievers;
+
+namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.ValueRetrieverTests
+{
+    [TestFixture, SetCulture("en-US")]
+    public class NullableDateTimeOffsetValueRetrieverTests
+    {
+        [Test]
+        public void Returns_the_value_from_the_DateTimeOffsetValueRetriever()
+        {
+            Func<string, DateTimeOffset> func = v =>
+            {
+                if (v == "one") return new DateTimeOffset(2011, 1, 2, 2, 0, 0, TimeSpan.Zero);
+                if (v == "two") return new DateTimeOffset(2015, 12, 31, 2, 0, 0, TimeSpan.Zero);
+                return DateTimeOffset.MinValue;
+            };
+
+            var retriever = new NullableDateTimeOffsetValueRetriever(func);
+            retriever.GetValue("one").ShouldEqual(new DateTimeOffset(2011, 1, 2, 2, 0, 0, TimeSpan.Zero));
+            retriever.GetValue("two").ShouldEqual(new DateTimeOffset(2015, 12, 31, 2, 0, 0, TimeSpan.Zero));
+        }
+
+        [Test]
+        public void Returns_null_when_value_is_null()
+        {
+            var retriever = new NullableDateTimeOffsetValueRetriever(v => DateTimeOffset.Parse("1/1/2016"));
+            retriever.GetValue(null).ShouldBeNull();
+        }
+
+        [Test]
+        public void Returns_null_when_string_is_empty()
+        {
+            var retriever = new NullableDateTimeOffsetValueRetriever(v => DateTimeOffset.Parse("1/1/2017"));
+            retriever.GetValue(string.Empty).ShouldBeNull();
+        }
+    }
+}

--- a/Tests/RuntimeTests/RuntimeTests.csproj
+++ b/Tests/RuntimeTests/RuntimeTests.csproj
@@ -105,9 +105,11 @@
     <Compile Include="AssistTests\ValueRetrieverTests\BoolValueRetrieverTests.cs" />
     <Compile Include="AssistTests\ValueRetrieverTests\ByteValueRetrieverTests.cs" />
     <Compile Include="AssistTests\ValueRetrieverTests\CharValueRetrieverTests.cs" />
+    <Compile Include="AssistTests\ValueRetrieverTests\DateTimeOffsetValueRetrieverTests.cs" />
     <Compile Include="AssistTests\ValueRetrieverTests\GuidValueRetriever_IsAValidGuidTests.cs" />
     <Compile Include="AssistTests\ValueRetrieverTests\LongValueRetrieverTests.cs" />
     <Compile Include="AssistTests\ValueRetrieverTests\NullableByteValueRetrieverTests.cs" />
+    <Compile Include="AssistTests\ValueRetrieverTests\NullableDateTimeOffsetValueRetriever.cs" />
     <Compile Include="AssistTests\ValueRetrieverTests\NullableFloatValueRetrieverTests.cs" />
     <Compile Include="AssistTests\ValueRetrieverTests\FloatValueRetrieverTests.cs" />
     <Compile Include="AssistTests\ValueRetrieverTests\NullableLongValueRetrieverTests.cs" />


### PR DESCRIPTION
Table -> Object translation was not converting DateTimeOffset table
values.  This should allow the Table Assist helpers to do so.