### PR TITLE
Added new FindInSet Assist method

### DIFF
--- a/Runtime/Assist/FindInSetExtensionMethods.cs
+++ b/Runtime/Assist/FindInSetExtensionMethods.cs
@@ -1,0 +1,34 @@
+﻿using System.Collections.Generic;
+
+namespace TechTalk.SpecFlow.Assist
+{
+    public static class FindInSetExtensionMethods
+    {
+        public static T FindInSet<T>(this Table table, IEnumerable<T> set)
+        {
+            var instanceTable = TEHelpers.GetTheProperInstanceTable(table, typeof(T));
+
+            foreach (var instance in set)
+            {
+                if (InstanceMatchesTable(instance, instanceTable))
+                {
+                    return instance;
+                }
+            }
+
+            throw new ComparisonException("No instance in the set matches the table");
+        }
+
+        private static bool InstanceMatchesTable<T>(T instance, Table table)
+        {
+            foreach (var row in table.Rows)
+            {
+                if (InstanceHelper.ThereIsADifference(instance, row))
+                {
+                    return false;
+                }
+            }
+            return true;
+        }
+    }
+}

--- a/Runtime/Assist/InstanceComparisonExtensionMethods.cs
+++ b/Runtime/Assist/InstanceComparisonExtensionMethods.cs
@@ -50,7 +50,7 @@ namespace TechTalk.SpecFlow.Assist
         private static IEnumerable<Difference> FindAnyDifferences<T>(Table table, T instance)
         {
             return from row in table.Rows
-                   where ThePropertyDoesNotExist(instance, row) || TheValuesDoNotMatch(instance, row)
+                   where InstanceHelper.ThereIsADifference(instance, row)
                    select CreateDifferenceForThisRow(instance, row);
         }
 
@@ -59,41 +59,9 @@ namespace TechTalk.SpecFlow.Assist
             return differences.Count() > 0;
         }
 
