### PR TITLE
NUnit generator adds tags to TestCase attributes generated from outline ...

### DIFF
--- a/Generator/UnitTestProvider/NUnitTestGeneratorProvider.cs
+++ b/Generator/UnitTestProvider/NUnitTestGeneratorProvider.cs
@@ -101,11 +101,19 @@ namespace TechTalk.SpecFlow.Generator.UnitTestProvider
               arg => new CodeAttributeArgument(new CodePrimitiveExpression(arg))).ToList();
 
             // addressing ReSharper bug: TestCase attribute with empty string[] param causes inconclusive result - https://github.com/techtalk/SpecFlow/issues/116
-            var exampleTagExpressionList = tags.Select(t => new CodePrimitiveExpression(t)).ToArray();
-            CodeExpression exampleTagsExpression = exampleTagExpressionList.Length == 0 ?
+            bool hasExampleTags = tags.Any();
+            var exampleTagExpressionList = tags.Select(t => new CodePrimitiveExpression(t));
+            CodeExpression exampleTagsExpression = hasExampleTags ?
                 (CodeExpression)new CodePrimitiveExpression(null) :
-                new CodeArrayCreateExpression(typeof(string[]), exampleTagExpressionList);
+                new CodeArrayCreateExpression(typeof(string[]), exampleTagExpressionList.ToArray());
             args.Add(new CodeAttributeArgument(exampleTagsExpression));
+
+            // adds 'Category' named parameter so that NUnit also understands that this test case belongs to the given categories
+            if (hasExampleTags)
+            {
+                CodeExpression exampleTagsStringExpr = new CodePrimitiveExpression(string.Join(",", tags.ToArray()));
+                args.Add(new CodeAttributeArgument("Category", exampleTagsStringExpr));
+            }
 
             if (isIgnored)
                 args.Add(new CodeAttributeArgument("Ignored", new CodePrimitiveExpression(true)));

--- a/changelog.txt
+++ b/changelog.txt
@@ -9,6 +9,7 @@ Breaking changes:
 + The new release will not work with .NET runtimes older than .NET 4.5. 
 
 New Features:
++ NUnit generator adds tags to TestCase attributes generated from outline examples. This way the NUnit test adapter in Visual Studio will display the tags.
 
 Fixed issues:
 


### PR DESCRIPTION
NUnit supports categories even for TestCases, which are generated from examples. The code looks like this:

```cs
[Test]
[TestCase(42, Category="comma, separated, list")]
public void MyTest(int number)
```

the following change to NUnitTestGeneratorProvider adds the "Category" named parameter to the TestCase attribute. This way the tags appear in the unit tests explorer in Visual Studio and one can use them when excluding/including tests to be run on CI server (TeamCity, ...)