### PR TITLE
Bring back the datetime offset retriever that got lost with v2

### DIFF
--- a/Runtime/Assist/Service.cs
+++ b/Runtime/Assist/Service.cs
@@ -88,6 +88,7 @@ namespace TechTalk.SpecFlow.Assist
             RegisterValueRetriever(new GuidValueRetriever());
             RegisterValueRetriever(new EnumValueRetriever());
             RegisterValueRetriever(new TimeSpanValueRetriever());
+            RegisterValueRetriever(new DateTimeOffsetValueRetriever());
             RegisterValueRetriever(new NullableGuidValueRetriever());
             RegisterValueRetriever(new NullableDateTimeValueRetriever());
             RegisterValueRetriever(new NullableBoolValueRetriever());
@@ -104,6 +105,7 @@ namespace TechTalk.SpecFlow.Assist
             RegisterValueRetriever(new NullableUShortValueRetriever());
             RegisterValueRetriever(new NullableLongValueRetriever());
             RegisterValueRetriever(new NullableTimeSpanValueRetriever());
+            RegisterValueRetriever(new NullableDateTimeOffsetValueRetriever());
         }
 
         public IValueRetriever GetValueRetrieverFor(TableRow row, Type type)

--- a/Runtime/Assist/ValueRetrievers/DateTimeOffsetValueRetriever.cs
+++ b/Runtime/Assist/ValueRetrievers/DateTimeOffsetValueRetriever.cs
@@ -1,0 +1,14 @@
+﻿using System;
+
+namespace TechTalk.SpecFlow.Assist.ValueRetrievers
+{
+    internal class DateTimeOffsetValueRetriever
+    {
+        public virtual DateTimeOffset GetValue(string value)
+        {
+            var returnValue = DateTimeOffset.MinValue;
+            DateTimeOffset.TryParse(value, out returnValue);
+            return returnValue;
+        }
+    }
+}

--- a/Runtime/Assist/ValueRetrievers/DateTimeOffsetValueRetriever.cs
+++ b/Runtime/Assist/ValueRetrievers/DateTimeOffsetValueRetriever.cs
@@ -21,6 +21,5 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
         {
             return type == typeof(DateTimeOffset);
         }
-
     }
 }

--- a/Runtime/Assist/ValueRetrievers/DateTimeOffsetValueRetriever.cs
+++ b/Runtime/Assist/ValueRetrievers/DateTimeOffsetValueRetriever.cs
@@ -1,8 +1,9 @@
 ﻿using System;
+using System.Collections.Generic;
 
 namespace TechTalk.SpecFlow.Assist.ValueRetrievers
 {
-    internal class DateTimeOffsetValueRetriever
+    public class DateTimeOffsetValueRetriever : IValueRetriever
     {
         public virtual DateTimeOffset GetValue(string value)
         {
@@ -10,5 +11,16 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
             DateTimeOffset.TryParse(value, out returnValue);
             return returnValue;
         }
+
+        public object Retrieve(KeyValuePair<string, string> keyValuePair, Type targetType)
+        {
+            return GetValue(keyValuePair.Value);
+        }
+
+        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type type)
+        {
+            return type == typeof(DateTimeOffset);
+        }
+
     }
 }

--- a/Runtime/Assist/ValueRetrievers/NullableDateTimeOffsetValueRetriever.cs
+++ b/Runtime/Assist/ValueRetrievers/NullableDateTimeOffsetValueRetriever.cs
@@ -1,0 +1,20 @@
+﻿using System;
+
+namespace TechTalk.SpecFlow.Assist.ValueRetrievers
+{
+    internal class NullableDateTimeOffsetValueRetriever
+    {
+        private readonly Func<string, DateTimeOffset> dateTimeOffsetValueRetriever;
+
+        public NullableDateTimeOffsetValueRetriever(Func<string, DateTimeOffset> dateTimeOffsetValueRetriever)
+        {
+            this.dateTimeOffsetValueRetriever = dateTimeOffsetValueRetriever;
+        }
+
+        public DateTimeOffset? GetValue(string value)
+        {
+            if (string.IsNullOrEmpty(value)) return null;
+            return dateTimeOffsetValueRetriever(value);
+        }
+    }
+}

