### PR TITLE
Updated usages of obsolete MSBuild project file parsing elements.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,10 +9,13 @@ obj/
 [Dd]ebug*/
 [Rr]elease*/
 _ReSharper*/
+_NCrunch*/
 [Tt]est[Rr]esult*
 *.pidb
 *.userprefs
 *.resharper
+*.ncrunchproject
+*.ncrunchsolution
 *.cache
 *.gpState
 *.dotCover

--- a/Generator/Project/MsBuildProjectFileExtensions.cs
+++ b/Generator/Project/MsBuildProjectFileExtensions.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Microsoft.Build.Evaluation;
+
+namespace TechTalk.SpecFlow.Generator.Project
+{
+    static class MsBuildProjectFileExtensions
+    {
+        public static IEnumerable<ProjectItem> FeatureFiles(this Microsoft.Build.Evaluation.Project project)
+        {
+            
+            return project.AllEvaluatedItems.Where(x => x.ItemType == "None" &&
+                                                        x.EvaluatedInclude.EndsWith(".feature", StringComparison.InvariantCultureIgnoreCase));
+        }
+
+        public static ProjectItem ApplicationConfigurationFile(this Microsoft.Build.Evaluation.Project project)
+        {
+            return project.AllEvaluatedItems.FirstOrDefault(x => x.ItemType == "Content" &&
+                                                                 Path.GetFileName(x.EvaluatedInclude).Equals("app.config", StringComparison.InvariantCultureIgnoreCase));
+
+        }
+    }
+}

