### PR TITLE
Cleanup public interface around SpecFlow.Assist extensions

### DIFF
--- a/Runtime/Assist/IValueComparer.cs
+++ b/Runtime/Assist/IValueComparer.cs
@@ -3,6 +3,6 @@
     public interface IValueComparer
     {
         bool CanCompare(object actualValue);
-        bool TheseValuesAreTheSame(string expectedValue, object actualValue);
+        bool Compare(string expectedValue, object actualValue);
     }
 }

--- a/Runtime/Assist/IValueComparer.cs
+++ b/Runtime/Assist/IValueComparer.cs
@@ -1,8 +1,22 @@
 ﻿namespace TechTalk.SpecFlow.Assist
 {
+    /// <summary>
+    /// A class that will compare a key->value from a table to an actual value.
+    /// </summary>
     public interface IValueComparer
     {
+        /// <summary>
+        /// Determines if this comparer can compare the actual value to a key->value set defined in a table.
+        /// </summary>
+        /// <returns><c>true</c> if this instance can compare the value to a key->value set in a table; otherwise, <c>false</c>.</returns>
+        /// <param name="actualValue">Actual value.</param>
         bool CanCompare(object actualValue);
+
+        /// <summary>
+        /// Compare the expected value to the actual value.
+        /// </summary>
+        /// <param name="expectedValue">Expected value.</param>
+        /// <param name="actualValue">Actual value.</param>
         bool Compare(string expectedValue, object actualValue);
     }
 }

--- a/Runtime/Assist/IValueRetriever.cs
+++ b/Runtime/Assist/IValueRetriever.cs
@@ -5,7 +5,7 @@ namespace TechTalk.SpecFlow.Assist
 {
     public interface IValueRetriever
     {
-        object ExtractValueFromRow(TableRow row, Type targetType);
-        bool CanRetrieve(TableRow row, Type type);
+        object Retrieve(KeyValuePair<string, string> keyValuePair, Type targetType);
+        bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type type);
     }
 }

--- a/Runtime/Assist/IValueRetriever.cs
+++ b/Runtime/Assist/IValueRetriever.cs
@@ -3,9 +3,24 @@ using System.Collections.Generic;
 
 namespace TechTalk.SpecFlow.Assist
 {
+    /// <summary>
+    /// A class that will retrieve an object's actual value from a key->value in a table.
+    /// </summary>
     public interface IValueRetriever
     {
-        object Retrieve(KeyValuePair<string, string> keyValuePair, Type targetType);
+        /// <summary>
+        /// Determines if this retriever can retrieve the actual value from a key->value set in a table.
+        /// </summary>
+        /// <returns><c>true</c> if this instance can retrieve the specified key->value; otherwise, <c>false</c>.</returns>
+        /// <param name="keyValuePair">Key value pair.</param>
+        /// <param name="type">The type of the object that is being built from the table.</param>
         bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type type);
+
+        /// <summary>
+        /// Retrieve the value from a key-> value set, as the expected type on targetType.
+        /// </summary>
+        /// <param name="keyValuePair">Key value pair.</param>
+        /// <param name="targetType">The type of the ojbect that is being built from the table.</param>
+        object Retrieve(KeyValuePair<string, string> keyValuePair, Type targetType);
     }
 }

--- a/Runtime/Assist/InstanceComparisonExtensionMethods.cs
+++ b/Runtime/Assist/InstanceComparisonExtensionMethods.cs
@@ -78,7 +78,7 @@ namespace TechTalk.SpecFlow.Assist
 
             return valueComparers
                 .FirstOrDefault(x => x.CanCompare(propertyValue))
-                .TheseValuesAreTheSame(expected, propertyValue) == false;
+                .Compare(expected, propertyValue) == false;
         }
 
         private static string GetTheExpectedValue(TableRow row)

--- a/Runtime/Assist/Service.cs
+++ b/Runtime/Assist/Service.cs
@@ -107,7 +107,7 @@ namespace TechTalk.SpecFlow.Assist
         public IValueRetriever GetValueRetrieverFor(TableRow row, Type type)
         {
             foreach(var valueRetriever in ValueRetrievers){
-                if (valueRetriever.CanRetrieve(row, type))
+                if (valueRetriever.CanRetrieve(new KeyValuePair<string, string>(row[0], row[1]), type))
                     return valueRetriever;
             }
             return null;

--- a/Runtime/Assist/TEHelpers.cs
+++ b/Runtime/Assist/TEHelpers.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using TechTalk.SpecFlow.Assist.ValueRetrievers;
+using System.Collections.Generic;
 
 namespace TechTalk.SpecFlow.Assist
 {
@@ -115,7 +116,7 @@ namespace TechTalk.SpecFlow.Assist
             public object GetValue()
             {
                 var valueRetriever = Service.Instance.GetValueRetrieverFor(Row, PropertyType);
-                return valueRetriever.ExtractValueFromRow(Row, Type);
+                return valueRetriever.Retrieve(new KeyValuePair<string, string>(Row[0], Row[1]), Type);
             }
         }
 

--- a/Runtime/Assist/ValueComparers/BoolValueComparer.cs
+++ b/Runtime/Assist/ValueComparers/BoolValueComparer.cs
@@ -9,7 +9,7 @@ namespace TechTalk.SpecFlow.Assist.ValueComparers
             return actualValue != null && actualValue.GetType() == typeof (bool);
         }
 
-        public bool TheseValuesAreTheSame(string expectedValue, object actualValue)
+        public bool Compare(string expectedValue, object actualValue)
         {
             return bool.Parse(expectedValue) == (bool) actualValue;
         }

--- a/Runtime/Assist/ValueComparers/DateTimeValueComparer.cs
+++ b/Runtime/Assist/ValueComparers/DateTimeValueComparer.cs
@@ -9,7 +9,7 @@ namespace TechTalk.SpecFlow.Assist.ValueComparers
             return actualValue != null && actualValue.GetType() == typeof (DateTime);
         }
 
-        public bool TheseValuesAreTheSame(string expectedValue, object actualValue)
+        public bool Compare(string expectedValue, object actualValue)
         {
             DateTime expected;
             if (DateTime.TryParse(expectedValue, out expected) == false)

--- a/Runtime/Assist/ValueComparers/DecimalValueComparer.cs
+++ b/Runtime/Assist/ValueComparers/DecimalValueComparer.cs
@@ -9,7 +9,7 @@ namespace TechTalk.SpecFlow.Assist.ValueComparers
             return actualValue != null && actualValue.GetType() == typeof (decimal);
         }
 