--- a/Runtime/Assist/ValueRetrievers/NullableDateTimeOffsetValueRetriever.cs
+++ b/Runtime/Assist/ValueRetrievers/NullableDateTimeOffsetValueRetriever.cs
@@ -1,8 +1,9 @@
 ﻿using System;
+using System.Collections.Generic;
 
 namespace TechTalk.SpecFlow.Assist.ValueRetrievers
 {
-    internal class NullableDateTimeOffsetValueRetriever
+    public class NullableDateTimeOffsetValueRetriever : IValueRetriever
     {
         private readonly Func<string, DateTimeOffset> dateTimeOffsetValueRetriever;
 
@@ -15,6 +16,16 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
         {
             if (string.IsNullOrEmpty(value)) return null;
             return dateTimeOffsetValueRetriever(value);
+        }
+
+        public object Retrieve(KeyValuePair<string, string> keyValuePair, Type targetType)
+        {
+            return GetValue(keyValuePair.Value);
+        }
+
+        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type type)
+        {
+            return type == typeof(DateTimeOffset);
         }
     }
 }

--- a/Runtime/Assist/ValueRetrievers/NullableDateTimeOffsetValueRetriever.cs
+++ b/Runtime/Assist/ValueRetrievers/NullableDateTimeOffsetValueRetriever.cs
@@ -5,11 +5,12 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
 {
     public class NullableDateTimeOffsetValueRetriever : IValueRetriever
     {
-        private readonly Func<string, DateTimeOffset> dateTimeOffsetValueRetriever;
+        private readonly Func<string, DateTimeOffset> dateTimeOffsetValueRetriever = v => new DateTimeOffsetValueRetriever().GetValue(v);
 
-        public NullableDateTimeOffsetValueRetriever(Func<string, DateTimeOffset> dateTimeOffsetValueRetriever)
+        public NullableDateTimeOffsetValueRetriever(Func<string, DateTimeOffset> dateTimeOffsetValueRetriever = null)
         {
-            this.dateTimeOffsetValueRetriever = dateTimeOffsetValueRetriever;
+            if (dateTimeOffsetValueRetriever != null)
+                this.dateTimeOffsetValueRetriever = dateTimeOffsetValueRetriever;
         }
 
         public DateTimeOffset? GetValue(string value)

--- a/Runtime/TechTalk.SpecFlow.csproj
+++ b/Runtime/TechTalk.SpecFlow.csproj
@@ -79,8 +79,10 @@
     <Compile Include="Assist\ValueRetrievers\BoolValueRetriever.cs" />
     <Compile Include="Assist\ValueRetrievers\ByteValueRetriever.cs" />
     <Compile Include="Assist\ValueRetrievers\CharValueRetriever.cs" />
+    <Compile Include="Assist\ValueRetrievers\DateTimeOffsetValueRetriever.cs" />
     <Compile Include="Assist\ValueRetrievers\LongValueRetriever.cs" />
     <Compile Include="Assist\ValueRetrievers\NullableByteValueRetriever.cs" />
+    <Compile Include="Assist\ValueRetrievers\NullableDateTimeOffsetValueRetriever.cs" />
     <Compile Include="Assist\ValueRetrievers\NullableLongValueRetriever.cs" />
     <Compile Include="Assist\ValueRetrievers\NullableSByteValueRetriever.cs" />
     <Compile Include="Assist\ValueRetrievers\NullableFloatValueRetriever.cs" />

--- a/Tests/RuntimeTests/AssistTests/ServiceTests.cs
+++ b/Tests/RuntimeTests/AssistTests/ServiceTests.cs
@@ -34,7 +34,7 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests
             var service = new Service();
 
             var results = service.ValueRetrievers;
-            Assert.AreEqual(34, results.Count());
+            Assert.AreEqual(36, results.Count());
 
             Assert.AreEqual(1, results.Where(x => x.GetType() == typeof(StringValueRetriever)).Count());
             Assert.AreEqual(1, results.Where(x => x.GetType() == typeof(ByteValueRetriever)).Count());
@@ -54,6 +54,7 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests
             Assert.AreEqual(1, results.Where(x => x.GetType() == typeof(GuidValueRetriever)).Count());
             Assert.AreEqual(1, results.Where(x => x.GetType() == typeof(EnumValueRetriever)).Count());
             Assert.AreEqual(1, results.Where(x => x.GetType() == typeof(TimeSpanValueRetriever)).Count());
+            Assert.AreEqual(1, results.Where(x => x.GetType() == typeof(DateTimeOffsetValueRetriever)).Count());
             Assert.AreEqual(1, results.Where(x => x.GetType() == typeof(NullableGuidValueRetriever)).Count());
             Assert.AreEqual(1, results.Where(x => x.GetType() == typeof(NullableDateTimeValueRetriever)).Count());
             Assert.AreEqual(1, results.Where(x => x.GetType() == typeof(NullableBoolValueRetriever)).Count());
@@ -70,6 +71,7 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests
             Assert.AreEqual(1, results.Where(x => x.GetType() == typeof(NullableUShortValueRetriever)).Count());
             Assert.AreEqual(1, results.Where(x => x.GetType() == typeof(NullableLongValueRetriever)).Count());
             Assert.AreEqual(1, results.Where(x => x.GetType() == typeof(NullableTimeSpanValueRetriever)).Count());
+            Assert.AreEqual(1, results.Where(x => x.GetType() == typeof(NullableDateTimeOffsetValueRetriever)).Count());
         }
 
         [Test]

--- a/Tests/RuntimeTests/AssistTests/ValueRetrieverTests/DateTimeOffsetValueRetrieverTests.cs
+++ b/Tests/RuntimeTests/AssistTests/ValueRetrieverTests/DateTimeOffsetValueRetrieverTests.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using NUnit.Framework;
+using Should;
+using TechTalk.SpecFlow.Assist.ValueRetrievers;
+
+namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.ValueRetrieverTests
+{
+    [TestFixture, SetCulture("en-US")]
+    public class DateTimeOffsetValueRetrieverTests
+    {
+        [Test]
+        public void Returns_MinValue_when_the_value_is_null()
+        {
+            var retriever = new DateTimeOffsetValueRetriever();
+            retriever.GetValue(null).ShouldEqual(DateTimeOffset.MinValue);
+        }
+
+        [Test]
+        public void Returns_MinValue_when_the_value_is_empty()
+        {
+            var retriever = new DateTimeOffsetValueRetriever();
+            retriever.GetValue(string.Empty).ShouldEqual(DateTimeOffset.MinValue);
+        }
+
+        [Test]
+        public void Returns_the_date_when_value_represents_a_valid_date()
+        {
+            var retriever = new DateTimeOffsetValueRetriever();
+            var date1 = new DateTime(2011, 1, 1);
+            retriever.GetValue("2011-01-01").ShouldEqual(new DateTimeOffset(2011, 1, 1, 0, 0, 0, TimeZone.CurrentTimeZone.GetUtcOffset(date1)));
+            var date2 = new DateTime(2013, 12, 5);
+            retriever.GetValue("2013-12-05").ShouldEqual(new DateTimeOffset(2013, 12, 5, 0, 0, 0, TimeZone.CurrentTimeZone.GetUtcOffset(date2)));
+        }
+
+        [Test]
+        public void Returns_the_date_and_time_when_value_represents_a_valid_datetime()
+        {
+            var retriever = new DateTimeOffsetValueRetriever();
+            var date1 = new DateTime(2011, 1, 1);
+            retriever.GetValue("2011-01-01 15:16:17").ShouldEqual(new DateTimeOffset(2011, 1, 1, 15, 16, 17, TimeZone.CurrentTimeZone.GetUtcOffset(date1)));
+            var date2 = new DateTime(2011, 1, 1);
+            retriever.GetValue("2011-01-01 5:6:7").ShouldEqual(new DateTimeOffset(2011, 1, 1, 5, 6, 7, TimeZone.CurrentTimeZone.GetUtcOffset(date2)));
+        }
+
+        [Test]
+        public void Returns_MinValue_when_the_value_is_not_a_valid_datetime()
+        {
+            var retriever = new DateTimeOffsetValueRetriever();
+            retriever.GetValue("xxxx").ShouldEqual(DateTimeOffset.MinValue);
+            retriever.GetValue("this is not a date").ShouldEqual(DateTimeOffset.MinValue);
+            retriever.GetValue("Thursday").ShouldEqual(DateTimeOffset.MinValue);
+        }
+    }
+}

--- a/Tests/RuntimeTests/AssistTests/ValueRetrieverTests/DateTimeOffsetValueRetrieverTests.cs
+++ b/Tests/RuntimeTests/AssistTests/ValueRetrieverTests/DateTimeOffsetValueRetrieverTests.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using NUnit.Framework;
-using Should;
+using FluentAssertions;
 using TechTalk.SpecFlow.Assist.ValueRetrievers;
 
 namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.ValueRetrieverTests
@@ -12,14 +12,14 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.ValueRetrieverTests
         public void Returns_MinValue_when_the_value_is_null()
         {
             var retriever = new DateTimeOffsetValueRetriever();
-            retriever.GetValue(null).ShouldEqual(DateTimeOffset.MinValue);
+            retriever.GetValue(null).Should().Be(DateTimeOffset.MinValue);
         }
 
         [Test]
         public void Returns_MinValue_when_the_value_is_empty()
         {
             var retriever = new DateTimeOffsetValueRetriever();
-            retriever.GetValue(string.Empty).ShouldEqual(DateTimeOffset.MinValue);
+            retriever.GetValue(string.Empty).Should().Be(DateTimeOffset.MinValue);
         }
 
         [Test]
@@ -27,9 +27,9 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.ValueRetrieverTests
         {
             var retriever = new DateTimeOffsetValueRetriever();
             var date1 = new DateTime(2011, 1, 1);
-            retriever.GetValue("2011-01-01").ShouldEqual(new DateTimeOffset(2011, 1, 1, 0, 0, 0, TimeZone.CurrentTimeZone.GetUtcOffset(date1)));
+            retriever.GetValue("2011-01-01").Should().Be(new DateTimeOffset(2011, 1, 1, 0, 0, 0, TimeZone.CurrentTimeZone.GetUtcOffset(date1)));
             var date2 = new DateTime(2013, 12, 5);
-            retriever.GetValue("2013-12-05").ShouldEqual(new DateTimeOffset(2013, 12, 5, 0, 0, 0, TimeZone.CurrentTimeZone.GetUtcOffset(date2)));
+            retriever.GetValue("2013-12-05").Should().Be(new DateTimeOffset(2013, 12, 5, 0, 0, 0, TimeZone.CurrentTimeZone.GetUtcOffset(date2)));
         }
 
         [Test]
@@ -37,18 +37,18 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.ValueRetrieverTests
         {
             var retriever = new DateTimeOffsetValueRetriever();
             var date1 = new DateTime(2011, 1, 1);
-            retriever.GetValue("2011-01-01 15:16:17").ShouldEqual(new DateTimeOffset(2011, 1, 1, 15, 16, 17, TimeZone.CurrentTimeZone.GetUtcOffset(date1)));
+            retriever.GetValue("2011-01-01 15:16:17").Should().Be(new DateTimeOffset(2011, 1, 1, 15, 16, 17, TimeZone.CurrentTimeZone.GetUtcOffset(date1)));
             var date2 = new DateTime(2011, 1, 1);
-            retriever.GetValue("2011-01-01 5:6:7").ShouldEqual(new DateTimeOffset(2011, 1, 1, 5, 6, 7, TimeZone.CurrentTimeZone.GetUtcOffset(date2)));
+            retriever.GetValue("2011-01-01 5:6:7").Should().Be(new DateTimeOffset(2011, 1, 1, 5, 6, 7, TimeZone.CurrentTimeZone.GetUtcOffset(date2)));
         }
 
         [Test]
         public void Returns_MinValue_when_the_value_is_not_a_valid_datetime()
         {
             var retriever = new DateTimeOffsetValueRetriever();
-            retriever.GetValue("xxxx").ShouldEqual(DateTimeOffset.MinValue);
-            retriever.GetValue("this is not a date").ShouldEqual(DateTimeOffset.MinValue);
-            retriever.GetValue("Thursday").ShouldEqual(DateTimeOffset.MinValue);
+            retriever.GetValue("xxxx").Should().Be(DateTimeOffset.MinValue);
+            retriever.GetValue("this is not a date").Should().Be(DateTimeOffset.MinValue);
+            retriever.GetValue("Thursday").Should().Be(DateTimeOffset.MinValue);
         }
     }
 }

