### PR TITLE
Step transformation value retriever

### DIFF
--- a/Runtime/Assist/Service.cs
+++ b/Runtime/Assist/Service.cs
@@ -70,7 +70,6 @@ namespace TechTalk.SpecFlow.Assist
             RegisterValueComparer(new FloatValueComparer());
             RegisterValueComparer(new DefaultValueComparer());
 
-            RegisterValueRetriever(new StepTransformationValueRetriever());
             RegisterValueRetriever(new StringValueRetriever());
             RegisterValueRetriever(new ByteValueRetriever());
             RegisterValueRetriever(new SByteValueRetriever());
@@ -105,6 +104,7 @@ namespace TechTalk.SpecFlow.Assist
             RegisterValueRetriever(new NullableUShortValueRetriever());
             RegisterValueRetriever(new NullableLongValueRetriever());
             RegisterValueRetriever(new NullableTimeSpanValueRetriever());
+            RegisterValueRetriever(new StepTransformationValueRetriever());
         }
 
         public IValueRetriever GetValueRetrieverFor(TableRow row, Type type)

--- a/Runtime/Assist/Service.cs
+++ b/Runtime/Assist/Service.cs
@@ -70,6 +70,7 @@ namespace TechTalk.SpecFlow.Assist
             RegisterValueComparer(new FloatValueComparer());
             RegisterValueComparer(new DefaultValueComparer());
 
+            RegisterValueRetriever(new StepTransformationValueRetriever());
             RegisterValueRetriever(new StringValueRetriever());
             RegisterValueRetriever(new ByteValueRetriever());
             RegisterValueRetriever(new SByteValueRetriever());

--- a/Runtime/Assist/ValueRetrievers/StepTransformationValueRetriever.cs
+++ b/Runtime/Assist/ValueRetrievers/StepTransformationValueRetriever.cs
@@ -10,32 +10,33 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
 {
     public class StepTransformationValueRetriever : IValueRetriever
     {
-        private IStepArgumentTypeConverter stepArgumentTypeConverter;
-        private CultureInfo cultureInfo;
-
-        public StepTransformationValueRetriever(IStepArgumentTypeConverter stepArgumentTypeConverter, CultureInfo cultureInfo)
-        {
-            this.stepArgumentTypeConverter = stepArgumentTypeConverter;
-            this.cultureInfo = cultureInfo;
-        }
-
-        public object ExtractValueFromRow(TableRow row, Type targetType)
-        {
-            return stepArgumentTypeConverter.Convert(row[1], BindingTypeFor(targetType), cultureInfo);
-        }
-
-        public bool CanRetrieve(TableRow row, Type type)
+        public bool CanRetrieve(KeyValuePair<string, string> row, Type type)
         {
             try {
-                return stepArgumentTypeConverter.CanConvert(row[1], BindingTypeFor(type), cultureInfo);
+                return StepArgumentTypeConverter().CanConvert(row.Value, BindingTypeFor(type), CultureInfo());
             } catch {
                 return false;
             }
         }
 
+        public object Retrieve(KeyValuePair<string, string> keyValuePair, Type targetType)
+        {
+            return StepArgumentTypeConverter().Convert(keyValuePair.Value, BindingTypeFor(targetType), CultureInfo());
+        }
+
         public IBindingType BindingTypeFor(Type type)
         {
             return new RuntimeBindingType(type);
+        }
+
+        public IStepArgumentTypeConverter StepArgumentTypeConverter()
+        {
+            return ScenarioContext.Current.ScenarioContainer.Resolve<IStepArgumentTypeConverter>();
+        }
+
+        public CultureInfo CultureInfo()
+        {
+            return ScenarioContext.Current.ScenarioContainer.Resolve<CultureInfo>();
         }
     }
 }

--- a/Runtime/Assist/ValueRetrievers/StepTransformationValueRetriever.cs
+++ b/Runtime/Assist/ValueRetrievers/StepTransformationValueRetriever.cs
@@ -5,11 +5,14 @@ using TechTalk.SpecFlow;
 using TechTalk.SpecFlow.Bindings;
 using TechTalk.SpecFlow.Bindings.Reflection;
 using System.Collections.Generic;