-        public bool TheseValuesAreTheSame(string expectedValue, object actualValue)
+        public bool Compare(string expectedValue, object actualValue)
         {
             Decimal expected;
             if (Decimal.TryParse(expectedValue, out expected) == false)

--- a/Runtime/Assist/ValueComparers/DefaultValueComparer.cs
+++ b/Runtime/Assist/ValueComparers/DefaultValueComparer.cs
@@ -9,7 +9,7 @@ namespace TechTalk.SpecFlow.Assist.ValueComparers
             return true;
         }
 
-        public bool TheseValuesAreTheSame(string expectedValue, object actualValue)
+        public bool Compare(string expectedValue, object actualValue)
         {
             var actual = actualValue == null ? String.Empty : actualValue.ToString();
 

--- a/Runtime/Assist/ValueComparers/DoubleValueComparer.cs
+++ b/Runtime/Assist/ValueComparers/DoubleValueComparer.cs
@@ -9,7 +9,7 @@ namespace TechTalk.SpecFlow.Assist.ValueComparers
             return actualValue != null && actualValue.GetType() == typeof (double);
         }
 
-        public bool TheseValuesAreTheSame(string expectedValue, object actualValue)
+        public bool Compare(string expectedValue, object actualValue)
         {
             Double expected;
             if (Double.TryParse(expectedValue, out expected) == false)

--- a/Runtime/Assist/ValueComparers/FloatValueComparer.cs
+++ b/Runtime/Assist/ValueComparers/FloatValueComparer.cs
@@ -9,7 +9,7 @@ namespace TechTalk.SpecFlow.Assist.ValueComparers
             return actualValue != null && actualValue.GetType() == typeof (float);
         }
 
-        public bool TheseValuesAreTheSame(string expectedValue, object actualValue)
+        public bool Compare(string expectedValue, object actualValue)
         {
             float expected;
             if (float.TryParse(expectedValue, out expected) == false)

--- a/Runtime/Assist/ValueComparers/GuidValueComparer.cs
+++ b/Runtime/Assist/ValueComparers/GuidValueComparer.cs
@@ -17,7 +17,7 @@ namespace TechTalk.SpecFlow.Assist.ValueComparers
             return actualValue != null && actualValue.GetType() == typeof (Guid);
         }
 
-        public bool TheseValuesAreTheSame(string expectedValue, object actualValue)
+        public bool Compare(string expectedValue, object actualValue)
         {
             try
             {

--- a/Runtime/Assist/ValueRetrievers/BoolValueRetriever.cs
+++ b/Runtime/Assist/ValueRetrievers/BoolValueRetriever.cs
@@ -10,12 +10,12 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
             return value == "True" || value == "true";
         }
 
-        public object ExtractValueFromRow(TableRow row, Type targetType)
+        public object Retrieve(KeyValuePair<string, string> keyValuePair, Type targetType)
         {
-            return GetValue(row[1]);
+            return GetValue(keyValuePair.Value);
         }
 
-        public bool CanRetrieve(TableRow row, Type type)
+        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type type)
         {
             return type == typeof(bool);
         }

--- a/Runtime/Assist/ValueRetrievers/ByteValueRetriever.cs
+++ b/Runtime/Assist/ValueRetrievers/ByteValueRetriever.cs
@@ -12,12 +12,12 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
             return returnValue;
         }
 
-        public object ExtractValueFromRow(TableRow row, Type targetType)
+        public object Retrieve(KeyValuePair<string, string> keyValuePair, Type targetType)
         {
-            return GetValue(row[1]);
+            return GetValue(keyValuePair.Value);
         }
 
-        public bool CanRetrieve(TableRow row, Type type)
+        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type type)
         {
             return type == typeof(byte);
         }

--- a/Runtime/Assist/ValueRetrievers/CharValueRetriever.cs
+++ b/Runtime/Assist/ValueRetrievers/CharValueRetriever.cs
@@ -12,12 +12,12 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
                        : value[0];
         }
             
-        public object ExtractValueFromRow(TableRow row, Type targetType)
+        public object Retrieve(KeyValuePair<string, string> keyValuePair, Type targetType)
         {
-            return GetValue(row[1]);
+            return GetValue(keyValuePair.Value);
         }
 
-        public bool CanRetrieve(TableRow row, Type type)
+        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type type)
         {
             return type == typeof(char);
         }

--- a/Runtime/Assist/ValueRetrievers/DateTimeValueRetriever.cs
+++ b/Runtime/Assist/ValueRetrievers/DateTimeValueRetriever.cs
@@ -12,12 +12,12 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
             return returnValue;
         }
 
-        public object ExtractValueFromRow(TableRow row, Type targetType)
+        public object Retrieve(KeyValuePair<string, string> keyValuePair, Type targetType)
         {
-            return GetValue(row[1]);
+            return GetValue(keyValuePair.Value);
         }
 
-        public bool CanRetrieve(TableRow row, Type type)
+        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type type)
         {
             return type == typeof(DateTime);
         }

--- a/Runtime/Assist/ValueRetrievers/DecimalValueRetriever.cs
+++ b/Runtime/Assist/ValueRetrievers/DecimalValueRetriever.cs
@@ -12,12 +12,12 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
             return returnValue;
         }
 
-        public object ExtractValueFromRow(TableRow row, Type targetType)
+        public object Retrieve(KeyValuePair<string, string> keyValuePair, Type targetType)
         {
-            return GetValue(row[1]);
+            return GetValue(keyValuePair.Value);
         }
 
-        public bool CanRetrieve(TableRow row, Type type)
+        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type type)
         {
             return type == typeof(decimal);
         }

--- a/Runtime/Assist/ValueRetrievers/DoubleValueRetriever.cs
+++ b/Runtime/Assist/ValueRetrievers/DoubleValueRetriever.cs
@@ -12,12 +12,12 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
             return returnValue;
         }
 
-        public object ExtractValueFromRow(TableRow row, Type targetType)
+        public object Retrieve(KeyValuePair<string, string> keyValuePair, Type targetType)
         {
-            return GetValue(row[1]);
+            return GetValue(keyValuePair.Value);
         }
 
-        public bool CanRetrieve(TableRow row, Type type)
+        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type type)
         {
             return type == typeof(double);
         }

--- a/Runtime/Assist/ValueRetrievers/EnumValueRetriever.cs
+++ b/Runtime/Assist/ValueRetrievers/EnumValueRetriever.cs
@@ -13,13 +13,13 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
             return ConvertTheStringToAnEnum(value, enumType);
         }
 