--- a/Tests/RuntimeTests/AssistTests/ValueRetrieverTests/DateTimeOffsetValueRetrieverTests.cs
+++ b/Tests/RuntimeTests/AssistTests/ValueRetrieverTests/DateTimeOffsetValueRetrieverTests.cs
@@ -49,6 +49,7 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.ValueRetrieverTests
             retriever.GetValue("xxxx").Should().Be(DateTimeOffset.MinValue);
             retriever.GetValue("this is not a date").Should().Be(DateTimeOffset.MinValue);
             retriever.GetValue("Thursday").Should().Be(DateTimeOffset.MinValue);
+            retriever.GetValue("Friday too").Should().Be(DateTimeOffset.MinValue);
         }
     }
 }

--- a/Tests/RuntimeTests/AssistTests/ValueRetrieverTests/NullableDateTimeOffsetValueRetriever.cs
+++ b/Tests/RuntimeTests/AssistTests/ValueRetrieverTests/NullableDateTimeOffsetValueRetriever.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using NUnit.Framework;
+using Should;
+using TechTalk.SpecFlow.Assist.ValueRetrievers;
+
+namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.ValueRetrieverTests
+{
+    [TestFixture, SetCulture("en-US")]
+    public class NullableDateTimeOffsetValueRetrieverTests
+    {
+        [Test]
+        public void Returns_the_value_from_the_DateTimeOffsetValueRetriever()
+        {
+            Func<string, DateTimeOffset> func = v =>
+            {
+                if (v == "one") return new DateTimeOffset(2011, 1, 2, 2, 0, 0, TimeSpan.Zero);
+                if (v == "two") return new DateTimeOffset(2015, 12, 31, 2, 0, 0, TimeSpan.Zero);
+                return DateTimeOffset.MinValue;
+            };
+
+            var retriever = new NullableDateTimeOffsetValueRetriever(func);
+            retriever.GetValue("one").ShouldEqual(new DateTimeOffset(2011, 1, 2, 2, 0, 0, TimeSpan.Zero));
+            retriever.GetValue("two").ShouldEqual(new DateTimeOffset(2015, 12, 31, 2, 0, 0, TimeSpan.Zero));
+        }
+
+        [Test]
+        public void Returns_null_when_value_is_null()
+        {
+            var retriever = new NullableDateTimeOffsetValueRetriever(v => DateTimeOffset.Parse("1/1/2016"));
+            retriever.GetValue(null).ShouldBeNull();
+        }
+
+        [Test]
+        public void Returns_null_when_string_is_empty()
+        {
+            var retriever = new NullableDateTimeOffsetValueRetriever(v => DateTimeOffset.Parse("1/1/2017"));
+            retriever.GetValue(string.Empty).ShouldBeNull();
+        }
+    }
+}