-        private static bool ThePropertyDoesNotExist<T>(T instance, TableRow row)
-        {
-            return instance.GetType().GetProperties()
-                .Any(property => TEHelpers.IsMemberMatchingToColumnName(property, row.Id())) == false;
-        }
-
-        private static bool TheValuesDoNotMatch<T>(T instance, TableRow row)
-        {
-            var expected = GetTheExpectedValue(row);
-            var propertyValue = instance.GetPropertyValue(row.Id());
-
-            var valueComparers = new IValueComparer[]
-                                     {
-                                         new DateTimeValueComparer(),
-                                         new BoolValueComparer(),
-                                         new GuidValueComparer(new GuidValueRetriever()),
-                                         new DecimalValueComparer(),
-                                         new DoubleValueComparer(),
-                                         new FloatValueComparer(),
-                                         new DefaultValueComparer()
-                                     };
-
-            return valueComparers
-                .FirstOrDefault(x => x.CanCompare(propertyValue))
-                .TheseValuesAreTheSame(expected, propertyValue) == false;
-        }
-
-        private static string GetTheExpectedValue(TableRow row)
-        {
-            return row.Value().ToString();
-        }
-
         private static Difference CreateDifferenceForThisRow<T>(T instance, TableRow row)
         {
-            if (ThePropertyDoesNotExist(instance, row))
+            if (InstanceHelper.ThePropertyDoesNotExist(instance, row))
                 return new Difference
                            {
                                Property = row.Id(),

--- a/Runtime/Assist/InstanceHelper.cs
+++ b/Runtime/Assist/InstanceHelper.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using TechTalk.SpecFlow.Assist.ValueComparers;
+using TechTalk.SpecFlow.Assist.ValueRetrievers;
+
+namespace TechTalk.SpecFlow.Assist
+{
+    internal static class InstanceHelper
+    {
+        public static bool ThePropertyDoesNotExist<T>(T instance, TableRow row)
+        {
+            return instance.GetType().GetProperties()
+                .Any(property => TEHelpers.IsMemberMatchingToColumnName(property, row.Id())) == false;
+        }
+
+        public static bool TheValuesDoNotMatch<T>(T instance, TableRow row)
+        {
+            var expected = GetTheExpectedValue(row);
+            var propertyValue = instance.GetPropertyValue(row.Id());
+
+            var valueComparers = new IValueComparer[]
+                                     {
+                                         new DateTimeValueComparer(),
+                                         new BoolValueComparer(),
+                                         new GuidValueComparer(new GuidValueRetriever()),
+                                         new DecimalValueComparer(),
+                                         new DoubleValueComparer(),
+                                         new FloatValueComparer(),
+                                         new DefaultValueComparer()
+                                     };
+
+            return valueComparers
+                .FirstOrDefault(x => x.CanCompare(propertyValue))
+                .TheseValuesAreTheSame(expected, propertyValue) == false;
+        }
+
+        public static bool ThereIsADifference<T>(T instance, TableRow row)
+        {
+            return ThePropertyDoesNotExist(instance, row) || TheValuesDoNotMatch(instance, row);
+        }
+
+        private static string GetTheExpectedValue(TableRow row)
+        {
+            return row.Value().ToString();
+        }
+    }
+}

--- a/Runtime/TechTalk.SpecFlow.csproj
+++ b/Runtime/TechTalk.SpecFlow.csproj
@@ -58,7 +58,9 @@
       <Link>BoDi\BoDi.cs</Link>
     </Compile>
     <Compile Include="Assist\EnumerableProjection.cs" />
+    <Compile Include="Assist\FindInSetExtensionMethods.cs" />
     <Compile Include="Assist\FormattingTableDiffExceptionBuilder.cs" />
+    <Compile Include="Assist\InstanceHelper.cs" />
     <Compile Include="Assist\SafetyTableDiffExceptionBuilder.cs" />
     <Compile Include="Assist\SetComparer.cs" />
     <Compile Include="Assist\TableDifferenceResults.cs" />

--- a/Tests/RuntimeTests/AssistTests/FindInSetExtensionMethodsTests.cs
+++ b/Tests/RuntimeTests/AssistTests/FindInSetExtensionMethodsTests.cs
@@ -1,0 +1,86 @@
+﻿using NUnit.Framework;
+using FluentAssertions;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Threading;
+using TechTalk.SpecFlow.Assist;
+using TechTalk.SpecFlow.RuntimeTests.AssistTests.TestInfrastructure;
+
+namespace TechTalk.SpecFlow.RuntimeTests.AssistTests
+{
+    [TestFixture]
+    class FindInSetExtensionMethodsTests
+    {
+        private IList<InstanceComparisonTestObject> testSet;
+
+        [SetUp]
+        public void SetUp()
+        {
+            Thread.CurrentThread.CurrentCulture = new CultureInfo("en-US");
+            testSet = new List<InstanceComparisonTestObject>();
+            testSet.Add(new InstanceComparisonTestObject { StringProperty = "Howard Rorak" });
+            testSet.Add(new InstanceComparisonTestObject { StringProperty = "Joel Mario", IntProperty = 20 });
+        }
+
+        [Test]
+        public void Throws_exception_when_table_does_not_exist_in_set()
+        {
+            var table = new Table("Field", "Value");
+            table.AddRow("String Property", "Peter Keating");
+
+            var comparisonResult = ExceptionWasThrownByThisSearch(table, testSet);
+
+            comparisonResult.ExceptionWasThrown.Should().BeTrue();
+        }
+
+        [Test]
+        public void Does_not_throw_exception_when_value_exists_set()
+        {
+            var table = new Table("Field", "Value");
+            table.AddRow("String Property", "Joel Mario");
+            table.AddRow("Int Property", "20");
+
+            var comparisonResult = ExceptionWasThrownByThisSearch(table, testSet);
+
+            comparisonResult.ExceptionWasThrown.Should().BeFalse();
+        }
+
+        [Test]
+        public void Returns_instance_on_full_match()
+        {
+            var table = new Table("Field", "Value");
+            table.AddRow("String Property", "Joel Mario");
+            table.AddRow("Int Property", "20");
+
+            var result = table.FindInSet(testSet);
+
+            result.Should().BeSameAs(testSet[1]);
+        }
+
+        [Test]
+        public void Returns_instance_on_partial_match()
+        {
+            var table = new Table("Field", "Value");
+            table.AddRow("Int Property", "20");
+
+            var result = table.FindInSet(testSet);
+
+            result.Should().BeSameAs(testSet[1]);
+        }
+
+        private ComparisonTestResult ExceptionWasThrownByThisSearch(Table table, IEnumerable<InstanceComparisonTestObject> set)
+        {
+            var result = new ComparisonTestResult { ExceptionWasThrown = false };
+            try
+            {
+                table.FindInSet(set);
+            }
+            catch (ComparisonException ex)
+            {
+                result.ExceptionWasThrown = true;
+                result.ExceptionMessage = ex.Message;
+            }
+            return result;
+        }
+    }
+}

--- a/Tests/RuntimeTests/RuntimeTests.csproj
+++ b/Tests/RuntimeTests/RuntimeTests.csproj
@@ -71,6 +71,7 @@
   <ItemGroup>
     <Compile Include="AssistTests\CreateInstanceHelperMethodTests.cs" />
     <Compile Include="AssistTests\ExampleEntities\EntityWithPropertiesAndFields.cs" />
+    <Compile Include="AssistTests\FindInSetExtensionMethodsTests.cs" />
     <Compile Include="AssistTests\FormattingTableDiffExceptionBuilderTests.cs" />
     <Compile Include="AssistTests\PivotTableTests.cs" />
     <Compile Include="AssistTests\RowExtensionMethodTests_GetEnum.cs" />
@@ -199,7 +200,9 @@
       <SubType>Designer</SubType>
     </None>
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.


### PR DESCRIPTION
Find the element described by the table in the given set. Useful if, for instance, you want to see if a certain item is in a list, but don't care about the other items in the list.

As far as I am aware, the only way to do this before was to loop through the set and call CompareToInstance on each item, catching and ignoring the ComparisonExceptions that would be thrown. While that works, it's not very pretty. If I'm wrong and there was a way to do this before, let me know.