-        public object ExtractValueFromRow(TableRow row, Type targetType)
+        public object Retrieve(KeyValuePair<string, string> keyValuePair, Type targetType)
         {
-            var propertyType = targetType.GetProperties().First(x => x.Name.MatchesThisColumnName(row[0])).PropertyType;
-            return GetValue(row[1], propertyType);
+            var propertyType = targetType.GetProperties().First(x => x.Name.MatchesThisColumnName(keyValuePair.Key)).PropertyType;
+            return GetValue(keyValuePair.Value, propertyType);
         }
 
-        public bool CanRetrieve(TableRow row, Type type)
+        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type type)
         {
             if (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(Nullable<>))
                 return typeof(Enum).IsAssignableFrom(type.GetGenericArguments()[0]);

--- a/Runtime/Assist/ValueRetrievers/FloatValueRetriever.cs
+++ b/Runtime/Assist/ValueRetrievers/FloatValueRetriever.cs
@@ -12,12 +12,12 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
             return returnValue;
         }
 
-        public object ExtractValueFromRow(TableRow row, Type targetType)
+        public object Retrieve(KeyValuePair<string, string> keyValuePair, Type targetType)
         {
-            return GetValue(row[1]);
+            return GetValue(keyValuePair.Value);
         }
 
-        public bool CanRetrieve(TableRow row, Type type)
+        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type type)
         {
             return type == typeof(float);
         }

--- a/Runtime/Assist/ValueRetrievers/GuidValueRetriever.cs
+++ b/Runtime/Assist/ValueRetrievers/GuidValueRetriever.cs
@@ -26,12 +26,12 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
             }
         }
 
-        public object ExtractValueFromRow(TableRow row, Type targetType)
+        public object Retrieve(KeyValuePair<string, string> keyValuePair, Type targetType)
         {
-            return GetValue(row[1]);
+            return GetValue(keyValuePair.Value);
         }
 
-        public bool CanRetrieve(TableRow row, Type type)
+        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type type)
         {
             return type == typeof(Guid);
         }

--- a/Runtime/Assist/ValueRetrievers/IntValueRetriever.cs
+++ b/Runtime/Assist/ValueRetrievers/IntValueRetriever.cs
@@ -12,12 +12,12 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
             return returnValue;
         }
 
-        public object ExtractValueFromRow(TableRow row, Type targetType)
+        public object Retrieve(KeyValuePair<string, string> keyValuePair, Type targetType)
         {
-            return GetValue(row[1]);
+            return GetValue(keyValuePair.Value);
         }
 
-        public bool CanRetrieve(TableRow row, Type type)
+        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type type)
         {
             return type == typeof(int);
         }

--- a/Runtime/Assist/ValueRetrievers/LongValueRetriever.cs
+++ b/Runtime/Assist/ValueRetrievers/LongValueRetriever.cs
@@ -12,12 +12,12 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
             return returnValue;
         }
             
-        public object ExtractValueFromRow(TableRow row, Type targetType)
+        public object Retrieve(KeyValuePair<string, string> keyValuePair, Type targetType)
         {
-            return GetValue(row[1]);
+            return GetValue(keyValuePair.Value);
         }
 
-        public bool CanRetrieve(TableRow row, Type type)
+        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type type)
         {
             return type == typeof(long);
         }

--- a/Runtime/Assist/ValueRetrievers/NullableBoolValueRetriever.cs
+++ b/Runtime/Assist/ValueRetrievers/NullableBoolValueRetriever.cs
@@ -19,12 +19,12 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
             return boolValueRetriever(thisValue);
         }
 
-        public object ExtractValueFromRow(TableRow row, Type targetType)
+        public object Retrieve(KeyValuePair<string, string> keyValuePair, Type targetType)
         {
-            return GetValue(row[1]);
+            return GetValue(keyValuePair.Value);
         }
 
-        public bool CanRetrieve(TableRow row, Type type)
+        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type type)
         {
             return type == typeof(bool?);
         }

--- a/Runtime/Assist/ValueRetrievers/NullableByteValueRetriever.cs
+++ b/Runtime/Assist/ValueRetrievers/NullableByteValueRetriever.cs
@@ -19,12 +19,12 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
             return byteValueRetriever(value);
         }
 
-        public object ExtractValueFromRow(TableRow row, Type targetType)
+        public object Retrieve(KeyValuePair<string, string> keyValuePair, Type targetType)
         {
-            return GetValue(row[1]);
+            return GetValue(keyValuePair.Value);
         }
 
-        public bool CanRetrieve(TableRow row, Type type)
+        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type type)
         {
             return type == typeof(byte?);
         }

--- a/Runtime/Assist/ValueRetrievers/NullableCharValueRetriever.cs
+++ b/Runtime/Assist/ValueRetrievers/NullableCharValueRetriever.cs
@@ -20,12 +20,12 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
             return charValueRetriever(value);
         }
 
-        public object ExtractValueFromRow(TableRow row, Type targetType)
+        public object Retrieve(KeyValuePair<string, string> keyValuePair, Type targetType)
         {
-            return GetValue(row[1]);
+            return GetValue(keyValuePair.Value);
         }
 
-        public bool CanRetrieve(TableRow row, Type type)
+        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type type)
         {
             return type == typeof(char?);
         }

--- a/Runtime/Assist/ValueRetrievers/NullableDateTimeValueRetriever.cs
+++ b/Runtime/Assist/ValueRetrievers/NullableDateTimeValueRetriever.cs
@@ -19,12 +19,12 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
             return dateTimeValueRetriever(value);
         }
 
-        public object ExtractValueFromRow(TableRow row, Type targetType)
+        public object Retrieve(KeyValuePair<string, string> keyValuePair, Type targetType)
         {
-            return GetValue(row[1]);
+            return GetValue(keyValuePair.Value);
         }
 
-        public bool CanRetrieve(TableRow row, Type type)
+        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type type)
         {
             return type == typeof(DateTime?);
         }

--- a/Runtime/Assist/ValueRetrievers/NullableDecimalValueRetriever.cs
+++ b/Runtime/Assist/ValueRetrievers/NullableDecimalValueRetriever.cs
@@ -19,12 +19,12 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
             return decimalValueRetriever(value);
         }
 
-        public object ExtractValueFromRow(TableRow row, Type targetType)
+        public object Retrieve(KeyValuePair<string, string> keyValuePair, Type targetType)
         {
-            return GetValue(row[1]);
+            return GetValue(keyValuePair.Value);
         }
 
-        public bool CanRetrieve(TableRow row, Type type)
+        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type type)
         {
             return type == typeof(decimal?);
         }

--- a/Runtime/Assist/ValueRetrievers/NullableDoubleValueRetriever.cs
+++ b/Runtime/Assist/ValueRetrievers/NullableDoubleValueRetriever.cs
@@ -19,12 +19,12 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
             return DoubleValueRetriever(value);
         }
 
