### PR TITLE
Snake case properties

### DIFF
--- a/Runtime/Assist/TEHelpers.cs
+++ b/Runtime/Assist/TEHelpers.cs
@@ -67,13 +67,20 @@ namespace TechTalk.SpecFlow.Assist
 
         internal static bool MatchesThisColumnName(this string propertyName, string columnName)
         {
-            // remove all characters that are not valid in a variable/property name
-            Regex pattern = new Regex("[^a-zA-Z0-9_]");
-
-            string normalizedColumnName = pattern.Replace(columnName, string.Empty);
-            string normalizedPropertyName = propertyName.Replace("_", "");
+            var normalizedColumnName = RemoveAllCharactersThatAreNotValidInAPropertyName(columnName);
+            var normalizedPropertyName = NormalizePropertyNamesForMatchingAgainstColumnHeaders(propertyName);
 
             return normalizedPropertyName.Equals(normalizedColumnName, StringComparison.OrdinalIgnoreCase);
+        }
+
+        internal static string RemoveAllCharactersThatAreNotValidInAPropertyName(string name)
+        {
+            return new Regex("[^a-zA-Z0-9_]").Replace(name, string.Empty);
+        }
+
+        internal static string NormalizePropertyNamesForMatchingAgainstColumnHeaders(string name)
+        {
+            return name.Replace("_", string.Empty);
         }
 
         internal static void LoadInstanceWithKeyValuePairs(Table table, object instance)

--- a/Runtime/Assist/TEHelpers.cs
+++ b/Runtime/Assist/TEHelpers.cs
@@ -68,7 +68,7 @@ namespace TechTalk.SpecFlow.Assist
         internal static bool MatchesThisColumnName(this string propertyName, string columnName)
         {
             var normalizedColumnName = RemoveAllCharactersThatAreNotValidInAPropertyName(columnName);
-            var normalizedPropertyName = NormalizePropertyNamesForMatchingAgainstColumnHeaders(propertyName);
+            var normalizedPropertyName = NormalizePropertyNameToMatchAgainstAColumnName(propertyName);
 
             return normalizedPropertyName.Equals(normalizedColumnName, StringComparison.OrdinalIgnoreCase);
         }
@@ -78,7 +78,7 @@ namespace TechTalk.SpecFlow.Assist
             return new Regex("[^a-zA-Z0-9_]").Replace(name, string.Empty);
         }
 
-        internal static string NormalizePropertyNamesForMatchingAgainstColumnHeaders(string name)
+        internal static string NormalizePropertyNameToMatchAgainstAColumnName(string name)
         {
             return name.Replace("_", string.Empty);
         }

--- a/Runtime/Assist/TEHelpers.cs
+++ b/Runtime/Assist/TEHelpers.cs
@@ -71,9 +71,9 @@ namespace TechTalk.SpecFlow.Assist
             Regex pattern = new Regex("[^a-zA-Z0-9_]");
 
             string normalizedColumnName = pattern.Replace(columnName, string.Empty);
+            string normalizedPropertyName = propertyName.Replace("_", "");
 
-            return propertyName.Equals(normalizedColumnName, StringComparison.OrdinalIgnoreCase);
-
+            return normalizedPropertyName.Equals(normalizedColumnName, StringComparison.OrdinalIgnoreCase);
         }
 
         internal static void LoadInstanceWithKeyValuePairs(Table table, object instance)

--- a/Tests/RuntimeTests/AssistTests/CreateInstanceHelperMethodTests.cs
+++ b/Tests/RuntimeTests/AssistTests/CreateInstanceHelperMethodTests.cs
@@ -318,10 +318,29 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests
             test.Prop2.Should().Be("world");
         }
 
+        [Test]
+        public void Woks_with_snake_case()
+        {
+            var table = new Table("Field", "Value");
+            table.AddRow("Look at me", "hello");
+            table.AddRow("This is so long", "world");
+
+            var test = table.CreateInstance<Snake>();
+
+            test.Look_at_me.Should().Be("hello");
+            test.this_is_so_long.Should().Be("world");
+        }
+
         private class Prop
         {
             public string Prop1 { get; set; }
             public string Prop2 { get; set; }
+        }
+
+        private class Snake
+        {
+            public string Look_at_me { get; set; }
+            public string this_is_so_long { get; set; }
         }
 
     }

--- a/Tests/RuntimeTests/AssistTests/CreateInstanceHelperMethodTests.cs
+++ b/Tests/RuntimeTests/AssistTests/CreateInstanceHelperMethodTests.cs
@@ -319,7 +319,7 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests
         }
 
         [Test]
-        public void Woks_with_snake_case()
+        public void Works_with_snake_case()
         {
             var table = new Table("Field", "Value");
             table.AddRow("Look at me", "hello");


### PR DESCRIPTION
Who would do this?

```c#
private class Snake
{
    public string Look_at_me { get; set; }
    public string this_is_so_long { get; set; }
}
```

Probably nobody.  Putting a spotlight on how we match columns to properties in #512 made me think that there might be some situations when the properties need to be changed to match the columns... but this is the only case I could think that wouldn't work.