### PR TITLE
Cover null handling around Get<T> and Set<T> directly

### DIFF
--- a/Tests/RuntimeTests/StronglyTypedContextAcessorTests.cs
+++ b/Tests/RuntimeTests/StronglyTypedContextAcessorTests.cs
@@ -243,6 +243,24 @@ namespace TechTalk.SpecFlow.RuntimeTests
             Assert.AreSame(expected, actual);
         }
 
+        [Test]
+        public void Can_get_and_set_a_null_value_with_an_object()
+        {
+            var scenarioContext = CreateScenarioContext();
+            scenarioContext.Set<object>(null, "SomeKey");
+            var result = scenarioContext.Get<object>("SomeKey");
+            Assert.IsNull(result);
+        }
+
+        [Test]
+        public void Can_get_and_set_a_null_value_with_a_string()
+        {
+            var scenarioContext = CreateScenarioContext();
+            scenarioContext.Set<string>(null, "SomeKey");
+            var result = scenarioContext.Get<string>("SomeKey");
+            Assert.IsNull(result);
+        }
+
         private static ScenarioContext CreateScenarioContext()
         {
             return new ScenarioContext(new ScenarioInfo("Test", new string[] {}), null, null);


### PR DESCRIPTION
Questions and issues like around #392 have come up a few times.

Though this problem has been solved, I saw that the solution was not tested directly.  I wrote two unit tests that match the failing examples from other users.  

Not so much for regressions, but just to make the expected behavior explicit.