-        public object ExtractValueFromRow(TableRow row, Type targetType)
+        public object Retrieve(KeyValuePair<string, string> keyValuePair, Type targetType)
         {
-            return GetValue(row[1]);
+            return GetValue(keyValuePair.Value);
         }
 
-        public bool CanRetrieve(TableRow row, Type type)
+        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type type)
         {
             return type == typeof(double?);
         }

--- a/Runtime/Assist/ValueRetrievers/NullableFloatValueRetriever.cs
+++ b/Runtime/Assist/ValueRetrievers/NullableFloatValueRetriever.cs
@@ -19,12 +19,12 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
             return FloatValueRetriever(value);
         }
 
-        public object ExtractValueFromRow(TableRow row, Type targetType)
+        public object Retrieve(KeyValuePair<string, string> keyValuePair, Type targetType)
         {
-            return GetValue(row[1]);
+            return GetValue(keyValuePair.Value);
         }
 
-        public bool CanRetrieve(TableRow row, Type type)
+        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type type)
         {
             return type == typeof(float?);
         }

--- a/Runtime/Assist/ValueRetrievers/NullableGuidValueRetriever.cs
+++ b/Runtime/Assist/ValueRetrievers/NullableGuidValueRetriever.cs
@@ -19,12 +19,12 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
             return guidValueRetriever(value);
         }
 
-        public object ExtractValueFromRow(TableRow row, Type targetType)
+        public object Retrieve(KeyValuePair<string, string> keyValuePair, Type targetType)
         {
-            return GetValue(row[1]);
+            return GetValue(keyValuePair.Value);
         }
 
-        public bool CanRetrieve(TableRow row, Type type)
+        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type type)
         {
             return type == typeof(Guid?);
         }

--- a/Runtime/Assist/ValueRetrievers/NullableIntValueRetriever.cs
+++ b/Runtime/Assist/ValueRetrievers/NullableIntValueRetriever.cs
@@ -19,12 +19,12 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
             return intValueRetriever(value);
         }
 
-        public object ExtractValueFromRow(TableRow row, Type targetType)
+        public object Retrieve(KeyValuePair<string, string> keyValuePair, Type targetType)
         {
-            return GetValue(row[1]);
+            return GetValue(keyValuePair.Value);
         }
 
-        public bool CanRetrieve(TableRow row, Type type)
+        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type type)
         {
             return type == typeof(int?);
         }

--- a/Runtime/Assist/ValueRetrievers/NullableLongValueRetriever.cs
+++ b/Runtime/Assist/ValueRetrievers/NullableLongValueRetriever.cs
@@ -19,12 +19,12 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
             return longValueRetriever(value);
         }
 
-        public object ExtractValueFromRow(TableRow row, Type targetType)
+        public object Retrieve(KeyValuePair<string, string> keyValuePair, Type targetType)
         {
-            return GetValue(row[1]);
+            return GetValue(keyValuePair.Value);
         }
 
-        public bool CanRetrieve(TableRow row, Type type)
+        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type type)
         {
             return type == typeof(long?);
         }

--- a/Runtime/Assist/ValueRetrievers/NullableSByteValueRetriever.cs
+++ b/Runtime/Assist/ValueRetrievers/NullableSByteValueRetriever.cs
@@ -19,12 +19,12 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
             return sbyteValueRetriever(value);
         }
 
-        public object ExtractValueFromRow(TableRow row, Type targetType)
+        public object Retrieve(KeyValuePair<string, string> keyValuePair, Type targetType)
         {
-            return GetValue(row[1]);
+            return GetValue(keyValuePair.Value);
         }
 
-        public bool CanRetrieve(TableRow row, Type type)
+        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type type)
         {
             return type == typeof(sbyte?);
         }

--- a/Runtime/Assist/ValueRetrievers/NullableShortValueRetriever.cs
+++ b/Runtime/Assist/ValueRetrievers/NullableShortValueRetriever.cs
@@ -19,12 +19,12 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
             return shortValueRetriever(value);
         }
 
-        public object ExtractValueFromRow(TableRow row, Type targetType)
+        public object Retrieve(KeyValuePair<string, string> keyValuePair, Type targetType)
         {
-            return GetValue(row[1]);
+            return GetValue(keyValuePair.Value);
         }
 
-        public bool CanRetrieve(TableRow row, Type type)
+        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type type)
         {
             return type == typeof(short?);
         }

--- a/Runtime/Assist/ValueRetrievers/NullableUIntValueRetriever.cs
+++ b/Runtime/Assist/ValueRetrievers/NullableUIntValueRetriever.cs
@@ -19,12 +19,12 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
             return uintValueRetriever(value);
         }
 
-        public object ExtractValueFromRow(TableRow row, Type targetType)
+        public object Retrieve(KeyValuePair<string, string> keyValuePair, Type targetType)
         {
-            return GetValue(row[1]);
+            return GetValue(keyValuePair.Value);
         }
 
-        public bool CanRetrieve(TableRow row, Type type)
+        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type type)
         {
             return type == typeof(uint?);
         }

--- a/Runtime/Assist/ValueRetrievers/NullableULongValueRetriever.cs
+++ b/Runtime/Assist/ValueRetrievers/NullableULongValueRetriever.cs
@@ -19,12 +19,12 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
             return ulongValueRetriever(value);
         }
 
-        public object ExtractValueFromRow(TableRow row, Type targetType)
+        public object Retrieve(KeyValuePair<string, string> keyValuePair, Type targetType)
         {
-            return GetValue(row[1]);
+            return GetValue(keyValuePair.Value);
         }
 
-        public bool CanRetrieve(TableRow row, Type type)
+        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type type)
         {
             return type == typeof(ulong?);
         }

--- a/Runtime/Assist/ValueRetrievers/NullableUShortValueRetriever.cs
+++ b/Runtime/Assist/ValueRetrievers/NullableUShortValueRetriever.cs
@@ -19,12 +19,12 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
             return ushortValueRetriever(value);
         }
 
-        public object ExtractValueFromRow(TableRow row, Type targetType)
+        public object Retrieve(KeyValuePair<string, string> keyValuePair, Type targetType)
         {
-            return GetValue(row[1]);
+            return GetValue(keyValuePair.Value);
         }
 
-        public bool CanRetrieve(TableRow row, Type type)
+        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type type)
         {
             return type == typeof(ushort?);
         }

--- a/Runtime/Assist/ValueRetrievers/SByteValueRetriever.cs
+++ b/Runtime/Assist/ValueRetrievers/SByteValueRetriever.cs
@@ -12,12 +12,12 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
             return returnValue;
         }
 
