### PR TITLE
#416 solved

### DIFF
--- a/Generator/TechTalk.SpecFlow.Generator.csproj
+++ b/Generator/TechTalk.SpecFlow.Generator.csproj
@@ -109,6 +109,7 @@
     <Compile Include="TestGenerator.cs" />
     <Compile Include="TestGeneratorFactory.cs" />
     <Compile Include="UnitTestConverter\IFeatureGeneratorProvider.cs" />
+    <Compile Include="UnitTestProvider\CodedUiGeneratorProvider.cs" />
     <Compile Include="UnitTestProvider\UnitTestGeneratorProviders.cs" />
     <Compile Include="UnitTestProvider\MbUnit3TestGeneratorProvider.cs" />
     <Compile Include="UnitTestProvider\MsTestSilverlightGeneratorProvider.cs" />

--- a/Generator/UnitTestProvider/CodedUiGeneratorProvider.cs
+++ b/Generator/UnitTestProvider/CodedUiGeneratorProvider.cs
@@ -1,0 +1,34 @@
+﻿using System.CodeDom;
+using TechTalk.SpecFlow.Utils;
+
+namespace TechTalk.SpecFlow.Generator.UnitTestProvider
+{
+    public class CodedUiGeneratorProvider : MsTest2010GeneratorProvider
+    {
+        protected const string CODEDUI_TESTFIXTURE_ATTR = "Microsoft.VisualStudio.TestTools.UITesting.CodedUITestAttribute";
+
+        public CodedUiGeneratorProvider(CodeDomHelper codeDomHelper)
+            : base(codeDomHelper)
+        {
+        }
+
+        public override void SetTestMethod(TestClassGenerationContext generationContext, CodeMemberMethod testMethod,
+            string scenarioTitle)
+        {
+            base.SetTestMethod(generationContext, testMethod, scenarioTitle);
+
+            foreach (CodeAttributeDeclaration declaration in generationContext.TestClass.CustomAttributes)
+            {
+                if (declaration.Name == TESTFIXTURE_ATTR)
+                {
+                    generationContext.TestClass.CustomAttributes.Remove(declaration);
+                    break;
+                }
+            }
+
+            generationContext.TestClass.CustomAttributes.Add(
+                new CodeAttributeDeclaration(
+                    new CodeTypeReference(CODEDUI_TESTFIXTURE_ATTR)));
+        }
+    }
+}

--- a/Generator/UnitTestProvider/UnitTestGeneratorProviders.cs
+++ b/Generator/UnitTestProvider/UnitTestGeneratorProviders.cs
@@ -18,6 +18,7 @@ namespace TechTalk.SpecFlow.Generator
             container.RegisterTypeAs<MsTestGeneratorProvider, IUnitTestGeneratorProvider>("mstest.2008");
             container.RegisterTypeAs<MsTest2010GeneratorProvider, IUnitTestGeneratorProvider>("mstest.2010");
             container.RegisterTypeAs<MsTest2010GeneratorProvider, IUnitTestGeneratorProvider>("mstest");
+            container.RegisterTypeAs<CodedUiGeneratorProvider, IUnitTestGeneratorProvider>("codedui");
 
             container.RegisterTypeAs<MsTestSilverlightGeneratorProvider, IUnitTestGeneratorProvider>("mstest.silverlight");
             container.RegisterTypeAs<MsTestSilverlightGeneratorProvider, IUnitTestGeneratorProvider>("mstest.silverlight3");

--- a/Runtime/Infrastructure/IRuntimePluginLoader.cs
+++ b/Runtime/Infrastructure/IRuntimePluginLoader.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.IO;
 using System.Reflection;
 
 namespace TechTalk.SpecFlow.Infrastructure
@@ -14,11 +15,24 @@ namespace TechTalk.SpecFlow.Infrastructure
 
         public IRuntimePlugin LoadPlugin(PluginDescriptor pluginDescriptor)
         {
-            var assemblyName = string.Format(ASSEMBLY_NAME_PATTERN, pluginDescriptor.Name);
             Assembly assembly;
+            string retroCompatibleAssemblyName = string.Format(ASSEMBLY_NAME_PATTERN, pluginDescriptor.Name);
+
             try
             {
-                assembly = Assembly.Load(assemblyName);
+                assembly = Assembly.Load(pluginDescriptor.Name);
+            }
+            catch (FileNotFoundException)
+            {
+                try
+                {
+                    assembly = Assembly.Load(retroCompatibleAssemblyName);
+                }
+                catch (Exception exception)
+                {
+                    throw new SpecFlowException(string.Format("Unable to load plugin: {0}. Please check http://go.specflow.org/doc-plugins for details.", pluginDescriptor.Name), exception);                    
+                    
+                }
             }
             catch(Exception ex)
             {


### PR DESCRIPTION
I made a change in which we will first try to load the plugin assembly
as the name states in the config file. If this doesn't succeed a
`FileNotFoundException` is thrown. If this is the case, in order to
maintain retro-compatibility, the code will try to load the assembly with
the suffix. If even that doesn't succeed, a `SpecFlowException` will be
thrown.
It is not the most elegant code, but it is a quick fix for an annoying
bug.