--- a/Generator/Project/MsBuildProjectFileExtensions.cs
+++ b/Generator/Project/MsBuildProjectFileExtensions.cs
@@ -10,14 +10,19 @@ namespace TechTalk.SpecFlow.Generator.Project
     {
         public static IEnumerable<ProjectItem> FeatureFiles(this Microsoft.Build.Evaluation.Project project)
         {
-            
-            return project.AllEvaluatedItems.Where(x => x.ItemType == "None" &&
+
+            return project.AllEvaluatedItems.Where(x => IsNonCompilingItem(x) &&
                                                         x.EvaluatedInclude.EndsWith(".feature", StringComparison.InvariantCultureIgnoreCase));
+        }
+
+        private static bool IsNonCompilingItem(ProjectItem x)
+        {
+            return (x.ItemType == "Content" || x.ItemType == "None");
         }
 
         public static ProjectItem ApplicationConfigurationFile(this Microsoft.Build.Evaluation.Project project)
         {
-            return project.AllEvaluatedItems.FirstOrDefault(x => x.ItemType == "Content" &&
+            return project.AllEvaluatedItems.FirstOrDefault(x => IsNonCompilingItem(x) &&
                                                                  Path.GetFileName(x.EvaluatedInclude).Equals("app.config", StringComparison.InvariantCultureIgnoreCase));
 
         }

--- a/Generator/TechTalk.SpecFlow.Generator.csproj
+++ b/Generator/TechTalk.SpecFlow.Generator.csproj
@@ -36,7 +36,7 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.Build.Engine" />
+    <Reference Include="Microsoft.Build" />
     <Reference Include="System" />
     <Reference Include="System.configuration" />
     <Reference Include="System.Core">
@@ -66,6 +66,7 @@
     <Compile Include="Plugins\IGeneratorPlugin.cs" />
     <Compile Include="Plugins\IGeneratorPluginLoader.cs" />
     <Compile Include="Project\ISpecFlowProjectReader.cs" />
+    <Compile Include="Project\MsBuildProjectFileExtensions.cs" />
     <Compile Include="Project\MsBuildProjectReader.cs" />
     <Compile Include="Configuration\RuntimeConfigurationReader.cs" />
     <Compile Include="Configuration\InProcGeneratorInfoProvider.cs" />

--- a/Tests/GeneratorTests/Data/app.config
+++ b/Tests/GeneratorTests/Data/app.config
@@ -1,0 +1,12 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <configSections>
+    <section name="specFlow" type="TechTalk.SpecFlow.Configuration.ConfigurationSectionHandler, TechTalk.SpecFlow" />
+  </configSections>
+  <specFlow>
+    <unitTestProvider name="MSTest" />
+    <stepAssemblies>
+      <stepAssembly assembly="Hacapp.Web.Tests.Shared" />
+    </stepAssemblies>
+  </specFlow>
+</configuration>

--- a/Tests/GeneratorTests/Data/sampleCsProjectfile.csproj
+++ b/Tests/GeneratorTests/Data/sampleCsProjectfile.csproj
@@ -1,0 +1,228 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{FAA2B575-765C-4925-B762-43734306CB2C}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Hacapp.Web.Tests.UI</RootNamespace>
+    <AssemblyName>Hacapp.Web.Tests.UI</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
+    <IsCodedUITest>False</IsCodedUITest>
+    <TestProjectType>UnitTest</TestProjectType>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="FluentAssertions">
+      <HintPath>..\packages\FluentAssertions.3.2.2\lib\net45\FluentAssertions.dll</HintPath>
+    </Reference>
+    <Reference Include="FluentAssertions.Core">
+      <HintPath>..\packages\FluentAssertions.3.2.2\lib\net45\FluentAssertions.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Data.Edm, Version=5.6.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\Microsoft.Data.Edm.5.6.2\lib\net40\Microsoft.Data.Edm.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Data.OData, Version=5.6.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\Microsoft.Data.OData.5.6.2\lib\net40\Microsoft.Data.OData.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Data.Services.Client, Version=5.6.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\Microsoft.Data.Services.Client.5.6.2\lib\net40\Microsoft.Data.Services.Client.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.WindowsAzure.Configuration, Version=1.8.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\Microsoft.WindowsAzure.ConfigurationManager.1.8.0.0\lib\net35-full\Microsoft.WindowsAzure.Configuration.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.WindowsAzure.Storage, Version=4.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\WindowsAzure.Storage.4.3.0\lib\net40\Microsoft.WindowsAzure.Storage.dll</HintPath>
+    </Reference>
+    <Reference Include="Newtonsoft.Json">
+      <HintPath>..\packages\Newtonsoft.Json.5.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Configuration" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Drawing" />
+    <Reference Include="System.Spatial, Version=5.6.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\System.Spatial.5.6.2\lib\net40\System.Spatial.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Web" />
+    <Reference Include="System.Xml" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="TechTalk.SpecFlow">
+      <HintPath>..\packages\SpecFlow.1.9.3.5\lib\net35\TechTalk.SpecFlow.dll</HintPath>
+    </Reference>
+    <Reference Include="WebDriver">
+      <HintPath>..\packages\Selenium.WebDriver.2.44.0\lib\net40\WebDriver.dll</HintPath>
+    </Reference>
+    <Reference Include="WebDriver.Support">
+      <HintPath>..\packages\Selenium.Support.2.44.0\lib\net40\WebDriver.Support.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+  <Choose>
+    <When Condition="('$(VisualStudioVersion)' == '10.0' or '$(VisualStudioVersion)' == '') and '$(TargetFrameworkVersion)' == 'v3.5'">
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+      </ItemGroup>
+    </When>
+    <Otherwise>
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework" />
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
+  <ItemGroup>
+    <Compile Include="Features\Login\SocialLogins.feature.cs">
+      <DependentUpon>SocialLogins.feature</DependentUpon>
+      <AutoGen>True</AutoGen>
+      <DesignTime>True</DesignTime>
+    </Compile>
+    <Compile Include="Features\WorkflowDefinition\CreateWorkflowDefinition.feature.cs">
+      <AutoGen>True</AutoGen>
+      <DesignTime>True</DesignTime>
+      <DependentUpon>CreateWorkflowDefinition.feature</DependentUpon>
+    </Compile>
+    <Compile Include="Features\WorkflowInstance\WorkflowInstance.feature.cs">
+      <AutoGen>True</AutoGen>
+      <DesignTime>True</DesignTime>
+      <DependentUpon>WorkflowInstance.feature</DependentUpon>
+    </Compile>
+    <Compile Include="MoreLinq\MoreEnumerable.MaxBy.cs" />
+    <Compile Include="MoreLinq\MoreEnumerable.MinBy.cs" />
+    <Compile Include="PageElements\Button.cs" />
+    <Compile Include="PageElements\CheckBox.cs" />
+    <Compile Include="PageElements\Div.cs" />
+    <Compile Include="PageElements\DropDown.cs" />
+    <Compile Include="PageElements\Header.cs" />
+    <Compile Include="PageElements\Link.cs" />
+    <Compile Include="PageElements\MultiSelect.cs" />
+    <Compile Include="PageElements\PageElement.cs" />
+    <Compile Include="PageElements\RadioButton.cs" />
+    <Compile Include="PageElements\Table.cs" />
+    <Compile Include="PageElements\TableCell.cs" />
+    <Compile Include="PageElements\TextBox.cs" />
+    <Compile Include="PageElements\TimePicker.cs" />
+    <Compile Include="PageElements\ValidationSummary.cs" />
+    <Compile Include="Browser.cs" />
+    <Compile Include="CaptureScreenShots.cs" />
+    <Compile Include="PageObjects\FacebookLoginPageObject.cs" />
+    <Compile Include="PageObjects\GenericPage.cs" />
+    <Compile Include="PageObjects\GoogleLoginPageObject.cs" />
+    <Compile Include="PageObjects\LoginPageObject.cs" />
+    <Compile Include="PageObjects\MicrosoftLoginPageObject.cs" />
+    <Compile Include="PageObjects\NavBarPageObject.cs" />
+    <Compile Include="PageObjects\Page.cs" />
+    <Compile Include="PageObjects\SocialLoginPageObject.cs" />
+    <Compile Include="PageObjects\TwitterLoginPageObject.cs" />
+    <Compile Include="PageObjects\WorkflowDefinitionCreatePageObject.cs" />
+    <Compile Include="PageObjects\WorkflowDefinitionsHomePageObject.cs" />
+    <Compile Include="Steps\CleanUpSteps.cs" />
+    <Compile Include="Steps\IUserCredentials.cs" />
+    <Compile Include="Steps\NavBarSteps.cs" />
+    <Compile Include="Steps\SeleniumContext.cs" />
+    <Compile Include="Steps\TestSettings.cs" />
+    <Compile Include="Steps\UiTestsSetup.cs" />
+    <Compile Include="Steps\UserContext.cs" />
+    <Compile Include="Steps\UserCredentials.cs" />
+    <Compile Include="Steps\UserSteps.cs" />
+    <Compile Include="Steps\WorkflowDefinitionCreateSteps.cs" />
+    <Compile Include="Steps\WorkflowDefinitionHomeSteps.cs" />
+    <Compile Include="Steps\WorkflowInstanceParametersPageObject.cs" />
+    <Compile Include="Steps\WorkflowInstanceParameterSteps.cs" />
+    <Compile Include="ValueToFind.cs" />
+    <Compile Include="WaitFor.cs" />
+    <Compile Include="WaitForElementFailedException.cs" />
+    <Compile Include="WebDriverExtensions.cs" />
+    <Compile Include="YesNoRadioButtonValue.cs" />
+    <Compile Include="Steps\SocialLoginSteps.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="app.config">
+      <SubType>Designer</SubType>
+    </Content>
+    <None Include="Features\Login\SocialLogins.feature">
+      <Generator>SpecFlowSingleFileGenerator</Generator>
+      <LastGenOutput>SocialLogins.feature.cs</LastGenOutput>
+    </None>
+    <None Include="Features\WorkflowDefinition\CreateWorkflowDefinition.feature">
+      <Generator>SpecFlowSingleFileGenerator</Generator>
+      <LastGenOutput>CreateWorkflowDefinition.feature.cs</LastGenOutput>
+    </None>
+    <None Include="Features\WorkflowInstance\WorkflowInstance.feature">
+      <Generator>SpecFlowSingleFileGenerator</Generator>
+      <LastGenOutput>WorkflowInstance.feature.cs</LastGenOutput>
+    </None>
+    <None Include="packages.config" />
+    <Compile Include="Steps\BrowserSelectionSteps.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\hacapp.core\Hacapp.Core.csproj">
+      <Project>{38A957ED-6237-439D-93AC-220BFD7D0409}</Project>
+      <Name>Hacapp.Core</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\Hacapp.Data.Azure\Hacapp.Data.Azure.csproj">
+      <Project>{246EF4BD-4252-4371-A824-2CEAD1F51CFE}</Project>
+      <Name>Hacapp.Data.Azure</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\Tests.Shared\Hacapp.Web.Tests.Shared.csproj">
+      <Project>{125f3b68-898e-4d70-8055-754d13f56bf8}</Project>
+      <Name>Hacapp.Web.Tests.Shared</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup />
+  <Choose>
+    <When Condition="'$(VisualStudioVersion)' == '10.0' And '$(IsCodedUITest)' == 'True'">
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.QualityTools.CodedUITestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.TestTools.UITest.Common, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.TestTools.UITest.Extension, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.TestTools.UITesting, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/Tests/GeneratorTests/GeneratorTests.csproj
+++ b/Tests/GeneratorTests/GeneratorTests.csproj
@@ -64,6 +64,7 @@
     <Compile Include="FeatureGeneratorProviderTests.cs" />
     <Compile Include="FeatureGeneratorRegistryTests.cs" />
     <Compile Include="IgnoredTestGeneratorTests.cs" />
+    <Compile Include="MsBuildProjectReaderTests.cs" />
     <Compile Include="TagFilterMatcherTests.cs" />
     <Compile Include="TestHeaderWriterTests.cs" />
     <Compile Include="TestGeneratorErrorsTests.cs" />
@@ -94,7 +95,16 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
+    <None Include="Data\app.config">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup />
+  <ItemGroup>
+    <Content Include="Data\sampleCsProjectfile.csproj">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/Tests/GeneratorTests/MsBuildProjectReaderTests.cs
+++ b/Tests/GeneratorTests/MsBuildProjectReaderTests.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.IO;
+using System.Linq;
+using FluentAssertions;
+using NUnit.Framework;
+using TechTalk.SpecFlow.Generator.Project;
+
+namespace TechTalk.SpecFlow.GeneratorTests
+{
+    [TestFixture]
+    public class MsBuildProjectReaderTests
+    {
+        [Test]
+        public void Should_parse_csproj_file_correctly()
+        {
+            string text = Path.Combine(Directory.GetCurrentDirectory(), "Data\\sampleCsProjectfile.csproj");
+            SpecFlowProject specflowProjectfile = MsBuildProjectReader.LoadSpecFlowProjectFromMsBuild(text);
+            specflowProjectfile.FeatureFiles.Count.Should().Be(3);
+            specflowProjectfile.FeatureFiles.Single(x => x.ProjectRelativePath == @"Features\Login\SocialLogins.feature").Should().NotBeNull();
+            specflowProjectfile.FeatureFiles.Single(x => x.ProjectRelativePath == @"Features\WorkflowDefinition\CreateWorkflowDefinition.feature").Should().NotBeNull();
+            specflowProjectfile.FeatureFiles.Single(x => x.ProjectRelativePath == @"Features\WorkflowInstance\WorkflowInstance.feature").Should().NotBeNull();
+
+            specflowProjectfile.ProjectSettings.AssemblyName.Should().Be("Hacapp.Web.Tests.UI");
+            specflowProjectfile.ProjectSettings.DefaultNamespace.Should().Be("Hacapp.Web.Tests.UI");
+            specflowProjectfile.ProjectSettings.ProjectName.Should().Be("sampleCsProjectfile");
+
+            specflowProjectfile.ProjectSettings.ProjectPlatformSettings.Language.Should().Be("C#");
+            specflowProjectfile.ProjectSettings.ProjectPlatformSettings.LanguageVersion.Should().Be(new Version(3,0));
+            specflowProjectfile.ProjectSettings.ProjectPlatformSettings.Platform.Should().Be(".NET");
+            specflowProjectfile.ProjectSettings.ProjectPlatformSettings.PlatformVersion.Should().Be(new Version(3,5));
+
+            specflowProjectfile.Configuration.GeneratorConfiguration.AllowDebugGeneratedFiles.Should().BeFalse();
+            specflowProjectfile.Configuration.GeneratorConfiguration.AllowRowTests.Should().BeTrue();
+            specflowProjectfile.Configuration.GeneratorConfiguration.GenerateAsyncTests.Should().BeFalse();
+            specflowProjectfile.Configuration.GeneratorConfiguration.GeneratorUnitTestProvider.Should().Be("MSTest");
+            specflowProjectfile.Configuration.GeneratorConfiguration.FeatureLanguage.Name.Should().Be("en-US");            
+        }
+    }
+}


### PR DESCRIPTION
This fixes the issues with the obsolete MSBuild related classes that were being used to parse the CSProj files in order to generate reports.

No tests existed that i could see for any of this stuff so I added a single characterisation test which parses a sample csproj file and app.config from one of my existing specflow projects. Code was updated to provide the same behaviour, but without using the obsolete classes. Hopefully this covers all the use cases, but without tests its hard to be certain.