-        public object ExtractValueFromRow(TableRow row, Type targetType)
+        public object Retrieve(KeyValuePair<string, string> keyValuePair, Type targetType)
         {
-            return GetValue(row[1]);
+            return GetValue(keyValuePair.Value);
         }
 
-        public bool CanRetrieve(TableRow row, Type type)
+        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type type)
         {
             return type == typeof(sbyte);
         }

--- a/Runtime/Assist/ValueRetrievers/ShortValueRetriever.cs
+++ b/Runtime/Assist/ValueRetrievers/ShortValueRetriever.cs
@@ -12,12 +12,12 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
             return returnValue;
         }
 
-        public object ExtractValueFromRow(TableRow row, Type targetType)
+        public object Retrieve(KeyValuePair<string, string> keyValuePair, Type targetType)
         {
-            return GetValue(row[1]);
+            return GetValue(keyValuePair.Value);
         }
 
-        public bool CanRetrieve(TableRow row, Type type)
+        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type type)
         {
             return type == typeof(short);
         }

--- a/Runtime/Assist/ValueRetrievers/StringValueRetriever.cs
+++ b/Runtime/Assist/ValueRetrievers/StringValueRetriever.cs
@@ -10,12 +10,12 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
             return value;
         }
 
-        public object ExtractValueFromRow(TableRow row, Type targetType)
+        public object Retrieve(KeyValuePair<string, string> keyValuePair, Type targetType)
         {
-            return GetValue(row[1]);
+            return GetValue(keyValuePair.Value);
         }
 
-        public bool CanRetrieve(TableRow row, Type type)
+        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type type)
         {
             return type == typeof(string);
         }

--- a/Runtime/Assist/ValueRetrievers/UIntValueRetriever.cs
+++ b/Runtime/Assist/ValueRetrievers/UIntValueRetriever.cs
@@ -12,12 +12,12 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
             return returnValue;
         }
 
-        public object ExtractValueFromRow(TableRow row, Type targetType)
+        public object Retrieve(KeyValuePair<string, string> keyValuePair, Type targetType)
         {
-            return GetValue(row[1]);
+            return GetValue(keyValuePair.Value);
         }
 
-        public bool CanRetrieve(TableRow row, Type type)
+        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type type)
         {
             return type == typeof(uint);
         }

--- a/Runtime/Assist/ValueRetrievers/ULongValueRetriever.cs
+++ b/Runtime/Assist/ValueRetrievers/ULongValueRetriever.cs
@@ -12,12 +12,12 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
             return returnValue;
         }
 
-        public object ExtractValueFromRow(TableRow row, Type targetType)
+        public object Retrieve(KeyValuePair<string, string> keyValuePair, Type targetType)
         {
-            return GetValue(row[1]);
+            return GetValue(keyValuePair.Value);
         }
 
-        public bool CanRetrieve(TableRow row, Type type)
+        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type type)
         {
             return type == typeof(ulong);
         }

--- a/Runtime/Assist/ValueRetrievers/UShortValueRetriever.cs
+++ b/Runtime/Assist/ValueRetrievers/UShortValueRetriever.cs
@@ -12,12 +12,12 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
             return returnValue;
         }
 
-        public object ExtractValueFromRow(TableRow row, Type targetType)
+        public object Retrieve(KeyValuePair<string, string> keyValuePair, Type targetType)
         {
-            return GetValue(row[1]);
+            return GetValue(keyValuePair.Value);
         }
 
-        public bool CanRetrieve(TableRow row, Type type)
+        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type type)
         {
             return type == typeof(ushort);
         }

--- a/Tests/RuntimeTests/AssistTests/ServiceTests.cs
+++ b/Tests/RuntimeTests/AssistTests/ServiceTests.cs
@@ -148,11 +148,11 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests
         {
             throw new NotImplementedException();
         }
-        public object ExtractValueFromRow(TableRow row, Type targetType)
+        public object Retrieve(KeyValuePair<string, string> keyValuePair, Type targetType)
         {
             throw new NotImplementedException();
         }
-        public bool CanRetrieve(TableRow row, Type type)
+        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type type)
         {
             throw new NotImplementedException();
         }

--- a/Tests/RuntimeTests/AssistTests/ServiceTests.cs
+++ b/Tests/RuntimeTests/AssistTests/ServiceTests.cs
@@ -136,7 +136,7 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests
         {
             throw new NotImplementedException();
         }
-        public bool TheseValuesAreTheSame(string expectedValue, object actualValue)
+        public bool Compare(string expectedValue, object actualValue)
         {
             throw new NotImplementedException();
         }

--- a/Tests/RuntimeTests/AssistTests/ValueComparerTests/BoolValueComparerTests.cs
+++ b/Tests/RuntimeTests/AssistTests/ValueComparerTests/BoolValueComparerTests.cs
@@ -38,26 +38,26 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.ValueComparerTests
         public void Returns_true_if_the_value_and_string_match()
         {
             var comparer = new BoolValueComparer();
-            comparer.TheseValuesAreTheSame("True", true).Should().BeTrue();
-            comparer.TheseValuesAreTheSame("False", false).Should().BeTrue();
+            comparer.Compare("True", true).Should().BeTrue();
+            comparer.Compare("False", false).Should().BeTrue();
         }
 
         [Test]
         public void Returns_false_if_the_value_and_string_do_not_match()
         {
             var comparer = new BoolValueComparer();
-            comparer.TheseValuesAreTheSame("True", false).Should().BeFalse();
-            comparer.TheseValuesAreTheSame("False", true).Should().BeFalse();
+            comparer.Compare("True", false).Should().BeFalse();
+            comparer.Compare("False", true).Should().BeFalse();
         }
 
         [Test]
         public void Ignores_casing_of_the_expected_value_when_matching()
         {
             var comparer = new BoolValueComparer();
-            comparer.TheseValuesAreTheSame("true", true).Should().BeTrue();
-            comparer.TheseValuesAreTheSame("FALSE", false).Should().BeTrue();
-            comparer.TheseValuesAreTheSame("truE", true).Should().BeTrue();
-            comparer.TheseValuesAreTheSame("false", false).Should().BeTrue();
+            comparer.Compare("true", true).Should().BeTrue();
+            comparer.Compare("FALSE", false).Should().BeTrue();
+            comparer.Compare("truE", true).Should().BeTrue();
+            comparer.Compare("false", false).Should().BeTrue();
         }
     }
 }