+using BoDi;
 
 namespace TechTalk.SpecFlow.Assist.ValueRetrievers
 {
     public class StepTransformationValueRetriever : IValueRetriever
     {
+        private IObjectContainer container;
+
         public bool CanRetrieve(KeyValuePair<string, string> row, Type type)
         {
             try {
@@ -31,12 +34,25 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
 
         public IStepArgumentTypeConverter StepArgumentTypeConverter()
         {
-            return ScenarioContext.Current.ScenarioContainer.Resolve<IStepArgumentTypeConverter>();
+            return ObjectContainer().Resolve<IStepArgumentTypeConverter>();
         }
 
         public CultureInfo CultureInfo()
         {
-            return ScenarioContext.Current.ScenarioContainer.Resolve<CultureInfo>();
+            return ObjectContainer().Resolve<CultureInfo>();
+        }
+
+        public IObjectContainer Container {
+            get;
+            set;
+        }
+
+        public virtual IObjectContainer ObjectContainer()
+        {
+            if (Container != null)
+                return Container;
+            else
+                return ScenarioContext.Current.ScenarioContainer;
         }
     }
 }

--- a/Runtime/Assist/ValueRetrievers/StepTransformationValueRetriever.cs
+++ b/Runtime/Assist/ValueRetrievers/StepTransformationValueRetriever.cs
@@ -11,8 +11,6 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
 {
     public class StepTransformationValueRetriever : IValueRetriever
     {
-        private IObjectContainer container;
-
         public bool CanRetrieve(KeyValuePair<string, string> row, Type type)
         {
             try {
@@ -34,23 +32,20 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
 
         public IStepArgumentTypeConverter StepArgumentTypeConverter()
         {
-            return ObjectContainer().Resolve<IStepArgumentTypeConverter>();
+            return Container().Resolve<IStepArgumentTypeConverter>();
         }
 
         public CultureInfo CultureInfo()
         {
-            return ObjectContainer().Resolve<CultureInfo>();
+            return Container().Resolve<CultureInfo>();
         }
 
-        public IObjectContainer Container {
-            get;
-            set;
-        }
+        public IObjectContainer ContainerToUseForThePurposeOfTesting { get; set; }
 
-        public virtual IObjectContainer ObjectContainer()
+        public virtual IObjectContainer Container()
         {
-            if (Container != null)
-                return Container;
+            if (ContainerToUseForThePurposeOfTesting != null)
+                return ContainerToUseForThePurposeOfTesting;
             else
                 return ScenarioContext.Current.ScenarioContainer;
         }

--- a/Runtime/Assist/ValueRetrievers/StepTransformationValueRetriever.cs
+++ b/Runtime/Assist/ValueRetrievers/StepTransformationValueRetriever.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Linq;
+using System.Globalization;
+using TechTalk.SpecFlow;
+using TechTalk.SpecFlow.Bindings;
+using TechTalk.SpecFlow.Bindings.Reflection;
+using System.Collections.Generic;
+
+namespace TechTalk.SpecFlow.Assist.ValueRetrievers
+{
+    public class StepTransformationValueRetriever : IValueRetriever
+    {
+        private IStepArgumentTypeConverter stepArgumentTypeConverter;
+        private CultureInfo cultureInfo;
+
+        public StepTransformationValueRetriever(IStepArgumentTypeConverter stepArgumentTypeConverter, CultureInfo cultureInfo)
+        {
+            this.stepArgumentTypeConverter = stepArgumentTypeConverter;
+            this.cultureInfo = cultureInfo;
+        }
+
+        public object ExtractValueFromRow(TableRow row, Type targetType)
+        {
+            return stepArgumentTypeConverter.Convert(row[1], BindingTypeFor(targetType), cultureInfo);
+        }
+
+        public bool CanRetrieve(TableRow row, Type type)
+        {
+            try {
+                return stepArgumentTypeConverter.CanConvert(row[1], BindingTypeFor(type), cultureInfo);
+            } catch {
+                return false;
+            }
+        }
+
+        public IBindingType BindingTypeFor(Type type)
+        {
+            return new RuntimeBindingType(type);
+        }
+    }
+}

--- a/Runtime/TechTalk.SpecFlow.csproj
+++ b/Runtime/TechTalk.SpecFlow.csproj
@@ -232,6 +232,7 @@
     <Compile Include="Assist\Service.cs" />
     <Compile Include="Assist\IValueRetriever.cs" />
     <Compile Include="Assist\ValueRetrievers\TimeSpanValueRetriever.cs" />
+    <Compile Include="Assist\ValueRetrievers\StepTransformationValueRetriever.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="..\Languages.xml">

--- a/Tests/RuntimeTests/AssistTests/ServiceTests.cs
+++ b/Tests/RuntimeTests/AssistTests/ServiceTests.cs
@@ -5,6 +5,7 @@ using TechTalk.SpecFlow.Assist;
 using TechTalk.SpecFlow.Assist.ValueComparers;
 using TechTalk.SpecFlow.Assist.ValueRetrievers;
 using System.Collections.Generic;
+using FluentAssertions;
 
 namespace TechTalk.SpecFlow.RuntimeTests.AssistTests
 {
@@ -71,6 +72,12 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests
             Assert.AreEqual(1, results.Where(x => x.GetType() == typeof(NullableLongValueRetriever)).Count());
             Assert.AreEqual(1, results.Where(x => x.GetType() == typeof(NullableTimeSpanValueRetriever)).Count());
             Assert.AreEqual(1, results.Where(x => x.GetType() == typeof(StepTransformationValueRetriever)).Count());
+        }
+
+        [Test]
+        public void Should_put_the_step_transformation_value_retriever_last_so_it_will_not_interfere_with_preexisting_features_in_assist()
+        {
+            new Service().ValueRetrievers.Last().GetType().Should().Be(typeof(StepTransformationValueRetriever));
         }
 
         [Test]

--- a/Tests/RuntimeTests/AssistTests/ServiceTests.cs
+++ b/Tests/RuntimeTests/AssistTests/ServiceTests.cs
@@ -34,7 +34,7 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests
             var service = new Service();
 
             var results = service.ValueRetrievers;
-            Assert.AreEqual(34, results.Count());
+            Assert.AreEqual(35, results.Count());
 
             Assert.AreEqual(1, results.Where(x => x.GetType() == typeof(StringValueRetriever)).Count());
             Assert.AreEqual(1, results.Where(x => x.GetType() == typeof(ByteValueRetriever)).Count());
@@ -70,6 +70,7 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests
             Assert.AreEqual(1, results.Where(x => x.GetType() == typeof(NullableUShortValueRetriever)).Count());
             Assert.AreEqual(1, results.Where(x => x.GetType() == typeof(NullableLongValueRetriever)).Count());
             Assert.AreEqual(1, results.Where(x => x.GetType() == typeof(NullableTimeSpanValueRetriever)).Count());
+            Assert.AreEqual(1, results.Where(x => x.GetType() == typeof(StepTransformationValueRetriever)).Count());
         }
 
         [Test]

--- a/Tests/RuntimeTests/AssistTests/ValueRetrieverTests/StepTransformationValueRetrieverTests.cs
+++ b/Tests/RuntimeTests/AssistTests/ValueRetrieverTests/StepTransformationValueRetrieverTests.cs
@@ -28,6 +28,34 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.ValueRetrieverTests
         }
 
         [Test]
+        public void Retriever_will_use_the_current_culture_info()
+        {
+            var stepArgumentTypeConverter = new Mock<IStepArgumentTypeConverter>();
+
+            //one culture
+            var frenchSubject = Subject();
+
+            var frenchCultureInfo = new CultureInfo("fr-FR");
+            frenchSubject.ContainerToUseForThePurposeOfTesting.RegisterInstanceAs<IStepArgumentTypeConverter>(stepArgumentTypeConverter.Object);
+            frenchSubject.ContainerToUseForThePurposeOfTesting.RegisterInstanceAs<CultureInfo>(frenchCultureInfo);
+
+            var french = new Object();
+            stepArgumentTypeConverter.Setup(x => x.Convert("2009/10/06", It.IsAny<IBindingType>(), frenchCultureInfo)).Returns(french);
+            frenchSubject.Retrieve(KeyValueFor("2009/10/06"), typeof(DateTime)).Should().BeSameAs(french);
+
+            //another culture
+            var usSubject = Subject();
+
+            var usCultureInfo = new CultureInfo("fr-FR");
+            usSubject.ContainerToUseForThePurposeOfTesting.RegisterInstanceAs<IStepArgumentTypeConverter>(stepArgumentTypeConverter.Object);
+            usSubject.ContainerToUseForThePurposeOfTesting.RegisterInstanceAs<CultureInfo>(usCultureInfo);
+
+            var us = new Object();
+            stepArgumentTypeConverter.Setup(x => x.Convert("2009/10/06", It.IsAny<IBindingType>(), frenchCultureInfo)).Returns(us);
+            frenchSubject.Retrieve(KeyValueFor("2009/10/06"), typeof(DateTime)).Should().BeSameAs(us);
+        }
+
+        [Test]
         public void CanRetrieve_will_return_true_if_the_value_can_be_retrieved_from_a_step_argument_transformation()
         {
             Subject().CanRetrieve(KeyValueFor("2009/10/06"), typeof(DateTime)).Should().BeTrue();

--- a/Tests/RuntimeTests/AssistTests/ValueRetrieverTests/StepTransformationValueRetrieverTests.cs
+++ b/Tests/RuntimeTests/AssistTests/ValueRetrieverTests/StepTransformationValueRetrieverTests.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using TechTalk.SpecFlow.Infrastructure;
 using TechTalk.SpecFlow.Tracing;
+using System;
 
 namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.ValueRetrieverTests
 {
@@ -14,7 +15,7 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.ValueRetrieverTests
     public class StepTransformationValueRetrieverTests
     {
         [Test]
-        public void Returns_the_string_value_back()
+        public void Convert_will_return_the_value_from_the_step_argument_type_converter()
         {
             var retriever = new StepTransformationValueRetriever();
 
@@ -32,11 +33,14 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.ValueRetrieverTests
             var cultureInfo = new CultureInfo("en-US");
 
             container.RegisterInstanceAs<IStepArgumentTypeConverter>(stepArgumentTypeConverter);
+            container.RegisterInstanceAs<CultureInfo>(cultureInfo);
 
-            var hit = stepArgumentTypeConverter.Convert ("testValue", typeof(string), cultureInfo);
+            var hit = stepArgumentTypeConverter.Convert("testValue", typeof(string), cultureInfo);
+            retriever.Container = container;
 
-            var result = retriever.Retrieve(new System.Collections.Generic.KeyValuePair<string, string>("", "test"), typeof(string));
+            var result = retriever.Retrieve(new System.Collections.Generic.KeyValuePair<string, string>("", "2009/10/06"), typeof(DateTime));
 
+            result.Should().Be(new DateTime(2009, 10, 6));
         }
     }
 }

--- a/Tests/RuntimeTests/AssistTests/ValueRetrieverTests/StepTransformationValueRetrieverTests.cs
+++ b/Tests/RuntimeTests/AssistTests/ValueRetrieverTests/StepTransformationValueRetrieverTests.cs
@@ -31,6 +31,7 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.ValueRetrieverTests
         public void Retriever_will_use_the_current_culture_info()
         {
             var stepArgumentTypeConverter = new Mock<IStepArgumentTypeConverter>();
+            var value = Guid.NewGuid().ToString();
 
             //one culture
             var frenchSubject = Subject();
@@ -40,8 +41,8 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.ValueRetrieverTests
             frenchSubject.ContainerToUseForThePurposeOfTesting.RegisterInstanceAs<CultureInfo>(frenchCultureInfo);
 
             var french = new Object();
-            stepArgumentTypeConverter.Setup(x => x.Convert("2009/10/06", It.IsAny<IBindingType>(), frenchCultureInfo)).Returns(french);
-            frenchSubject.Retrieve(KeyValueFor("2009/10/06"), typeof(DateTime)).Should().BeSameAs(french);
+            stepArgumentTypeConverter.Setup(x => x.Convert(value, It.IsAny<IBindingType>(), frenchCultureInfo)).Returns(french);
+            frenchSubject.Retrieve(KeyValueFor(value), typeof(DateTime)).Should().BeSameAs(french);
 
             //another culture
             var usSubject = Subject();
@@ -51,8 +52,8 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.ValueRetrieverTests
             usSubject.ContainerToUseForThePurposeOfTesting.RegisterInstanceAs<CultureInfo>(usCultureInfo);
 
             var us = new Object();
-            stepArgumentTypeConverter.Setup(x => x.Convert("2009/10/06", It.IsAny<IBindingType>(), usCultureInfo)).Returns(us);
-            usSubject.Retrieve(KeyValueFor("2009/10/06"), typeof(DateTime)).Should().BeSameAs(us);
+            stepArgumentTypeConverter.Setup(x => x.Convert(value, It.IsAny<IBindingType>(), usCultureInfo)).Returns(us);
+            usSubject.Retrieve(KeyValueFor(value), typeof(DateTime)).Should().BeSameAs(us);
         }
 
         [Test]

--- a/Tests/RuntimeTests/AssistTests/ValueRetrieverTests/StepTransformationValueRetrieverTests.cs
+++ b/Tests/RuntimeTests/AssistTests/ValueRetrieverTests/StepTransformationValueRetrieverTests.cs
@@ -40,7 +40,7 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.ValueRetrieverTests
 
             // removing the container here will cause the class to use the scenario context,
             // which was not set, so... it will throw
-            subject.Container = null;
+            subject.ContainerToUseForThePurposeOfTesting = null;
 
             subject.CanRetrieve(KeyValueFor("2009/10/06"), typeof(DateTime)).Should().BeFalse();
             subject.CanRetrieve(KeyValueFor("not a date"), typeof(DateTime)).Should().BeFalse();
@@ -81,7 +81,7 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.ValueRetrieverTests
             // now we have what we need to get a our subject, loaded
             // with a fake source for all of its dependencies
             var retriever = new StepTransformationValueRetriever();
-            retriever.Container = container;
+            retriever.ContainerToUseForThePurposeOfTesting = container;
             return retriever;
         }
 

--- a/Tests/RuntimeTests/AssistTests/ValueRetrieverTests/StepTransformationValueRetrieverTests.cs
+++ b/Tests/RuntimeTests/AssistTests/ValueRetrieverTests/StepTransformationValueRetrieverTests.cs
@@ -14,33 +14,53 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.ValueRetrieverTests
     [TestFixture]
     public class StepTransformationValueRetrieverTests
     {
+
         [Test]
         public void Convert_will_return_the_value_from_the_step_argument_type_converter()
         {
-            var retriever = new StepTransformationValueRetriever();
+            var dateTimeResult = Subject().Retrieve(KeyValueFor("2009/10/06"), typeof(DateTime));
+            dateTimeResult.Should().Be(new DateTime(2009, 10, 6));
 
+            var stringResult = Subject().Retrieve(KeyValueFor("2009/10/06"), typeof(string));
+            stringResult.Should().Be("2009/10/06");
+        }
+
+        private KeyValuePair<string, string> KeyValueFor(string value)
+        {
+            // retrieving a value requires a key->value set, but this class
+            // does not need the key... so we pass nothing for our tests
+            return new System.Collections.Generic.KeyValuePair<string, string> ("", value);
+        }
+
+        private StepTransformationValueRetriever Subject()
+        {
+            // have to set up a container with a bunch of mocked stuff
+            // in order to build a StepArgumentTypeConverter
             var container = new BoDi.ObjectContainer();
+
             var provider = new TechTalk.SpecFlow.Infrastructure.DefaultDependencyProvider();
             provider.RegisterTestRunnerDefaults(container);
 
             Mock<IBindingRegistry> bindingRegistryStub = new Mock<IBindingRegistry>();
             List<IStepArgumentTransformationBinding> stepTransformations = new List<IStepArgumentTransformationBinding>();
             bindingRegistryStub.Setup(br => br.GetStepTransformations()).Returns(stepTransformations);
-
             Mock<IBindingInvoker> methodBindingInvokerStub = new Mock<IBindingInvoker>();
 
             var stepArgumentTypeConverter = new StepArgumentTypeConverter(new Mock<ITestTracer>().Object, bindingRegistryStub.Object, new Mock<IContextManager>().Object, methodBindingInvokerStub.Object);
+
+            // need a culture info as well
             var cultureInfo = new CultureInfo("en-US");
 
+            // load them into the container
             container.RegisterInstanceAs<IStepArgumentTypeConverter>(stepArgumentTypeConverter);
             container.RegisterInstanceAs<CultureInfo>(cultureInfo);
 
-            var hit = stepArgumentTypeConverter.Convert("testValue", typeof(string), cultureInfo);
+            // now we have what we need to get a our subject, loaded
+            // with a fake source for all of its dependencies
+            var retriever = new StepTransformationValueRetriever();
             retriever.Container = container;
-
-            var result = retriever.Retrieve(new System.Collections.Generic.KeyValuePair<string, string>("", "2009/10/06"), typeof(DateTime));
-
-            result.Should().Be(new DateTime(2009, 10, 6));
+            return retriever;
         }
+
     }
 }

--- a/Tests/RuntimeTests/AssistTests/ValueRetrieverTests/StepTransformationValueRetrieverTests.cs
+++ b/Tests/RuntimeTests/AssistTests/ValueRetrieverTests/StepTransformationValueRetrieverTests.cs
@@ -16,7 +16,7 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.ValueRetrieverTests
     {
 
         [Test]
-        public void Convert_will_return_the_value_from_the_step_argument_type_converter()
+        public void Retrieve_will_return_the_value_from_the_step_argument_type_converter()
         {
             var dateTimeResult = Subject().Retrieve(KeyValueFor("2009/10/06"), typeof(DateTime));
             dateTimeResult.Should().Be(new DateTime(2009, 10, 6));

--- a/Tests/RuntimeTests/AssistTests/ValueRetrieverTests/StepTransformationValueRetrieverTests.cs
+++ b/Tests/RuntimeTests/AssistTests/ValueRetrieverTests/StepTransformationValueRetrieverTests.cs
@@ -25,6 +25,29 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.ValueRetrieverTests
             stringResult.Should().Be("2009/10/06");
         }
 
+        [Test]
+        public void CanRetrieve_will_return_true_if_the_value_can_be_retrieved_from_a_step_argument_transformation()
+        {
+            Subject().CanRetrieve(KeyValueFor("2009/10/06"), typeof(DateTime)).Should().BeTrue();
+            Subject().CanRetrieve(KeyValueFor("not a date"), typeof(DateTime)).Should().BeFalse();
+            Subject().CanRetrieve(KeyValueFor("not a date"), typeof(string)).Should().BeTrue();
+        }
+
+        [Test]
+        public void CanRetrieve_will_return_false_if_the_step_argument_transformation_work_is_throwing()
+        {
+            var subject = Subject();
+
+            // removing the container here will cause the class to use the scenario context,
+            // which was not set, so... it will throw
+            subject.Container = null;
+
+            subject.CanRetrieve(KeyValueFor("2009/10/06"), typeof(DateTime)).Should().BeFalse();
+            subject.CanRetrieve(KeyValueFor("not a date"), typeof(DateTime)).Should().BeFalse();
+            subject.CanRetrieve(KeyValueFor("not a date"), typeof(string)).Should().BeFalse();
+        }
+
+
         private KeyValuePair<string, string> KeyValueFor(string value)
         {
             // retrieving a value requires a key->value set, but this class

--- a/Tests/RuntimeTests/AssistTests/ValueRetrieverTests/StepTransformationValueRetrieverTests.cs
+++ b/Tests/RuntimeTests/AssistTests/ValueRetrieverTests/StepTransformationValueRetrieverTests.cs
@@ -1,0 +1,42 @@
+﻿using FluentAssertions;
+using NUnit.Framework;
+using TechTalk.SpecFlow.Assist.ValueRetrievers;
+using Moq;
+using TechTalk.SpecFlow.Bindings;
+using System.Collections.Generic;
+using System.Globalization;
+using TechTalk.SpecFlow.Infrastructure;
+using TechTalk.SpecFlow.Tracing;
+
+namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.ValueRetrieverTests
+{
+    [TestFixture]
+    public class StepTransformationValueRetrieverTests
+    {
+        [Test]
+        public void Returns_the_string_value_back()
+        {
+            var retriever = new StepTransformationValueRetriever();
+
+            var container = new BoDi.ObjectContainer();
+            var provider = new TechTalk.SpecFlow.Infrastructure.DefaultDependencyProvider();
+            provider.RegisterTestRunnerDefaults(container);
+
+            Mock<IBindingRegistry> bindingRegistryStub = new Mock<IBindingRegistry>();
+            List<IStepArgumentTransformationBinding> stepTransformations = new List<IStepArgumentTransformationBinding>();
+            bindingRegistryStub.Setup(br => br.GetStepTransformations()).Returns(stepTransformations);
+
+            Mock<IBindingInvoker> methodBindingInvokerStub = new Mock<IBindingInvoker>();
+
+            var stepArgumentTypeConverter = new StepArgumentTypeConverter(new Mock<ITestTracer>().Object, bindingRegistryStub.Object, new Mock<IContextManager>().Object, methodBindingInvokerStub.Object);
+            var cultureInfo = new CultureInfo("en-US");
+
+            container.RegisterInstanceAs<IStepArgumentTypeConverter>(stepArgumentTypeConverter);
+
+            var hit = stepArgumentTypeConverter.Convert ("testValue", typeof(string), cultureInfo);
+
+            var result = retriever.Retrieve(new System.Collections.Generic.KeyValuePair<string, string>("", "test"), typeof(string));
+
+        }
+    }
+}

--- a/Tests/RuntimeTests/AssistTests/ValueRetrieverTests/StepTransformationValueRetrieverTests.cs
+++ b/Tests/RuntimeTests/AssistTests/ValueRetrieverTests/StepTransformationValueRetrieverTests.cs
@@ -51,8 +51,8 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.ValueRetrieverTests
             usSubject.ContainerToUseForThePurposeOfTesting.RegisterInstanceAs<CultureInfo>(usCultureInfo);
 
             var us = new Object();
-            stepArgumentTypeConverter.Setup(x => x.Convert("2009/10/06", It.IsAny<IBindingType>(), frenchCultureInfo)).Returns(us);
-            frenchSubject.Retrieve(KeyValueFor("2009/10/06"), typeof(DateTime)).Should().BeSameAs(us);
+            stepArgumentTypeConverter.Setup(x => x.Convert("2009/10/06", It.IsAny<IBindingType>(), usCultureInfo)).Returns(us);
+            usSubject.Retrieve(KeyValueFor("2009/10/06"), typeof(DateTime)).Should().BeSameAs(us);
         }
 
         [Test]

--- a/Tests/RuntimeTests/AssistTests/ValueRetrieverTests/StepTransformationValueRetrieverTests.cs
+++ b/Tests/RuntimeTests/AssistTests/ValueRetrieverTests/StepTransformationValueRetrieverTests.cs
@@ -48,14 +48,14 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.ValueRetrieverTests
         }
 
 
-        private KeyValuePair<string, string> KeyValueFor(string value)
+        private static KeyValuePair<string, string> KeyValueFor(string value)
         {
             // retrieving a value requires a key->value set, but this class
             // does not need the key... so we pass nothing for our tests
             return new System.Collections.Generic.KeyValuePair<string, string> ("", value);
         }
 
-        private StepTransformationValueRetriever Subject()
+        private static StepTransformationValueRetriever Subject()
         {
             // have to set up a container with a bunch of mocked stuff
             // in order to build a StepArgumentTypeConverter

--- a/Tests/RuntimeTests/RuntimeTests.csproj
+++ b/Tests/RuntimeTests/RuntimeTests.csproj
@@ -176,6 +176,7 @@
     <Compile Include="AssistTests\ServiceTests.cs" />
     <Compile Include="AssistTests\WorkingExampleOfValueRetrieverAndComparerAddition.cs" />
     <Compile Include="AssistTests\ValueRetrieverTests\TimeSpanValueRetrieverTests.cs" />
+    <Compile Include="AssistTests\ValueRetrieverTests\StepTransformationValueRetrieverTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Generator\TechTalk.SpecFlow.Generator.csproj">


### PR DESCRIPTION
This feature allows step argument transformations to be used in the SpecFlow.Assist helpers.

For example, let's say you had a StepArgumentTransformation to change a string into a ```Product```.

```c#
[StepArgumentTransformation]
public Product ToProduct(string name)
{
    return new Product(name);
}
```

You could then do this:

```gherkin
Given I have these things
| Product |
| a       |
| b       |
```

```c#

public class Thing
{
    public Product Product { get; set; }
}

[Given("I have these things")]
public void x(Table table)
{
    // the conversion of the strings "a" and "b" will run through
    // your step argument transformation
    var things = table.CreateSet<Thing>();
    things[0].Product.Name; // will equal "a"
    things[1].Product.Name; // will equal "b"
}
```

This feature really needs to be investigated by someone who uses step transformations, though.  I can trace the code and wire these bits up, but I have very little practical experience with step transformations.  Honestly, I think I've used them probably once or twice in all of these years of SpecFlow.

So can someone take this PR for a spin and see if it works well for you?  The bigger fan of step transformations you are, the better.