### PR TITLE
Added XUnit implementation for SetTestClassCategories using traits

### DIFF
--- a/Generator/UnitTestProvider/XUnitTestGeneratorProvider.cs
+++ b/Generator/UnitTestProvider/XUnitTestGeneratorProvider.cs
@@ -134,7 +134,8 @@ namespace TechTalk.SpecFlow.Generator.UnitTestProvider
 
         public void SetTestMethodCategories(TestClassGenerationContext generationContext, CodeMemberMethod testMethod, IEnumerable<string> scenarioCategories)
         {
-            // xUnit does not support caregories
+            foreach (string str in scenarioCategories)
+                SetProperty((CodeTypeMember)testMethod, "Category", str);
         }
 
         public void SetTestInitializeMethod(TestClassGenerationContext generationContext)

--- a/Generator/UnitTestProvider/XUnitTestGeneratorProvider.cs
+++ b/Generator/UnitTestProvider/XUnitTestGeneratorProvider.cs
@@ -17,6 +17,7 @@ namespace TechTalk.SpecFlow.Generator.UnitTestProvider
         private const string SKIP_REASON = "Ignored";
         private const string TRAIT_ATTRIBUTE = "Xunit.TraitAttribute";
         private const string IUSEFIXTURE_INTERFACE = "Xunit.IUseFixture";
+        private const string CATEGORY_PROPERTY_NAME = "Category";
 
         private CodeTypeDeclaration _currentFixtureDataTypeDeclaration = null;
 
@@ -37,7 +38,9 @@ namespace TechTalk.SpecFlow.Generator.UnitTestProvider
 
         public void SetTestClassCategories(TestClassGenerationContext generationContext, IEnumerable<string> featureCategories)
         {
-            // xUnit does not support caregories
+            // Set Category trait which can be used with the /trait or /-trait xunit flags to include/exclude tests
+            foreach (string str in featureCategories)
+                SetProperty(generationContext.TestClass, CATEGORY_PROPERTY_NAME, str);
         }
 
         public void SetTestClassInitializeMethod(TestClassGenerationContext generationContext)


### PR DESCRIPTION
Setting the Category as a trait attribute, which allows you to include/exclude groups of tests using the /trait or /-trait parameters.

We've used this successfully already via a Specflow plugin, thought we'd see if you'd like to include it in the main Specflow implementation.

Eg.  Include all smoketest categorised tests but exclude broken ones
/trait "Category=smoketest" /-trait "Category=broken"