--- a/Tests/RuntimeTests/AssistTests/ValueComparerTests/DateTimeValueComparerTests.cs
+++ b/Tests/RuntimeTests/AssistTests/ValueComparerTests/DateTimeValueComparerTests.cs
@@ -37,9 +37,9 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.ValueComparerTests
         public void Returns_true_when_the_string_and_values_match_exactly()
         {
             var comparer = new DateTimeValueComparer();
-            comparer.TheseValuesAreTheSame(new DateTime(2011, 1, 2).ToString(), new DateTime(2011, 1, 2))
+            comparer.Compare(new DateTime(2011, 1, 2).ToString(), new DateTime(2011, 1, 2))
                 .Should().BeTrue();
-            comparer.TheseValuesAreTheSame(new DateTime(2020, 12, 31).ToString(), new DateTime(2020, 12, 31))
+            comparer.Compare(new DateTime(2020, 12, 31).ToString(), new DateTime(2020, 12, 31))
                 .Should().BeTrue();
         }
 
@@ -47,13 +47,13 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.ValueComparerTests
         public void Returns_false_when_the_string_and_values_match_for_different_dates()
         {
             var comparer = new DateTimeValueComparer();
-            comparer.TheseValuesAreTheSame(new DateTime(2011, 1, 3).ToString(), new DateTime(2011, 1, 2))
+            comparer.Compare(new DateTime(2011, 1, 3).ToString(), new DateTime(2011, 1, 2))
                 .Should().BeFalse();
-            comparer.TheseValuesAreTheSame(new DateTime(2011, 1, 2).ToString(), new DateTime(2011, 1, 3))
+            comparer.Compare(new DateTime(2011, 1, 2).ToString(), new DateTime(2011, 1, 3))
                 .Should().BeFalse();
-            comparer.TheseValuesAreTheSame(new DateTime(2011, 1, 1).ToString(), new DateTime(2012, 1, 1))
+            comparer.Compare(new DateTime(2011, 1, 1).ToString(), new DateTime(2012, 1, 1))
                 .Should().BeFalse();
-            comparer.TheseValuesAreTheSame(new DateTime(2011, 1, 1).ToString(), new DateTime(2011, 2, 1))
+            comparer.Compare(new DateTime(2011, 1, 1).ToString(), new DateTime(2011, 2, 1))
                 .Should().BeFalse();
         }
 
@@ -61,9 +61,9 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.ValueComparerTests
         public void Returns_false_when_the_expected_value_is_not_a_valid_datetime()
         {
             var comparer = new DateTimeValueComparer();
-            comparer.TheseValuesAreTheSame("x", new DateTime(2020, 1, 1))
+            comparer.Compare("x", new DateTime(2020, 1, 1))
                 .Should().BeFalse();
-            comparer.TheseValuesAreTheSame("January1", new DateTime(2020, 1, 1))
+            comparer.Compare("January1", new DateTime(2020, 1, 1))
                 .Should().BeFalse();
         }
 
@@ -71,9 +71,9 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.ValueComparerTests
         public void Returns_false_the_value_is_correct_format_but_not_a_valid_date()
         {
             var comparer = new DateTimeValueComparer();
-            comparer.TheseValuesAreTheSame(new DateTime(2011, 2, 28).ToString().Replace("28", "29"), new DateTime(2011, 2, 28))
+            comparer.Compare(new DateTime(2011, 2, 28).ToString().Replace("28", "29"), new DateTime(2011, 2, 28))
                 .Should().BeFalse();
-            comparer.TheseValuesAreTheSame(new DateTime(2011, 12, 1).ToString().Replace("12", "13"), new DateTime(2011, 12, 1))
+            comparer.Compare(new DateTime(2011, 12, 1).ToString().Replace("12", "13"), new DateTime(2011, 12, 1))
                 .Should().BeFalse();
         }
     }

--- a/Tests/RuntimeTests/AssistTests/ValueComparerTests/DecimalValueComparerTests.cs
+++ b/Tests/RuntimeTests/AssistTests/ValueComparerTests/DecimalValueComparerTests.cs
@@ -37,27 +37,27 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.ValueComparerTests
         public void Returns_true_when_the_decimal_values_match()
         {
             var valueComparer = new DecimalValueComparer();
-            valueComparer.TheseValuesAreTheSame("3.14", 3.14M).Should().BeTrue();
-            valueComparer.TheseValuesAreTheSame("0", 0M).Should().BeTrue();
-            valueComparer.TheseValuesAreTheSame("-1", -1M).Should().BeTrue();
+            valueComparer.Compare("3.14", 3.14M).Should().BeTrue();
+            valueComparer.Compare("0", 0M).Should().BeTrue();
+            valueComparer.Compare("-1", -1M).Should().BeTrue();
         }
 
         [Test]
         public void Returns_false_when_the_decimal_values_do_not_match()
         {
             var valueComparer = new DecimalValueComparer();
-            valueComparer.TheseValuesAreTheSame("-1", 1M).Should().BeFalse();
-            valueComparer.TheseValuesAreTheSame("0", 1M).Should().BeFalse();
-            valueComparer.TheseValuesAreTheSame("100.2874", 100.2873M).Should().BeFalse();
+            valueComparer.Compare("-1", 1M).Should().BeFalse();
+            valueComparer.Compare("0", 1M).Should().BeFalse();
+            valueComparer.Compare("100.2874", 100.2873M).Should().BeFalse();
         }
 
         [Test]
         public void Returns_false_when_the_expected_value_is_not_a_decimal()
         {
             var valueComparer = new DecimalValueComparer();
-            valueComparer.TheseValuesAreTheSame("x", 0M).Should().BeFalse();
-            valueComparer.TheseValuesAreTheSame("", 0M).Should().BeFalse();
-            valueComparer.TheseValuesAreTheSame("-----3", 0M).Should().BeFalse();
+            valueComparer.Compare("x", 0M).Should().BeFalse();
+            valueComparer.Compare("", 0M).Should().BeFalse();
+            valueComparer.Compare("-----3", 0M).Should().BeFalse();
         }
     }
 }

