### PR TITLE
#293 - specflow editor should respect tabs vs spaces setting of VS

### DIFF
--- a/IdeIntegration/MonoDevelopIntegration/Templates/SpecFlowFeature.xft.xml
+++ b/IdeIntegration/MonoDevelopIntegration/Templates/SpecFlowFeature.xft.xml
@@ -13,17 +13,17 @@
 	<!-- Template Content -->
 	<TemplateFiles>
 		<File name="${Name}.feature" CustomTool="SpecFlowSingleFileGenerator">
-		<![CDATA[Feature: Addition
-	In order to avoid silly mistakes
-	As a math idiot
-	I want to be told the sum of two numbers
-	
+        <![CDATA[Feature: Addition
+    In order to avoid silly mistakes
+    As a math idiot
+    I want to be told the sum of two numbers
+    
 @mytag
 Scenario: Add two numbers
-	Given I have entered 50 into the calculator
-	And I have entered 70 into the calculator
-	When I press add
-	Then the result should be 120 on the screen]]>
-		</File>
+    Given I have entered 50 into the calculator
+    And I have entered 70 into the calculator
+    When I press add
+    Then the result should be 120 on the screen]]>
+        </File>
 	</TemplateFiles>
 </Template>

--- a/IdeIntegration/SharpDevelop4Integration/Templates/SpecFlowFeature.xft
+++ b/IdeIntegration/SharpDevelop4Integration/Templates/SpecFlowFeature.xft
@@ -33,16 +33,16 @@
 	<Files>
 		<File name="${FullName}" Generator="SpecFlowSingleFileGenerator"><![CDATA[
 Feature: Addition
-	In order to avoid silly mistakes
-	As a math idiot
-	I want to be told the sum of two numbers
-	
+    In order to avoid silly mistakes
+    As a math idiot
+    I want to be told the sum of two numbers
+    
 @mytag
 Scenario: Add two numbers
-	Given I have entered 50 into the calculator
-	And I have entered 70 into the calculator
-	When I press add
-	Then the result should be 120 on the screen
+    Given I have entered 50 into the calculator
+    And I have entered 70 into the calculator
+    When I press add
+    Then the result should be 120 on the screen
 ]]></File>
 	</Files>
 	

--- a/IdeIntegration/Vs2008Integration/ItemTemplates/SpecFlowFeature_CSharp/SpecFlowFeature1.feature
+++ b/IdeIntegration/Vs2008Integration/ItemTemplates/SpecFlowFeature_CSharp/SpecFlowFeature1.feature
@@ -1,11 +1,11 @@
 ﻿Feature: $itemname$
-	In order to avoid silly mistakes
-	As a math idiot
-	I want to be told the sum of two numbers
+    In order to avoid silly mistakes
+    As a math idiot
+    I want to be told the sum of two numbers
 
 @mytag
 Scenario: Add two numbers
-	Given I have entered 50 into the calculator
-	And I have entered 70 into the calculator
-	When I press add
-	Then the result should be 120 on the screen
+    Given I have entered 50 into the calculator
+    And I have entered 70 into the calculator
+    When I press add
+    Then the result should be 120 on the screen

--- a/IdeIntegration/Vs2008Integration/ItemTemplates/SpecFlowFeature_VB/SpecFlowFeature1.feature
+++ b/IdeIntegration/Vs2008Integration/ItemTemplates/SpecFlowFeature_VB/SpecFlowFeature1.feature
@@ -1,11 +1,11 @@
 ﻿Feature: $itemname$
-	In order to avoid silly mistakes
-	As a math idiot
-	I want to be told the sum of two numbers
+    In order to avoid silly mistakes
+    As a math idiot
+    I want to be told the sum of two numbers
 
 @mytag
 Scenario: Add two numbers
-	Given I have entered 50 into the calculator
-	And I have entered 70 into the calculator
-	When I press add
-	Then the result should be 120 on the screen
+    Given I have entered 50 into the calculator
+    And I have entered 70 into the calculator
+    When I press add
+    Then the result should be 120 on the screen

--- a/Tests/GeneratorTests/TestGeneratorErrorsTests.cs
+++ b/Tests/GeneratorTests/TestGeneratorErrorsTests.cs
@@ -37,7 +37,7 @@ namespace TechTalk.SpecFlow.GeneratorTests
             var result = testGenerator.GenerateTestFile(CreateSimpleFeatureFileInput(@"
                 Feature: Addition
                 Scenario: Add two numbers
-	                Given I have entered 50 into the calculator
+                    Given I have entered 50 into the calculator
                     AndXXX the keyword is misspelled
                     AndYYY this keyword is also misspelled"), defaultSettings);
             result.Errors.Should().NotBeNull();

--- a/Tests/GeneratorTests/TestGeneratorTestsBase.cs
+++ b/Tests/GeneratorTests/TestGeneratorTestsBase.cs
@@ -55,10 +55,10 @@ Feature: Addition
 
 @mytag
 Scenario: Add two numbers
-	Given I have entered 50 into the calculator
-	And I have entered 70 into the calculator
-	When I press add
-	Then the result should be 120 on the screen
+    Given I have entered 50 into the calculator
+    And I have entered 70 into the calculator
+    When I press add
+    Then the result should be 120 on the screen
 ");
         }
 
@@ -72,7 +72,7 @@ Scenario: Add two numbers
             return CreateSimpleFeatureFileInput(@"
 Feature: Addition
 Scenario: Add two numbers
-	Given I have entered 50 into the calculator
+    Given I have entered 50 into the calculator
     AndXXX the keyword is misspelled
 ");
         }

--- a/Tests/IdeIntegrationTests/RemoteAppDomainTestGeneratorFactoryTests.cs
+++ b/Tests/IdeIntegrationTests/RemoteAppDomainTestGeneratorFactoryTests.cs
@@ -248,10 +248,10 @@ Feature: Addition
 
 @mytag
 Scenario: Add two numbers
-	Given I have entered 50 into the calculator
-	And I have entered 70 into the calculator
-	When I press add
-	Then the result should be 120 on the screen
+    Given I have entered 50 into the calculator
+    And I have entered 70 into the calculator
+    When I press add
+    Then the result should be 120 on the screen
 "
                                                         };
                 var result = generator.GenerateTestFile(featureFileInput, new GenerationSettings());
@@ -277,7 +277,7 @@ Scenario: Add two numbers
                                                             FeatureFileContent = @"
 Feature: Addition
 Scenario: Add two numbers
-	Given I have entered 50 into the calculator
+    Given I have entered 50 into the calculator
     AndXXX the keyword is misspelled
 "
                                                         };


### PR DESCRIPTION
Replaced all tabulation in generated feature file to 4 spaces
