### PR TITLE
Added additional line pragmas to link the generated tests back to the sc...

### DIFF
--- a/Generator/UnitTestFeatureGenerator.cs
+++ b/Generator/UnitTestFeatureGenerator.cs
@@ -475,6 +475,7 @@ namespace TechTalk.SpecFlow.Generator
                     scenatioOutlineTestMethod.Name,
                     argumentExpressions.ToArray()));
 
+            AddLineDirectiveHidden(testMethod.Statements);
             var arguments = paramToIdentifier.Select((p2i, paramIndex) => new KeyValuePair<string, string>(p2i.Key, row.Cells[paramIndex].Value)).ToList();
             testGeneratorProvider.SetTestMethodAsRow(generationContext, testMethod, scenarioOutline.Title, exampleSetTitle, variantName, arguments);
         }


### PR DESCRIPTION
...enario outline examples so that code coverage for the scenario examples works correctly in NCrunch.

This is a re-issue of the fix in [this pull request](https://github.com/techtalk/SpecFlow/pull/372), but onto the v2 branch.