--- a/Tests/RuntimeTests/AssistTests/ValueComparerTests/DoubleValueComparerTests.cs
+++ b/Tests/RuntimeTests/AssistTests/ValueComparerTests/DoubleValueComparerTests.cs
@@ -37,27 +37,27 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.ValueComparerTests
         public void Returns_true_when_the_double_values_match()
         {
             var valueComparer = new DoubleValueComparer();
-            valueComparer.TheseValuesAreTheSame("3.14", 3.14).Should().BeTrue();
-            valueComparer.TheseValuesAreTheSame("0", 0.0).Should().BeTrue();
-            valueComparer.TheseValuesAreTheSame("-1", -1.0).Should().BeTrue();
+            valueComparer.Compare("3.14", 3.14).Should().BeTrue();
+            valueComparer.Compare("0", 0.0).Should().BeTrue();
+            valueComparer.Compare("-1", -1.0).Should().BeTrue();
         }
 
         [Test]
         public void Returns_false_when_the_double_values_do_not_match()
         {
             var valueComparer = new DoubleValueComparer();
-            valueComparer.TheseValuesAreTheSame("-1", 1.0).Should().BeFalse();
-            valueComparer.TheseValuesAreTheSame("0", 1.0).Should().BeFalse();
-            valueComparer.TheseValuesAreTheSame("100.2874", 100.2873).Should().BeFalse();
+            valueComparer.Compare("-1", 1.0).Should().BeFalse();
+            valueComparer.Compare("0", 1.0).Should().BeFalse();
+            valueComparer.Compare("100.2874", 100.2873).Should().BeFalse();
         }
 
         [Test]
         public void Returns_false_when_the_expected_value_is_not_a_double()
         {
             var valueComparer = new DoubleValueComparer();
-            valueComparer.TheseValuesAreTheSame("x", 0.0).Should().BeFalse();
-            valueComparer.TheseValuesAreTheSame("", 0.0).Should().BeFalse();
-            valueComparer.TheseValuesAreTheSame("-----3", 0).Should().BeFalse();
+            valueComparer.Compare("x", 0.0).Should().BeFalse();
+            valueComparer.Compare("", 0.0).Should().BeFalse();
+            valueComparer.Compare("-----3", 0).Should().BeFalse();
         }
     }
 }

--- a/Tests/RuntimeTests/AssistTests/ValueComparerTests/FloatValueComparerTests.cs
+++ b/Tests/RuntimeTests/AssistTests/ValueComparerTests/FloatValueComparerTests.cs
@@ -37,27 +37,27 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.ValueComparerTests
         public void Returns_true_when_the_single_values_match()
         {
             var valueComparer = new FloatValueComparer();
-            valueComparer.TheseValuesAreTheSame("3.14", 3.14F).Should().BeTrue();
-            valueComparer.TheseValuesAreTheSame("0", 0.0F).Should().BeTrue();
-            valueComparer.TheseValuesAreTheSame("-1", -1.0F).Should().BeTrue();
+            valueComparer.Compare("3.14", 3.14F).Should().BeTrue();
+            valueComparer.Compare("0", 0.0F).Should().BeTrue();
+            valueComparer.Compare("-1", -1.0F).Should().BeTrue();
         }
 
         [Test]
         public void Returns_false_when_the_single_values_do_not_match()
         {
             var valueComparer = new FloatValueComparer();
-            valueComparer.TheseValuesAreTheSame("-1", 1.0F).Should().BeFalse();
-            valueComparer.TheseValuesAreTheSame("0", 1.0F).Should().BeFalse();
-            valueComparer.TheseValuesAreTheSame("100.2874", 100.2873F).Should().BeFalse();
+            valueComparer.Compare("-1", 1.0F).Should().BeFalse();
+            valueComparer.Compare("0", 1.0F).Should().BeFalse();
+            valueComparer.Compare("100.2874", 100.2873F).Should().BeFalse();
         }
 
         [Test]
         public void Returns_false_when_the_expected_value_is_not_a_single()
         {
             var valueComparer = new FloatValueComparer();
-            valueComparer.TheseValuesAreTheSame("x", 0.0F).Should().BeFalse();
-            valueComparer.TheseValuesAreTheSame("", 0.0F).Should().BeFalse();
-            valueComparer.TheseValuesAreTheSame("-----3", 0F).Should().BeFalse();
+            valueComparer.Compare("x", 0.0F).Should().BeFalse();
+            valueComparer.Compare("", 0.0F).Should().BeFalse();
+            valueComparer.Compare("-----3", 0F).Should().BeFalse();
         }
     }
 }