--- a/Tests/RuntimeTests/AssistTests/ValueRetrieverTests/NullableDateTimeOffsetValueRetriever.cs
+++ b/Tests/RuntimeTests/AssistTests/ValueRetrieverTests/NullableDateTimeOffsetValueRetriever.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using NUnit.Framework;
-using Should;
+using FluentAssertions;
 using TechTalk.SpecFlow.Assist.ValueRetrievers;
 
 namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.ValueRetrieverTests
@@ -19,22 +19,22 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.ValueRetrieverTests
             };
 
             var retriever = new NullableDateTimeOffsetValueRetriever(func);
-            retriever.GetValue("one").ShouldEqual(new DateTimeOffset(2011, 1, 2, 2, 0, 0, TimeSpan.Zero));
-            retriever.GetValue("two").ShouldEqual(new DateTimeOffset(2015, 12, 31, 2, 0, 0, TimeSpan.Zero));
+            retriever.GetValue("one").Should().Be(new DateTimeOffset(2011, 1, 2, 2, 0, 0, TimeSpan.Zero));
+            retriever.GetValue("two").Should().Be(new DateTimeOffset(2015, 12, 31, 2, 0, 0, TimeSpan.Zero));
         }
 
         [Test]
         public void Returns_null_when_value_is_null()
         {
             var retriever = new NullableDateTimeOffsetValueRetriever(v => DateTimeOffset.Parse("1/1/2016"));
-            retriever.GetValue(null).ShouldBeNull();
+            retriever.GetValue(null).Should().NotHaveValue();
         }
 
         [Test]
         public void Returns_null_when_string_is_empty()
         {
             var retriever = new NullableDateTimeOffsetValueRetriever(v => DateTimeOffset.Parse("1/1/2017"));
-            retriever.GetValue(string.Empty).ShouldBeNull();
+            retriever.GetValue(string.Empty).Should().NotHaveValue();
         }
     }
 }