--- a/Tests/RuntimeTests/AssistTests/ValueComparerTests/GuidValueComparerTests.cs
+++ b/Tests/RuntimeTests/AssistTests/ValueComparerTests/GuidValueComparerTests.cs
@@ -39,10 +39,10 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.ValueComparerTests
         public void Returns_true_when_the_value_and_the_string_match()
         {
             var valueComparer = CreateComparer();
-            valueComparer.TheseValuesAreTheSame("A5C82A02-4A2F-4DEE-AB4A-E829E7B476B3",
+            valueComparer.Compare("A5C82A02-4A2F-4DEE-AB4A-E829E7B476B3",
                                                 new Guid("A5C82A02-4A2F-4DEE-AB4A-E829E7B476B3"))
                 .Should().BeTrue();
-            valueComparer.TheseValuesAreTheSame("D237B442-8364-4C07-AE13-99FFD55F729B",
+            valueComparer.Compare("D237B442-8364-4C07-AE13-99FFD55F729B",
                                                 new Guid("D237B442-8364-4C07-AE13-99FFD55F729B"))
                 .Should().BeTrue();
         }
@@ -51,10 +51,10 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.ValueComparerTests
         public void Returns_false_when_the_value_and_the_string_do_not_match()
         {
             var valueComparer = CreateComparer();
-            valueComparer.TheseValuesAreTheSame("B5C82A02-4A2F-4DEE-AB4A-E829E7B476B3",
+            valueComparer.Compare("B5C82A02-4A2F-4DEE-AB4A-E829E7B476B3",
                                                 new Guid("A5C82A02-4A2F-4DEE-AB4A-E829E7B476B3"))
                 .Should().BeFalse();
-            valueComparer.TheseValuesAreTheSame("D237B442-8364-4C07-AE13-99FFD55F729C",
+            valueComparer.Compare("D237B442-8364-4C07-AE13-99FFD55F729C",
                                                 new Guid("D237B442-8364-4C07-AE13-99FFD55F729B"))
                 .Should().BeFalse();
         }
@@ -63,10 +63,10 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.ValueComparerTests
         public void Returns_true_even_if_the_expected_value_is_wrapped_in_curly_braces()
         {
             var valueComparer = CreateComparer();
-            valueComparer.TheseValuesAreTheSame("{5C50F10A-87C7-4A6E-B772-8055317A39B8}",
+            valueComparer.Compare("{5C50F10A-87C7-4A6E-B772-8055317A39B8}",
                                                 new Guid("{5C50F10A-87C7-4A6E-B772-8055317A39B8}"))
                 .Should().BeTrue();
-            valueComparer.TheseValuesAreTheSame("{A44604A1-0144-4AA1-B4EC-3B1117C1127D}",
+            valueComparer.Compare("{A44604A1-0144-4AA1-B4EC-3B1117C1127D}",
                                                 new Guid("{A44604A1-0144-4AA1-B4EC-3B1117C1127D}"))
                 .Should().BeTrue();
         }
@@ -75,9 +75,9 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.ValueComparerTests
         public void Returns_false_if_the_expected_value_is_not_a_valid_guid()
         {
             var valueComparer = CreateComparer();
-            valueComparer.TheseValuesAreTheSame("x", new Guid())
+            valueComparer.Compare("x", new Guid())
                 .Should().BeFalse();
-            valueComparer.TheseValuesAreTheSame("g234", new Guid("{4CD16C19-9A8A-4B2B-BA8C-2D3985EBD292}"))
+            valueComparer.Compare("g234", new Guid("{4CD16C19-9A8A-4B2B-BA8C-2D3985EBD292}"))
                 .Should().BeFalse();
         }
 
@@ -85,7 +85,7 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.ValueComparerTests
         public void Returns_true_if_the_expected_value_is_0_and_the_expected_is_an_empty_guid()
         {
             var valueComparer = CreateComparer();
-            valueComparer.TheseValuesAreTheSame("0", new Guid())
+            valueComparer.Compare("0", new Guid())
                 .Should().BeTrue();
         }
 
@@ -93,10 +93,10 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.ValueComparerTests
         public void Matches_regardless_of_casing()
         {
             var valueComparer = CreateComparer();
-            valueComparer.TheseValuesAreTheSame("{767c5221-ed1e-4e6b-9028-6b77b5195d56}",
+            valueComparer.Compare("{767c5221-ed1e-4e6b-9028-6b77b5195d56}",
                                                 new Guid("{767C5221-ED1E-4E6B-9028-6B77B5195D56}"))
                 .Should().BeTrue();
-            valueComparer.TheseValuesAreTheSame("{43BA4A14-C65C-4D47-9A83-6D36E03F3576}",
+            valueComparer.Compare("{43BA4A14-C65C-4D47-9A83-6D36E03F3576}",
                                                 new Guid("{43ba4a14-C65c-4D47-9a83-6d36e03f3576}"))
                 .Should().BeTrue();
         }
@@ -105,11 +105,11 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.ValueComparerTests
         public void Matches_based_on_the_first_eight_digits_when_the_rest_are_zeroes()
         {
             var valueComparer = CreateComparer();
-            valueComparer.TheseValuesAreTheSame("B6F8CA06",
+            valueComparer.Compare("B6F8CA06",
                                                 new Guid("B6F8CA06-0000-0000-0000-000000000000"))
                 .Should().BeTrue();
 
-            valueComparer.TheseValuesAreTheSame("35E9525C",
+            valueComparer.Compare("35E9525C",
                                                 new Guid("35E9525C-0000-0000-0000-000000000000"))
                 .Should().BeTrue();
         }
@@ -118,11 +118,11 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.ValueComparerTests
         public void Matches_based_on_the_first_nine_digits_when_the_rest_are_zeroes()
         {
             var valueComparer = CreateComparer();
-            valueComparer.TheseValuesAreTheSame("B6F8CA067",
+            valueComparer.Compare("B6F8CA067",
                                                 new Guid("B6F8CA06-7000-0000-0000-000000000000"))
                 .Should().BeTrue();
 
-            valueComparer.TheseValuesAreTheSame("35E9525CA",
+            valueComparer.Compare("35E9525CA",
                                                 new Guid("35E9525C-A000-0000-0000-000000000000"))
                 .Should().BeTrue();
         }

--- a/Tests/RuntimeTests/AssistTests/WorkingExampleOfValueRetrieverAndComparerAddition.cs
+++ b/Tests/RuntimeTests/AssistTests/WorkingExampleOfValueRetrieverAndComparerAddition.cs
@@ -60,7 +60,7 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests
             return actualValue != null && actualValue.GetType() == typeof(FancyName);
         }
 
-        public bool TheseValuesAreTheSame(string expectedValue, object actualValue)
+        public bool Compare(string expectedValue, object actualValue)
         {
             var expected = FancyNameValueRetriever.Parse(expectedValue);
             var actual = (FancyName)actualValue; 
@@ -159,7 +159,7 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests
             return actualValue != null && actualValue.GetType() == typeof(ProductCategory);
         }
 
-        public bool TheseValuesAreTheSame(string expectedValue, object actualValue)
+        public bool Compare(string expectedValue, object actualValue)
         {
             var expected = ProductCategoryValueRetriever.Parse(expectedValue);
             var actual = (ProductCategory)actualValue; 

--- a/Tests/RuntimeTests/AssistTests/WorkingExampleOfValueRetrieverAndComparerAddition.cs
+++ b/Tests/RuntimeTests/AssistTests/WorkingExampleOfValueRetrieverAndComparerAddition.cs
@@ -41,12 +41,12 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests
             return new Type[]{ typeof(FancyName) };
         }
 
-        public object ExtractValueFromRow(TableRow row, Type targetType)
+        public object Retrieve(KeyValuePair<string, string> keyValuePair, Type targetType)
         {
-            return FancyNameValueRetriever.Parse(row[1]);
+            return FancyNameValueRetriever.Parse(keyValuePair.Value);
         }
 
-        public bool CanRetrieve(TableRow row, Type type)
+        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type type)
         {
             return this.TypesForWhichIRetrieveValues().Contains(type);
         }
@@ -140,12 +140,12 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests
             return new Type[]{ typeof(ProductCategory) };
         }
 
-        public object ExtractValueFromRow(TableRow row, Type targetType)
+        public object Retrieve(KeyValuePair<string, string> keyValuePair, Type targetType)
         {
-            return ProductCategoryValueRetriever.Parse(row[1]);
+            return ProductCategoryValueRetriever.Parse(keyValuePair.Value);
         }
 
-        public bool CanRetrieve(TableRow row, Type type)
+        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type type)
         {
             return this.TypesForWhichIRetrieveValues().Contains(type);
         }


### PR DESCRIPTION
1.)  For clarity, ```IValueRetriever``` and ```IValueComparer``` now have a very clear ```CanRetrieve```/```CanCompare```.  

2.)  Added XML comments to these two new public interfaces to better explain them to those who use them.

3.)  When these were internal classes, each property defined in a table was passed around as a ```TableRow```.  The code just ended up that way, and it was always assumed that ```row[0]``` was the key and ```row[1]``` was the value.  Since these are now public interfaces, I switched to a ```KeyValuePair<string, string>``` to make it clear to those who might want to implement these classes.