--- a/Tests/RuntimeTests/RuntimeTests.csproj
+++ b/Tests/RuntimeTests/RuntimeTests.csproj
@@ -110,9 +110,11 @@
     <Compile Include="AssistTests\ValueRetrieverTests\BoolValueRetrieverTests.cs" />
     <Compile Include="AssistTests\ValueRetrieverTests\ByteValueRetrieverTests.cs" />
     <Compile Include="AssistTests\ValueRetrieverTests\CharValueRetrieverTests.cs" />
+    <Compile Include="AssistTests\ValueRetrieverTests\DateTimeOffsetValueRetrieverTests.cs" />
     <Compile Include="AssistTests\ValueRetrieverTests\GuidValueRetriever_IsAValidGuidTests.cs" />
     <Compile Include="AssistTests\ValueRetrieverTests\LongValueRetrieverTests.cs" />
     <Compile Include="AssistTests\ValueRetrieverTests\NullableByteValueRetrieverTests.cs" />
+    <Compile Include="AssistTests\ValueRetrieverTests\NullableDateTimeOffsetValueRetriever.cs" />
     <Compile Include="AssistTests\ValueRetrieverTests\NullableFloatValueRetrieverTests.cs" />
     <Compile Include="AssistTests\ValueRetrieverTests\FloatValueRetrieverTests.cs" />
     <Compile Include="AssistTests\ValueRetrieverTests\NullableLongValueRetrieverTests.cs" />


### PR DESCRIPTION
We had datetime offset retrievers for SpecFlow.Assist in the pre-v2 master, thanks to Tim Gebhardt.  I must have screwed up something, somehow, because the two classes were lost in the v2 changes.

So I cherry-picked them back, made them implement the new ```IValueRetriever```, and we should be back to normal!