### PR TITLE
More consistent value retriever signature

### DIFF
--- a/Runtime/Assist/IValueRetriever.cs
+++ b/Runtime/Assist/IValueRetriever.cs
@@ -21,7 +21,7 @@ namespace TechTalk.SpecFlow.Assist
         /// </summary>
         /// <param name="keyValuePair">Key value pair.</param>
         /// <param name="targetType">The type of the ojbect that is being built from the table.</param>
-        /// <param name="propertyType"></param>
+        /// <param name="propertyType">The type of the property or member that is being set.</param>
         object Retrieve(KeyValuePair<string, string> keyValuePair, Type targetType, Type propertyType);
     }
 }

--- a/Runtime/Assist/IValueRetriever.cs
+++ b/Runtime/Assist/IValueRetriever.cs
@@ -21,6 +21,7 @@ namespace TechTalk.SpecFlow.Assist
         /// </summary>
         /// <param name="keyValuePair">Key value pair.</param>
         /// <param name="targetType">The type of the ojbect that is being built from the table.</param>
-        object Retrieve(KeyValuePair<string, string> keyValuePair, Type targetType);
+        /// <param name="propertyType"></param>
+        object Retrieve(KeyValuePair<string, string> keyValuePair, Type targetType, Type propertyType);
     }
 }

--- a/Runtime/Assist/IValueRetriever.cs
+++ b/Runtime/Assist/IValueRetriever.cs
@@ -13,7 +13,7 @@ namespace TechTalk.SpecFlow.Assist
         /// </summary>
         /// <returns><c>true</c> if this instance can retrieve the specified key->value; otherwise, <c>false</c>.</returns>
         /// <param name="keyValuePair">Key value pair.</param>
-        /// <param name="targetType"></param>
+        /// <param name="targetType">The type of the object that is being built from the table.</param>
         /// <param name="propertyType">The type of the property or member that is being set.</param>
         bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type targetType, Type propertyType);
 
@@ -21,7 +21,7 @@ namespace TechTalk.SpecFlow.Assist
         /// Retrieve the value from a key-> value set, as the expected type on targetType.
         /// </summary>
         /// <param name="keyValuePair">Key value pair.</param>
-        /// <param name="targetType">The type of the ojbect that is being built from the table.</param>
+        /// <param name="targetType">The type of the object that is being built from the table.</param>
         /// <param name="propertyType">The type of the property or member that is being set.</param>
         object Retrieve(KeyValuePair<string, string> keyValuePair, Type targetType, Type propertyType);
     }

--- a/Runtime/Assist/IValueRetriever.cs
+++ b/Runtime/Assist/IValueRetriever.cs
@@ -13,8 +13,9 @@ namespace TechTalk.SpecFlow.Assist
         /// </summary>
         /// <returns><c>true</c> if this instance can retrieve the specified key->value; otherwise, <c>false</c>.</returns>
         /// <param name="keyValuePair">Key value pair.</param>
+        /// <param name="targetType"></param>
         /// <param name="propertyType">The type of the property or member that is being set.</param>
-        bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type propertyType);
+        bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type targetType, Type propertyType);
 
         /// <summary>
         /// Retrieve the value from a key-> value set, as the expected type on targetType.

--- a/Runtime/Assist/IValueRetriever.cs
+++ b/Runtime/Assist/IValueRetriever.cs
@@ -13,8 +13,8 @@ namespace TechTalk.SpecFlow.Assist
         /// </summary>
         /// <returns><c>true</c> if this instance can retrieve the specified key->value; otherwise, <c>false</c>.</returns>
         /// <param name="keyValuePair">Key value pair.</param>
-        /// <param name="type">The type of the object that is being built from the table.</param>
-        bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type type);
+        /// <param name="propertyType">The type of the property or member that is being set.</param>
+        bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type propertyType);
 
         /// <summary>
         /// Retrieve the value from a key-> value set, as the expected type on targetType.

--- a/Runtime/Assist/Service.cs
+++ b/Runtime/Assist/Service.cs
@@ -112,7 +112,7 @@ namespace TechTalk.SpecFlow.Assist
         public IValueRetriever GetValueRetrieverFor(TableRow row, Type targetType, Type propertyType)
         {
             foreach(var valueRetriever in ValueRetrievers){
-                if (valueRetriever.CanRetrieve(new KeyValuePair<string, string>(row[0], row[1]), propertyType))
+                if (valueRetriever.CanRetrieve(new KeyValuePair<string, string>(row[0], row[1]), targetType, propertyType))
                     return valueRetriever;
             }
             return null;

--- a/Runtime/Assist/Service.cs
+++ b/Runtime/Assist/Service.cs
@@ -109,10 +109,10 @@ namespace TechTalk.SpecFlow.Assist
             RegisterValueRetriever(new StepTransformationValueRetriever());
         }
 
-        public IValueRetriever GetValueRetrieverFor(TableRow row, Type type)
+        public IValueRetriever GetValueRetrieverFor(TableRow row, Type targetType, Type propertyType)
         {
             foreach(var valueRetriever in ValueRetrievers){
-                if (valueRetriever.CanRetrieve(new KeyValuePair<string, string>(row[0], row[1]), type))
+                if (valueRetriever.CanRetrieve(new KeyValuePair<string, string>(row[0], row[1]), propertyType))
                     return valueRetriever;
             }
             return null;

--- a/Runtime/Assist/TEHelpers.cs
+++ b/Runtime/Assist/TEHelpers.cs
@@ -129,7 +129,7 @@ namespace TechTalk.SpecFlow.Assist
             public object GetValue()
             {
                 var valueRetriever = Service.Instance.GetValueRetrieverFor(Row, Type, PropertyType);
-                return valueRetriever.Retrieve(new KeyValuePair<string, string>(Row[0], Row[1]), Type);
+                return valueRetriever.Retrieve(new KeyValuePair<string, string>(Row[0], Row[1]), Type, PropertyType);
             }
         }
 

--- a/Runtime/Assist/TEHelpers.cs
+++ b/Runtime/Assist/TEHelpers.cs
@@ -95,13 +95,13 @@ namespace TechTalk.SpecFlow.Assist
         {
             var properties = from property in type.GetProperties()
                              from row in table.Rows
-                             where TheseTypesMatch(property.PropertyType, row)
+                             where TheseTypesMatch(type, property.PropertyType, row)
                                    && IsMemberMatchingToColumnName(property, row.Id())
                 select new MemberHandler { Type = type, Row = row, MemberName = property.Name, PropertyType = property.PropertyType, Setter = (i, v) => property.SetValue(i, v, null) };
 
             var fields = from field in type.GetFields()
                              from row in table.Rows
-                             where TheseTypesMatch(field.FieldType, row)
+                             where TheseTypesMatch(type, field.FieldType, row)
                                    && IsMemberMatchingToColumnName(field, row.Id())
                 select new MemberHandler { Type = type, Row = row, MemberName = field.Name, PropertyType = field.FieldType, Setter = (i, v) => field.SetValue(i, v) };
 
@@ -113,9 +113,9 @@ namespace TechTalk.SpecFlow.Assist
             return memberHandlers;
         }
 
-        private static bool TheseTypesMatch(Type memberType, TableRow row)
+        private static bool TheseTypesMatch(Type targetType, Type memberType, TableRow row)
         {
-            return Assist.Service.Instance.GetValueRetrieverFor(row, memberType) != null;
+            return Service.Instance.GetValueRetrieverFor(row, targetType, memberType) != null;
         }
 
         internal class MemberHandler
@@ -128,7 +128,7 @@ namespace TechTalk.SpecFlow.Assist
 
             public object GetValue()
             {
-                var valueRetriever = Service.Instance.GetValueRetrieverFor(Row, PropertyType);
+                var valueRetriever = Service.Instance.GetValueRetrieverFor(Row, Type, PropertyType);
                 return valueRetriever.Retrieve(new KeyValuePair<string, string>(Row[0], Row[1]), Type);
             }
         }

--- a/Runtime/Assist/ValueRetrievers/BoolValueRetriever.cs
+++ b/Runtime/Assist/ValueRetrievers/BoolValueRetriever.cs
@@ -15,7 +15,7 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
             return GetValue(keyValuePair.Value);
         }
 
-        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type propertyType)
+        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type targetType, Type propertyType)
         {
             return propertyType == typeof(bool);
         }

--- a/Runtime/Assist/ValueRetrievers/BoolValueRetriever.cs
+++ b/Runtime/Assist/ValueRetrievers/BoolValueRetriever.cs
@@ -15,9 +15,9 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
             return GetValue(keyValuePair.Value);
         }
 
-        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type type)
+        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type propertyType)
         {
-            return type == typeof(bool);
+            return propertyType == typeof(bool);
         }
     }
 }

--- a/Runtime/Assist/ValueRetrievers/BoolValueRetriever.cs
+++ b/Runtime/Assist/ValueRetrievers/BoolValueRetriever.cs
@@ -10,7 +10,7 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
             return value == "True" || value == "true";
         }
 
-        public object Retrieve(KeyValuePair<string, string> keyValuePair, Type targetType)
+        public object Retrieve(KeyValuePair<string, string> keyValuePair, Type targetType, Type propertyType)
         {
             return GetValue(keyValuePair.Value);
         }

--- a/Runtime/Assist/ValueRetrievers/ByteValueRetriever.cs
+++ b/Runtime/Assist/ValueRetrievers/ByteValueRetriever.cs
@@ -17,7 +17,7 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
             return GetValue(keyValuePair.Value);
         }
 
-        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type propertyType)
+        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type targetType, Type propertyType)
         {
             return propertyType == typeof(byte);
         }

--- a/Runtime/Assist/ValueRetrievers/ByteValueRetriever.cs
+++ b/Runtime/Assist/ValueRetrievers/ByteValueRetriever.cs
@@ -12,7 +12,7 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
             return returnValue;
         }
 
-        public object Retrieve(KeyValuePair<string, string> keyValuePair, Type targetType)
+        public object Retrieve(KeyValuePair<string, string> keyValuePair, Type targetType, Type propertyType)
         {
             return GetValue(keyValuePair.Value);
         }

--- a/Runtime/Assist/ValueRetrievers/ByteValueRetriever.cs
+++ b/Runtime/Assist/ValueRetrievers/ByteValueRetriever.cs
@@ -17,9 +17,9 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
             return GetValue(keyValuePair.Value);
         }
 
-        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type type)
+        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type propertyType)
         {
-            return type == typeof(byte);
+            return propertyType == typeof(byte);
         }
     }
 }

--- a/Runtime/Assist/ValueRetrievers/CharValueRetriever.cs
+++ b/Runtime/Assist/ValueRetrievers/CharValueRetriever.cs
@@ -12,7 +12,7 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
                        : value[0];
         }
             
-        public object Retrieve(KeyValuePair<string, string> keyValuePair, Type targetType)
+        public object Retrieve(KeyValuePair<string, string> keyValuePair, Type targetType, Type propertyType)
         {
             return GetValue(keyValuePair.Value);
         }

--- a/Runtime/Assist/ValueRetrievers/CharValueRetriever.cs
+++ b/Runtime/Assist/ValueRetrievers/CharValueRetriever.cs
@@ -17,9 +17,9 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
             return GetValue(keyValuePair.Value);
         }
 
-        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type type)
+        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type propertyType)
         {
-            return type == typeof(char);
+            return propertyType == typeof(char);
         }
 
         private bool ThisStringIsNotASingleCharacter(string value)

--- a/Runtime/Assist/ValueRetrievers/CharValueRetriever.cs
+++ b/Runtime/Assist/ValueRetrievers/CharValueRetriever.cs
@@ -17,7 +17,7 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
             return GetValue(keyValuePair.Value);
         }
 
-        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type propertyType)
+        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type targetType, Type propertyType)
         {
             return propertyType == typeof(char);
         }

--- a/Runtime/Assist/ValueRetrievers/DateTimeOffsetValueRetriever.cs
+++ b/Runtime/Assist/ValueRetrievers/DateTimeOffsetValueRetriever.cs
@@ -12,7 +12,7 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
             return returnValue;
         }
 
-        public object Retrieve(KeyValuePair<string, string> keyValuePair, Type targetType)
+        public object Retrieve(KeyValuePair<string, string> keyValuePair, Type targetType, Type propertyType)
         {
             return GetValue(keyValuePair.Value);
         }

--- a/Runtime/Assist/ValueRetrievers/DateTimeOffsetValueRetriever.cs
+++ b/Runtime/Assist/ValueRetrievers/DateTimeOffsetValueRetriever.cs
@@ -17,7 +17,7 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
             return GetValue(keyValuePair.Value);
         }
 
-        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type propertyType)
+        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type targetType, Type propertyType)
         {
             return propertyType == typeof(DateTimeOffset);
         }

--- a/Runtime/Assist/ValueRetrievers/DateTimeOffsetValueRetriever.cs
+++ b/Runtime/Assist/ValueRetrievers/DateTimeOffsetValueRetriever.cs
@@ -17,9 +17,9 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
             return GetValue(keyValuePair.Value);
         }
 
-        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type type)
+        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type propertyType)
         {
-            return type == typeof(DateTimeOffset);
+            return propertyType == typeof(DateTimeOffset);
         }
     }
 }

--- a/Runtime/Assist/ValueRetrievers/DateTimeValueRetriever.cs
+++ b/Runtime/Assist/ValueRetrievers/DateTimeValueRetriever.cs
@@ -17,9 +17,9 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
             return GetValue(keyValuePair.Value);
         }
 
-        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type type)
+        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type propertyType)
         {
-            if (type != typeof (DateTime)) return false;
+            if (propertyType != typeof (DateTime)) return false;
 
             DateTime ignore;
             return DateTime.TryParse(keyValuePair.Value, out ignore);

--- a/Runtime/Assist/ValueRetrievers/DateTimeValueRetriever.cs
+++ b/Runtime/Assist/ValueRetrievers/DateTimeValueRetriever.cs
@@ -12,7 +12,7 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
             return returnValue;
         }
 
-        public object Retrieve(KeyValuePair<string, string> keyValuePair, Type targetType)
+        public object Retrieve(KeyValuePair<string, string> keyValuePair, Type targetType, Type propertyType)
         {
             return GetValue(keyValuePair.Value);
         }

--- a/Runtime/Assist/ValueRetrievers/DateTimeValueRetriever.cs
+++ b/Runtime/Assist/ValueRetrievers/DateTimeValueRetriever.cs
@@ -17,7 +17,7 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
             return GetValue(keyValuePair.Value);
         }
 
-        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type propertyType)
+        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type targetType, Type propertyType)
         {
             if (propertyType != typeof (DateTime)) return false;
 

--- a/Runtime/Assist/ValueRetrievers/DecimalValueRetriever.cs
+++ b/Runtime/Assist/ValueRetrievers/DecimalValueRetriever.cs
@@ -12,7 +12,7 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
             return returnValue;
         }
 
-        public object Retrieve(KeyValuePair<string, string> keyValuePair, Type targetType)
+        public object Retrieve(KeyValuePair<string, string> keyValuePair, Type targetType, Type propertyType)
         {
             return GetValue(keyValuePair.Value);
         }

--- a/Runtime/Assist/ValueRetrievers/DecimalValueRetriever.cs
+++ b/Runtime/Assist/ValueRetrievers/DecimalValueRetriever.cs
@@ -17,7 +17,7 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
             return GetValue(keyValuePair.Value);
         }
 
-        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type propertyType)
+        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type targetType, Type propertyType)
         {
             return propertyType == typeof(decimal);
         }

--- a/Runtime/Assist/ValueRetrievers/DecimalValueRetriever.cs
+++ b/Runtime/Assist/ValueRetrievers/DecimalValueRetriever.cs
@@ -17,9 +17,9 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
             return GetValue(keyValuePair.Value);
         }
 
-        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type type)
+        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type propertyType)
         {
-            return type == typeof(decimal);
+            return propertyType == typeof(decimal);
         }
     }
 }

--- a/Runtime/Assist/ValueRetrievers/DoubleValueRetriever.cs
+++ b/Runtime/Assist/ValueRetrievers/DoubleValueRetriever.cs
@@ -17,7 +17,7 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
             return GetValue(keyValuePair.Value);
         }
 
-        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type propertyType)
+        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type targetType, Type propertyType)
         {
             return propertyType == typeof(double);
         }

--- a/Runtime/Assist/ValueRetrievers/DoubleValueRetriever.cs
+++ b/Runtime/Assist/ValueRetrievers/DoubleValueRetriever.cs
@@ -12,7 +12,7 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
             return returnValue;
         }
 
-        public object Retrieve(KeyValuePair<string, string> keyValuePair, Type targetType)
+        public object Retrieve(KeyValuePair<string, string> keyValuePair, Type targetType, Type propertyType)
         {
             return GetValue(keyValuePair.Value);
         }

--- a/Runtime/Assist/ValueRetrievers/DoubleValueRetriever.cs
+++ b/Runtime/Assist/ValueRetrievers/DoubleValueRetriever.cs
@@ -17,9 +17,9 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
             return GetValue(keyValuePair.Value);
         }
 
-        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type type)
+        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type propertyType)
         {
-            return type == typeof(double);
+            return propertyType == typeof(double);
         }
     }
 }

--- a/Runtime/Assist/ValueRetrievers/EnumValueRetriever.cs
+++ b/Runtime/Assist/ValueRetrievers/EnumValueRetriever.cs
@@ -13,9 +13,8 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
             return ConvertTheStringToAnEnum(value, enumType);
         }
 
-        public object Retrieve(KeyValuePair<string, string> keyValuePair, Type targetType, Type propertyType1)
+        public object Retrieve(KeyValuePair<string, string> keyValuePair, Type targetType, Type propertyType)
         {
-            var propertyType = targetType.GetProperties().First(x => x.Name.MatchesThisColumnName(keyValuePair.Key)).PropertyType;
             return GetValue(keyValuePair.Value, propertyType);
         }
 

--- a/Runtime/Assist/ValueRetrievers/EnumValueRetriever.cs
+++ b/Runtime/Assist/ValueRetrievers/EnumValueRetriever.cs
@@ -18,7 +18,7 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
             return GetValue(keyValuePair.Value, propertyType);
         }
 
-        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type propertyType)
+        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type targetType, Type propertyType)
         {
             if (propertyType.IsGenericType && propertyType.GetGenericTypeDefinition() == typeof(Nullable<>))
                 return typeof(Enum).IsAssignableFrom(propertyType.GetGenericArguments()[0]);

--- a/Runtime/Assist/ValueRetrievers/EnumValueRetriever.cs
+++ b/Runtime/Assist/ValueRetrievers/EnumValueRetriever.cs
@@ -18,11 +18,11 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
             return GetValue(keyValuePair.Value, propertyType);
         }
 
-        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type type)
+        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type propertyType)
         {
-            if (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(Nullable<>))
-                return typeof(Enum).IsAssignableFrom(type.GetGenericArguments()[0]);
-            return type.IsEnum;
+            if (propertyType.IsGenericType && propertyType.GetGenericTypeDefinition() == typeof(Nullable<>))
+                return typeof(Enum).IsAssignableFrom(propertyType.GetGenericArguments()[0]);
+            return propertyType.IsEnum;
         }
 
         private object ConvertTheStringToAnEnum(string value, Type enumType)

--- a/Runtime/Assist/ValueRetrievers/EnumValueRetriever.cs
+++ b/Runtime/Assist/ValueRetrievers/EnumValueRetriever.cs
@@ -13,7 +13,7 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
             return ConvertTheStringToAnEnum(value, enumType);
         }
 
-        public object Retrieve(KeyValuePair<string, string> keyValuePair, Type targetType)
+        public object Retrieve(KeyValuePair<string, string> keyValuePair, Type targetType, Type propertyType1)
         {
             var propertyType = targetType.GetProperties().First(x => x.Name.MatchesThisColumnName(keyValuePair.Key)).PropertyType;
             return GetValue(keyValuePair.Value, propertyType);

--- a/Runtime/Assist/ValueRetrievers/FloatValueRetriever.cs
+++ b/Runtime/Assist/ValueRetrievers/FloatValueRetriever.cs
@@ -12,7 +12,7 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
             return returnValue;
         }
 
-        public object Retrieve(KeyValuePair<string, string> keyValuePair, Type targetType)
+        public object Retrieve(KeyValuePair<string, string> keyValuePair, Type targetType, Type propertyType)
         {
             return GetValue(keyValuePair.Value);
         }

--- a/Runtime/Assist/ValueRetrievers/FloatValueRetriever.cs
+++ b/Runtime/Assist/ValueRetrievers/FloatValueRetriever.cs
@@ -17,9 +17,9 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
             return GetValue(keyValuePair.Value);
         }
 
-        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type type)
+        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type propertyType)
         {
-            return type == typeof(float);
+            return propertyType == typeof(float);
         }
     }
 }

--- a/Runtime/Assist/ValueRetrievers/FloatValueRetriever.cs
+++ b/Runtime/Assist/ValueRetrievers/FloatValueRetriever.cs
@@ -17,7 +17,7 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
             return GetValue(keyValuePair.Value);
         }
 
-        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type propertyType)
+        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type targetType, Type propertyType)
         {
             return propertyType == typeof(float);
         }

--- a/Runtime/Assist/ValueRetrievers/GuidValueRetriever.cs
+++ b/Runtime/Assist/ValueRetrievers/GuidValueRetriever.cs
@@ -31,7 +31,7 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
             return GetValue(keyValuePair.Value);
         }
 
-        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type propertyType)
+        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type targetType, Type propertyType)
         {
             return propertyType == typeof(Guid);
         }

--- a/Runtime/Assist/ValueRetrievers/GuidValueRetriever.cs
+++ b/Runtime/Assist/ValueRetrievers/GuidValueRetriever.cs
@@ -31,9 +31,9 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
             return GetValue(keyValuePair.Value);
         }
 
-        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type type)
+        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type propertyType)
         {
-            return type == typeof(Guid);
+            return propertyType == typeof(Guid);
         }
 
         private static Guid AttempToBuildAGuidFromTheString(string value)

--- a/Runtime/Assist/ValueRetrievers/GuidValueRetriever.cs
+++ b/Runtime/Assist/ValueRetrievers/GuidValueRetriever.cs
@@ -26,7 +26,7 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
             }
         }
 
-        public object Retrieve(KeyValuePair<string, string> keyValuePair, Type targetType)
+        public object Retrieve(KeyValuePair<string, string> keyValuePair, Type targetType, Type propertyType)
         {
             return GetValue(keyValuePair.Value);
         }

--- a/Runtime/Assist/ValueRetrievers/IntValueRetriever.cs
+++ b/Runtime/Assist/ValueRetrievers/IntValueRetriever.cs
@@ -12,7 +12,7 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
             return returnValue;
         }
 
-        public object Retrieve(KeyValuePair<string, string> keyValuePair, Type targetType)
+        public object Retrieve(KeyValuePair<string, string> keyValuePair, Type targetType, Type propertyType)
         {
             return GetValue(keyValuePair.Value);
         }

--- a/Runtime/Assist/ValueRetrievers/IntValueRetriever.cs
+++ b/Runtime/Assist/ValueRetrievers/IntValueRetriever.cs
@@ -17,7 +17,7 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
             return GetValue(keyValuePair.Value);
         }
 
-        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type propertyType)
+        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type targetType, Type propertyType)
         {
             return propertyType == typeof(int);
         }

--- a/Runtime/Assist/ValueRetrievers/IntValueRetriever.cs
+++ b/Runtime/Assist/ValueRetrievers/IntValueRetriever.cs
@@ -17,9 +17,9 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
             return GetValue(keyValuePair.Value);
         }
 
-        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type type)
+        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type propertyType)
         {
-            return type == typeof(int);
+            return propertyType == typeof(int);
         }
     }
 }

--- a/Runtime/Assist/ValueRetrievers/LongValueRetriever.cs
+++ b/Runtime/Assist/ValueRetrievers/LongValueRetriever.cs
@@ -17,7 +17,7 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
             return GetValue(keyValuePair.Value);
         }
 
-        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type propertyType)
+        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type targetType, Type propertyType)
         {
             return propertyType == typeof(long);
         }

--- a/Runtime/Assist/ValueRetrievers/LongValueRetriever.cs
+++ b/Runtime/Assist/ValueRetrievers/LongValueRetriever.cs
@@ -12,7 +12,7 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
             return returnValue;
         }
             
-        public object Retrieve(KeyValuePair<string, string> keyValuePair, Type targetType)
+        public object Retrieve(KeyValuePair<string, string> keyValuePair, Type targetType, Type propertyType)
         {
             return GetValue(keyValuePair.Value);
         }

--- a/Runtime/Assist/ValueRetrievers/LongValueRetriever.cs
+++ b/Runtime/Assist/ValueRetrievers/LongValueRetriever.cs
@@ -17,9 +17,9 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
             return GetValue(keyValuePair.Value);
         }
 
-        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type type)
+        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type propertyType)
         {
-            return type == typeof(long);
+            return propertyType == typeof(long);
         }
     }
 }

--- a/Runtime/Assist/ValueRetrievers/NullableBoolValueRetriever.cs
+++ b/Runtime/Assist/ValueRetrievers/NullableBoolValueRetriever.cs
@@ -19,7 +19,7 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
             return boolValueRetriever(thisValue);
         }
 
-        public object Retrieve(KeyValuePair<string, string> keyValuePair, Type targetType)
+        public object Retrieve(KeyValuePair<string, string> keyValuePair, Type targetType, Type propertyType)
         {
             return GetValue(keyValuePair.Value);
         }

--- a/Runtime/Assist/ValueRetrievers/NullableBoolValueRetriever.cs
+++ b/Runtime/Assist/ValueRetrievers/NullableBoolValueRetriever.cs
@@ -24,9 +24,9 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
             return GetValue(keyValuePair.Value);
         }
 
-        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type type)
+        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type propertyType)
         {
-            return type == typeof(bool?);
+            return propertyType == typeof(bool?);
         }
     }
 }

--- a/Runtime/Assist/ValueRetrievers/NullableBoolValueRetriever.cs
+++ b/Runtime/Assist/ValueRetrievers/NullableBoolValueRetriever.cs
@@ -24,7 +24,7 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
             return GetValue(keyValuePair.Value);
         }
 
-        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type propertyType)
+        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type targetType, Type propertyType)
         {
             return propertyType == typeof(bool?);
         }

--- a/Runtime/Assist/ValueRetrievers/NullableByteValueRetriever.cs
+++ b/Runtime/Assist/ValueRetrievers/NullableByteValueRetriever.cs
@@ -19,7 +19,7 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
             return byteValueRetriever(value);
         }
 
-        public object Retrieve(KeyValuePair<string, string> keyValuePair, Type targetType)
+        public object Retrieve(KeyValuePair<string, string> keyValuePair, Type targetType, Type propertyType)
         {
             return GetValue(keyValuePair.Value);
         }

--- a/Runtime/Assist/ValueRetrievers/NullableByteValueRetriever.cs
+++ b/Runtime/Assist/ValueRetrievers/NullableByteValueRetriever.cs
@@ -24,7 +24,7 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
             return GetValue(keyValuePair.Value);
         }
 
-        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type propertyType)
+        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type targetType, Type propertyType)
         {
             return propertyType == typeof(byte?);
         }

--- a/Runtime/Assist/ValueRetrievers/NullableByteValueRetriever.cs
+++ b/Runtime/Assist/ValueRetrievers/NullableByteValueRetriever.cs
@@ -24,9 +24,9 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
             return GetValue(keyValuePair.Value);
         }
 
-        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type type)
+        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type propertyType)
         {
-            return type == typeof(byte?);
+            return propertyType == typeof(byte?);
         }
     }
 }

--- a/Runtime/Assist/ValueRetrievers/NullableCharValueRetriever.cs
+++ b/Runtime/Assist/ValueRetrievers/NullableCharValueRetriever.cs
@@ -25,9 +25,9 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
             return GetValue(keyValuePair.Value);
         }
 
-        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type type)
+        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type propertyType)
         {
-            return type == typeof(char?);
+            return propertyType == typeof(char?);
         }
     }
 }

--- a/Runtime/Assist/ValueRetrievers/NullableCharValueRetriever.cs
+++ b/Runtime/Assist/ValueRetrievers/NullableCharValueRetriever.cs
@@ -25,7 +25,7 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
             return GetValue(keyValuePair.Value);
         }
 
-        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type propertyType)
+        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type targetType, Type propertyType)
         {
             return propertyType == typeof(char?);
         }

--- a/Runtime/Assist/ValueRetrievers/NullableCharValueRetriever.cs
+++ b/Runtime/Assist/ValueRetrievers/NullableCharValueRetriever.cs
@@ -20,7 +20,7 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
             return charValueRetriever(value);
         }
 
-        public object Retrieve(KeyValuePair<string, string> keyValuePair, Type targetType)
+        public object Retrieve(KeyValuePair<string, string> keyValuePair, Type targetType, Type propertyType)
         {
             return GetValue(keyValuePair.Value);
         }

--- a/Runtime/Assist/ValueRetrievers/NullableDateTimeOffsetValueRetriever.cs
+++ b/Runtime/Assist/ValueRetrievers/NullableDateTimeOffsetValueRetriever.cs
@@ -19,7 +19,7 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
             return dateTimeOffsetValueRetriever(value);
         }
 
-        public object Retrieve(KeyValuePair<string, string> keyValuePair, Type targetType)
+        public object Retrieve(KeyValuePair<string, string> keyValuePair, Type targetType, Type propertyType)
         {
             return GetValue(keyValuePair.Value);
         }

--- a/Runtime/Assist/ValueRetrievers/NullableDateTimeOffsetValueRetriever.cs
+++ b/Runtime/Assist/ValueRetrievers/NullableDateTimeOffsetValueRetriever.cs
@@ -24,9 +24,9 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
             return GetValue(keyValuePair.Value);
         }
 
-        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type type)
+        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type propertyType)
         {
-            return type == typeof(DateTimeOffset);
+            return propertyType == typeof(DateTimeOffset);
         }
     }
 }

--- a/Runtime/Assist/ValueRetrievers/NullableDateTimeOffsetValueRetriever.cs
+++ b/Runtime/Assist/ValueRetrievers/NullableDateTimeOffsetValueRetriever.cs
@@ -24,7 +24,7 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
             return GetValue(keyValuePair.Value);
         }
 
-        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type propertyType)
+        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type targetType, Type propertyType)
         {
             return propertyType == typeof(DateTimeOffset);
         }

--- a/Runtime/Assist/ValueRetrievers/NullableDateTimeValueRetriever.cs
+++ b/Runtime/Assist/ValueRetrievers/NullableDateTimeValueRetriever.cs
@@ -24,7 +24,7 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
             return GetValue(keyValuePair.Value);
         }
 
-        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type propertyType)
+        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type targetType, Type propertyType)
         {
             return propertyType == typeof(DateTime?);
         }

--- a/Runtime/Assist/ValueRetrievers/NullableDateTimeValueRetriever.cs
+++ b/Runtime/Assist/ValueRetrievers/NullableDateTimeValueRetriever.cs
@@ -19,7 +19,7 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
             return dateTimeValueRetriever(value);
         }
 
-        public object Retrieve(KeyValuePair<string, string> keyValuePair, Type targetType)
+        public object Retrieve(KeyValuePair<string, string> keyValuePair, Type targetType, Type propertyType)
         {
             return GetValue(keyValuePair.Value);
         }

--- a/Runtime/Assist/ValueRetrievers/NullableDateTimeValueRetriever.cs
+++ b/Runtime/Assist/ValueRetrievers/NullableDateTimeValueRetriever.cs
@@ -24,9 +24,9 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
             return GetValue(keyValuePair.Value);
         }
 
-        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type type)
+        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type propertyType)
         {
-            return type == typeof(DateTime?);
+            return propertyType == typeof(DateTime?);
         }
     }
 }

--- a/Runtime/Assist/ValueRetrievers/NullableDecimalValueRetriever.cs
+++ b/Runtime/Assist/ValueRetrievers/NullableDecimalValueRetriever.cs
@@ -24,7 +24,7 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
             return GetValue(keyValuePair.Value);
         }
 
-        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type propertyType)
+        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type targetType, Type propertyType)
         {
             return propertyType == typeof(decimal?);
         }

--- a/Runtime/Assist/ValueRetrievers/NullableDecimalValueRetriever.cs
+++ b/Runtime/Assist/ValueRetrievers/NullableDecimalValueRetriever.cs
@@ -19,7 +19,7 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
             return decimalValueRetriever(value);
         }
 
-        public object Retrieve(KeyValuePair<string, string> keyValuePair, Type targetType)
+        public object Retrieve(KeyValuePair<string, string> keyValuePair, Type targetType, Type propertyType)
         {
             return GetValue(keyValuePair.Value);
         }

--- a/Runtime/Assist/ValueRetrievers/NullableDecimalValueRetriever.cs
+++ b/Runtime/Assist/ValueRetrievers/NullableDecimalValueRetriever.cs
@@ -24,9 +24,9 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
             return GetValue(keyValuePair.Value);
         }
 
-        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type type)
+        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type propertyType)
         {
-            return type == typeof(decimal?);
+            return propertyType == typeof(decimal?);
         }
     }
 }

--- a/Runtime/Assist/ValueRetrievers/NullableDoubleValueRetriever.cs
+++ b/Runtime/Assist/ValueRetrievers/NullableDoubleValueRetriever.cs
@@ -24,9 +24,9 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
             return GetValue(keyValuePair.Value);
         }
 
-        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type type)
+        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type propertyType)
         {
-            return type == typeof(double?);
+            return propertyType == typeof(double?);
         }
     }
 }

--- a/Runtime/Assist/ValueRetrievers/NullableDoubleValueRetriever.cs
+++ b/Runtime/Assist/ValueRetrievers/NullableDoubleValueRetriever.cs
@@ -19,7 +19,7 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
             return DoubleValueRetriever(value);
         }
 
-        public object Retrieve(KeyValuePair<string, string> keyValuePair, Type targetType)
+        public object Retrieve(KeyValuePair<string, string> keyValuePair, Type targetType, Type propertyType)
         {
             return GetValue(keyValuePair.Value);
         }

--- a/Runtime/Assist/ValueRetrievers/NullableDoubleValueRetriever.cs
+++ b/Runtime/Assist/ValueRetrievers/NullableDoubleValueRetriever.cs
@@ -24,7 +24,7 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
             return GetValue(keyValuePair.Value);
         }
 
-        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type propertyType)
+        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type targetType, Type propertyType)
         {
             return propertyType == typeof(double?);
         }

--- a/Runtime/Assist/ValueRetrievers/NullableFloatValueRetriever.cs
+++ b/Runtime/Assist/ValueRetrievers/NullableFloatValueRetriever.cs
@@ -19,7 +19,7 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
             return FloatValueRetriever(value);
         }
 
-        public object Retrieve(KeyValuePair<string, string> keyValuePair, Type targetType)
+        public object Retrieve(KeyValuePair<string, string> keyValuePair, Type targetType, Type propertyType)
         {
             return GetValue(keyValuePair.Value);
         }

--- a/Runtime/Assist/ValueRetrievers/NullableFloatValueRetriever.cs
+++ b/Runtime/Assist/ValueRetrievers/NullableFloatValueRetriever.cs
@@ -24,9 +24,9 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
             return GetValue(keyValuePair.Value);
         }
 
-        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type type)
+        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type propertyType)
         {
-            return type == typeof(float?);
+            return propertyType == typeof(float?);
         }
     }
 }

--- a/Runtime/Assist/ValueRetrievers/NullableFloatValueRetriever.cs
+++ b/Runtime/Assist/ValueRetrievers/NullableFloatValueRetriever.cs
@@ -24,7 +24,7 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
             return GetValue(keyValuePair.Value);
         }
 
-        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type propertyType)
+        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type targetType, Type propertyType)
         {
             return propertyType == typeof(float?);
         }

--- a/Runtime/Assist/ValueRetrievers/NullableGuidValueRetriever.cs
+++ b/Runtime/Assist/ValueRetrievers/NullableGuidValueRetriever.cs
@@ -24,7 +24,7 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
             return GetValue(keyValuePair.Value);
         }
 
-        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type propertyType)
+        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type targetType, Type propertyType)
         {
             return propertyType == typeof(Guid?);
         }

--- a/Runtime/Assist/ValueRetrievers/NullableGuidValueRetriever.cs
+++ b/Runtime/Assist/ValueRetrievers/NullableGuidValueRetriever.cs
@@ -19,7 +19,7 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
             return guidValueRetriever(value);
         }
 
-        public object Retrieve(KeyValuePair<string, string> keyValuePair, Type targetType)
+        public object Retrieve(KeyValuePair<string, string> keyValuePair, Type targetType, Type propertyType)
         {
             return GetValue(keyValuePair.Value);
         }

--- a/Runtime/Assist/ValueRetrievers/NullableGuidValueRetriever.cs
+++ b/Runtime/Assist/ValueRetrievers/NullableGuidValueRetriever.cs
@@ -24,9 +24,9 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
             return GetValue(keyValuePair.Value);
         }
 
-        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type type)
+        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type propertyType)
         {
-            return type == typeof(Guid?);
+            return propertyType == typeof(Guid?);
         }
     }
 }

--- a/Runtime/Assist/ValueRetrievers/NullableIntValueRetriever.cs
+++ b/Runtime/Assist/ValueRetrievers/NullableIntValueRetriever.cs
@@ -24,9 +24,9 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
             return GetValue(keyValuePair.Value);
         }
 
-        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type type)
+        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type propertyType)
         {
-            return type == typeof(int?);
+            return propertyType == typeof(int?);
         }
     }
 }

--- a/Runtime/Assist/ValueRetrievers/NullableIntValueRetriever.cs
+++ b/Runtime/Assist/ValueRetrievers/NullableIntValueRetriever.cs
@@ -19,7 +19,7 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
             return intValueRetriever(value);
         }
 
-        public object Retrieve(KeyValuePair<string, string> keyValuePair, Type targetType)
+        public object Retrieve(KeyValuePair<string, string> keyValuePair, Type targetType, Type propertyType)
         {
             return GetValue(keyValuePair.Value);
         }

--- a/Runtime/Assist/ValueRetrievers/NullableIntValueRetriever.cs
+++ b/Runtime/Assist/ValueRetrievers/NullableIntValueRetriever.cs
@@ -24,7 +24,7 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
             return GetValue(keyValuePair.Value);
         }
 
-        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type propertyType)
+        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type targetType, Type propertyType)
         {
             return propertyType == typeof(int?);
         }

--- a/Runtime/Assist/ValueRetrievers/NullableLongValueRetriever.cs
+++ b/Runtime/Assist/ValueRetrievers/NullableLongValueRetriever.cs
@@ -24,9 +24,9 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
             return GetValue(keyValuePair.Value);
         }
 
-        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type type)
+        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type propertyType)
         {
-            return type == typeof(long?);
+            return propertyType == typeof(long?);
         }
     }
 }

--- a/Runtime/Assist/ValueRetrievers/NullableLongValueRetriever.cs
+++ b/Runtime/Assist/ValueRetrievers/NullableLongValueRetriever.cs
@@ -24,7 +24,7 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
             return GetValue(keyValuePair.Value);
         }
 
-        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type propertyType)
+        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type targetType, Type propertyType)
         {
             return propertyType == typeof(long?);
         }

--- a/Runtime/Assist/ValueRetrievers/NullableLongValueRetriever.cs
+++ b/Runtime/Assist/ValueRetrievers/NullableLongValueRetriever.cs
@@ -19,7 +19,7 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
             return longValueRetriever(value);
         }
 
-        public object Retrieve(KeyValuePair<string, string> keyValuePair, Type targetType)
+        public object Retrieve(KeyValuePair<string, string> keyValuePair, Type targetType, Type propertyType)
         {
             return GetValue(keyValuePair.Value);
         }

--- a/Runtime/Assist/ValueRetrievers/NullableSByteValueRetriever.cs
+++ b/Runtime/Assist/ValueRetrievers/NullableSByteValueRetriever.cs
@@ -19,7 +19,7 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
             return sbyteValueRetriever(value);
         }
 
-        public object Retrieve(KeyValuePair<string, string> keyValuePair, Type targetType)
+        public object Retrieve(KeyValuePair<string, string> keyValuePair, Type targetType, Type propertyType)
         {
             return GetValue(keyValuePair.Value);
         }

--- a/Runtime/Assist/ValueRetrievers/NullableSByteValueRetriever.cs
+++ b/Runtime/Assist/ValueRetrievers/NullableSByteValueRetriever.cs
@@ -24,9 +24,9 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
             return GetValue(keyValuePair.Value);
         }
 
-        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type type)
+        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type propertyType)
         {
-            return type == typeof(sbyte?);
+            return propertyType == typeof(sbyte?);
         }
     }
 }

--- a/Runtime/Assist/ValueRetrievers/NullableSByteValueRetriever.cs
+++ b/Runtime/Assist/ValueRetrievers/NullableSByteValueRetriever.cs
@@ -24,7 +24,7 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
             return GetValue(keyValuePair.Value);
         }
 
-        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type propertyType)
+        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type targetType, Type propertyType)
         {
             return propertyType == typeof(sbyte?);
         }

--- a/Runtime/Assist/ValueRetrievers/NullableShortValueRetriever.cs
+++ b/Runtime/Assist/ValueRetrievers/NullableShortValueRetriever.cs
@@ -19,7 +19,7 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
             return shortValueRetriever(value);
         }
 
-        public object Retrieve(KeyValuePair<string, string> keyValuePair, Type targetType)
+        public object Retrieve(KeyValuePair<string, string> keyValuePair, Type targetType, Type propertyType)
         {
             return GetValue(keyValuePair.Value);
         }

--- a/Runtime/Assist/ValueRetrievers/NullableShortValueRetriever.cs
+++ b/Runtime/Assist/ValueRetrievers/NullableShortValueRetriever.cs
@@ -24,9 +24,9 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
             return GetValue(keyValuePair.Value);
         }
 
-        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type type)
+        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type propertyType)
         {
-            return type == typeof(short?);
+            return propertyType == typeof(short?);
         }
     }
 }

--- a/Runtime/Assist/ValueRetrievers/NullableShortValueRetriever.cs
+++ b/Runtime/Assist/ValueRetrievers/NullableShortValueRetriever.cs
@@ -24,7 +24,7 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
             return GetValue(keyValuePair.Value);
         }
 
-        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type propertyType)
+        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type targetType, Type propertyType)
         {
             return propertyType == typeof(short?);
         }

--- a/Runtime/Assist/ValueRetrievers/NullableTimeSpanValueRetriever.cs
+++ b/Runtime/Assist/ValueRetrievers/NullableTimeSpanValueRetriever.cs
@@ -25,7 +25,7 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
             return GetValue(keyValuePair.Value);
         }
 
-        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type propertyType)
+        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type targetType, Type propertyType)
         {
             return propertyType == typeof(TimeSpan?);
         }

--- a/Runtime/Assist/ValueRetrievers/NullableTimeSpanValueRetriever.cs
+++ b/Runtime/Assist/ValueRetrievers/NullableTimeSpanValueRetriever.cs
@@ -20,7 +20,7 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
             return dateTimeValueRetriever(value);
         }
 
-        public object Retrieve(KeyValuePair<string, string> keyValuePair, Type targetType)
+        public object Retrieve(KeyValuePair<string, string> keyValuePair, Type targetType, Type propertyType)
         {
             return GetValue(keyValuePair.Value);
         }

--- a/Runtime/Assist/ValueRetrievers/NullableTimeSpanValueRetriever.cs
+++ b/Runtime/Assist/ValueRetrievers/NullableTimeSpanValueRetriever.cs
@@ -25,9 +25,9 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
             return GetValue(keyValuePair.Value);
         }
 
-        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type type)
+        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type propertyType)
         {
-            return type == typeof(TimeSpan?);
+            return propertyType == typeof(TimeSpan?);
         }
     }
 }

--- a/Runtime/Assist/ValueRetrievers/NullableUIntValueRetriever.cs
+++ b/Runtime/Assist/ValueRetrievers/NullableUIntValueRetriever.cs
@@ -19,7 +19,7 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
             return uintValueRetriever(value);
         }
 
-        public object Retrieve(KeyValuePair<string, string> keyValuePair, Type targetType)
+        public object Retrieve(KeyValuePair<string, string> keyValuePair, Type targetType, Type propertyType)
         {
             return GetValue(keyValuePair.Value);
         }

--- a/Runtime/Assist/ValueRetrievers/NullableUIntValueRetriever.cs
+++ b/Runtime/Assist/ValueRetrievers/NullableUIntValueRetriever.cs
@@ -24,9 +24,9 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
             return GetValue(keyValuePair.Value);
         }
 
-        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type type)
+        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type propertyType)
         {
-            return type == typeof(uint?);
+            return propertyType == typeof(uint?);
         }
     }
 }

--- a/Runtime/Assist/ValueRetrievers/NullableUIntValueRetriever.cs
+++ b/Runtime/Assist/ValueRetrievers/NullableUIntValueRetriever.cs
@@ -24,7 +24,7 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
             return GetValue(keyValuePair.Value);
         }
 
-        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type propertyType)
+        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type targetType, Type propertyType)
         {
             return propertyType == typeof(uint?);
         }

--- a/Runtime/Assist/ValueRetrievers/NullableULongValueRetriever.cs
+++ b/Runtime/Assist/ValueRetrievers/NullableULongValueRetriever.cs
@@ -24,9 +24,9 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
             return GetValue(keyValuePair.Value);
         }
 
-        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type type)
+        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type propertyType)
         {
-            return type == typeof(ulong?);
+            return propertyType == typeof(ulong?);
         }
     }
 }

--- a/Runtime/Assist/ValueRetrievers/NullableULongValueRetriever.cs
+++ b/Runtime/Assist/ValueRetrievers/NullableULongValueRetriever.cs
@@ -19,7 +19,7 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
             return ulongValueRetriever(value);
         }
 
-        public object Retrieve(KeyValuePair<string, string> keyValuePair, Type targetType)
+        public object Retrieve(KeyValuePair<string, string> keyValuePair, Type targetType, Type propertyType)
         {
             return GetValue(keyValuePair.Value);
         }

--- a/Runtime/Assist/ValueRetrievers/NullableULongValueRetriever.cs
+++ b/Runtime/Assist/ValueRetrievers/NullableULongValueRetriever.cs
@@ -24,7 +24,7 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
             return GetValue(keyValuePair.Value);
         }
 
-        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type propertyType)
+        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type targetType, Type propertyType)
         {
             return propertyType == typeof(ulong?);
         }

--- a/Runtime/Assist/ValueRetrievers/NullableUShortValueRetriever.cs
+++ b/Runtime/Assist/ValueRetrievers/NullableUShortValueRetriever.cs
@@ -24,9 +24,9 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
             return GetValue(keyValuePair.Value);
         }
 
-        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type type)
+        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type propertyType)
         {
-            return type == typeof(ushort?);
+            return propertyType == typeof(ushort?);
         }
     }
 }

--- a/Runtime/Assist/ValueRetrievers/NullableUShortValueRetriever.cs
+++ b/Runtime/Assist/ValueRetrievers/NullableUShortValueRetriever.cs
@@ -19,7 +19,7 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
             return ushortValueRetriever(value);
         }
 
-        public object Retrieve(KeyValuePair<string, string> keyValuePair, Type targetType)
+        public object Retrieve(KeyValuePair<string, string> keyValuePair, Type targetType, Type propertyType)
         {
             return GetValue(keyValuePair.Value);
         }

--- a/Runtime/Assist/ValueRetrievers/NullableUShortValueRetriever.cs
+++ b/Runtime/Assist/ValueRetrievers/NullableUShortValueRetriever.cs
@@ -24,7 +24,7 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
             return GetValue(keyValuePair.Value);
         }
 
-        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type propertyType)
+        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type targetType, Type propertyType)
         {
             return propertyType == typeof(ushort?);
         }

--- a/Runtime/Assist/ValueRetrievers/SByteValueRetriever.cs
+++ b/Runtime/Assist/ValueRetrievers/SByteValueRetriever.cs
@@ -12,7 +12,7 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
             return returnValue;
         }
 
-        public object Retrieve(KeyValuePair<string, string> keyValuePair, Type targetType)
+        public object Retrieve(KeyValuePair<string, string> keyValuePair, Type targetType, Type propertyType)
         {
             return GetValue(keyValuePair.Value);
         }

--- a/Runtime/Assist/ValueRetrievers/SByteValueRetriever.cs
+++ b/Runtime/Assist/ValueRetrievers/SByteValueRetriever.cs
@@ -17,9 +17,9 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
             return GetValue(keyValuePair.Value);
         }
 
-        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type type)
+        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type propertyType)
         {
-            return type == typeof(sbyte);
+            return propertyType == typeof(sbyte);
         }
     }
 }

--- a/Runtime/Assist/ValueRetrievers/SByteValueRetriever.cs
+++ b/Runtime/Assist/ValueRetrievers/SByteValueRetriever.cs
@@ -17,7 +17,7 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
             return GetValue(keyValuePair.Value);
         }
 
-        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type propertyType)
+        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type targetType, Type propertyType)
         {
             return propertyType == typeof(sbyte);
         }

--- a/Runtime/Assist/ValueRetrievers/ShortValueRetriever.cs
+++ b/Runtime/Assist/ValueRetrievers/ShortValueRetriever.cs
@@ -12,7 +12,7 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
             return returnValue;
         }
 
-        public object Retrieve(KeyValuePair<string, string> keyValuePair, Type targetType)
+        public object Retrieve(KeyValuePair<string, string> keyValuePair, Type targetType, Type propertyType)
         {
             return GetValue(keyValuePair.Value);
         }

--- a/Runtime/Assist/ValueRetrievers/ShortValueRetriever.cs
+++ b/Runtime/Assist/ValueRetrievers/ShortValueRetriever.cs
@@ -17,7 +17,7 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
             return GetValue(keyValuePair.Value);
         }
 
-        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type propertyType)
+        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type targetType, Type propertyType)
         {
             return propertyType == typeof(short);
         }

--- a/Runtime/Assist/ValueRetrievers/ShortValueRetriever.cs
+++ b/Runtime/Assist/ValueRetrievers/ShortValueRetriever.cs
@@ -17,9 +17,9 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
             return GetValue(keyValuePair.Value);
         }
 
-        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type type)
+        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type propertyType)
         {
-            return type == typeof(short);
+            return propertyType == typeof(short);
         }
     }
 }

--- a/Runtime/Assist/ValueRetrievers/StepTransformationValueRetriever.cs
+++ b/Runtime/Assist/ValueRetrievers/StepTransformationValueRetriever.cs
@@ -21,7 +21,7 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
             }
         }
 
-        public object Retrieve(KeyValuePair<string, string> keyValuePair, Type targetType)
+        public object Retrieve(KeyValuePair<string, string> keyValuePair, Type targetType, Type propertyType1)
         {
             var propertyType = targetType.GetProperties().First(x => x.Name.MatchesThisColumnName(keyValuePair.Key)).PropertyType;
             return StepArgumentTypeConverter().Convert(keyValuePair.Value, BindingTypeFor(propertyType), CultureInfo());

--- a/Runtime/Assist/ValueRetrievers/StepTransformationValueRetriever.cs
+++ b/Runtime/Assist/ValueRetrievers/StepTransformationValueRetriever.cs
@@ -21,9 +21,8 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
             }
         }
 
-        public object Retrieve(KeyValuePair<string, string> keyValuePair, Type targetType, Type propertyType1)
+        public object Retrieve(KeyValuePair<string, string> keyValuePair, Type targetType, Type propertyType)
         {
-            var propertyType = targetType.GetProperties().First(x => x.Name.MatchesThisColumnName(keyValuePair.Key)).PropertyType;
             return StepArgumentTypeConverter().Convert(keyValuePair.Value, BindingTypeFor(propertyType), CultureInfo());
         }
 

--- a/Runtime/Assist/ValueRetrievers/StepTransformationValueRetriever.cs
+++ b/Runtime/Assist/ValueRetrievers/StepTransformationValueRetriever.cs
@@ -12,7 +12,7 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
 {
     public class StepTransformationValueRetriever : IValueRetriever
     {
-        public bool CanRetrieve(KeyValuePair<string, string> row, Type propertyType)
+        public bool CanRetrieve(KeyValuePair<string, string> row, Type targetType, Type propertyType)
         {
             try {
                 return StepArgumentTypeConverter().CanConvert(row.Value, BindingTypeFor(propertyType), CultureInfo());

--- a/Runtime/Assist/ValueRetrievers/StepTransformationValueRetriever.cs
+++ b/Runtime/Assist/ValueRetrievers/StepTransformationValueRetriever.cs
@@ -12,10 +12,10 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
 {
     public class StepTransformationValueRetriever : IValueRetriever
     {
-        public bool CanRetrieve(KeyValuePair<string, string> row, Type type)
+        public bool CanRetrieve(KeyValuePair<string, string> row, Type propertyType)
         {
             try {
-                return StepArgumentTypeConverter().CanConvert(row.Value, BindingTypeFor(type), CultureInfo());
+                return StepArgumentTypeConverter().CanConvert(row.Value, BindingTypeFor(propertyType), CultureInfo());
             } catch {
                 return false;
             }

--- a/Runtime/Assist/ValueRetrievers/StringValueRetriever.cs
+++ b/Runtime/Assist/ValueRetrievers/StringValueRetriever.cs
@@ -15,7 +15,7 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
             return GetValue(keyValuePair.Value);
         }
 
-        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type propertyType)
+        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type targetType, Type propertyType)
         {
             return propertyType == typeof(string);
         }

--- a/Runtime/Assist/ValueRetrievers/StringValueRetriever.cs
+++ b/Runtime/Assist/ValueRetrievers/StringValueRetriever.cs
@@ -15,9 +15,9 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
             return GetValue(keyValuePair.Value);
         }
 
-        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type type)
+        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type propertyType)
         {
-            return type == typeof(string);
+            return propertyType == typeof(string);
         }
     }
 }

--- a/Runtime/Assist/ValueRetrievers/StringValueRetriever.cs
+++ b/Runtime/Assist/ValueRetrievers/StringValueRetriever.cs
@@ -10,7 +10,7 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
             return value;
         }
 
-        public object Retrieve(KeyValuePair<string, string> keyValuePair, Type targetType)
+        public object Retrieve(KeyValuePair<string, string> keyValuePair, Type targetType, Type propertyType)
         {
             return GetValue(keyValuePair.Value);
         }

--- a/Runtime/Assist/ValueRetrievers/TimeSpanValueRetriever.cs
+++ b/Runtime/Assist/ValueRetrievers/TimeSpanValueRetriever.cs
@@ -15,9 +15,9 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
             return GetValue(keyValuePair.Value);
         }
 
-        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type type)
+        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type propertyType)
         {
-            return type == typeof(System.TimeSpan);
+            return propertyType == typeof(System.TimeSpan);
         }
     }
 }

--- a/Runtime/Assist/ValueRetrievers/TimeSpanValueRetriever.cs
+++ b/Runtime/Assist/ValueRetrievers/TimeSpanValueRetriever.cs
@@ -15,7 +15,7 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
             return GetValue(keyValuePair.Value);
         }
 
-        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type propertyType)
+        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type targetType, Type propertyType)
         {
             return propertyType == typeof(System.TimeSpan);
         }

--- a/Runtime/Assist/ValueRetrievers/TimeSpanValueRetriever.cs
+++ b/Runtime/Assist/ValueRetrievers/TimeSpanValueRetriever.cs
@@ -10,7 +10,7 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
             return TimeSpan.Parse(value);
         }
 
-        public object Retrieve(KeyValuePair<string, string> keyValuePair, Type targetType)
+        public object Retrieve(KeyValuePair<string, string> keyValuePair, Type targetType, Type propertyType)
         {
             return GetValue(keyValuePair.Value);
         }

--- a/Runtime/Assist/ValueRetrievers/UIntValueRetriever.cs
+++ b/Runtime/Assist/ValueRetrievers/UIntValueRetriever.cs
@@ -12,7 +12,7 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
             return returnValue;
         }
 
-        public object Retrieve(KeyValuePair<string, string> keyValuePair, Type targetType)
+        public object Retrieve(KeyValuePair<string, string> keyValuePair, Type targetType, Type propertyType)
         {
             return GetValue(keyValuePair.Value);
         }

--- a/Runtime/Assist/ValueRetrievers/UIntValueRetriever.cs
+++ b/Runtime/Assist/ValueRetrievers/UIntValueRetriever.cs
@@ -17,7 +17,7 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
             return GetValue(keyValuePair.Value);
         }
 
-        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type propertyType)
+        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type targetType, Type propertyType)
         {
             return propertyType == typeof(uint);
         }

--- a/Runtime/Assist/ValueRetrievers/UIntValueRetriever.cs
+++ b/Runtime/Assist/ValueRetrievers/UIntValueRetriever.cs
@@ -17,9 +17,9 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
             return GetValue(keyValuePair.Value);
         }
 
-        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type type)
+        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type propertyType)
         {
-            return type == typeof(uint);
+            return propertyType == typeof(uint);
         }
     }
 }

--- a/Runtime/Assist/ValueRetrievers/ULongValueRetriever.cs
+++ b/Runtime/Assist/ValueRetrievers/ULongValueRetriever.cs
@@ -12,7 +12,7 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
             return returnValue;
         }
 
-        public object Retrieve(KeyValuePair<string, string> keyValuePair, Type targetType)
+        public object Retrieve(KeyValuePair<string, string> keyValuePair, Type targetType, Type propertyType)
         {
             return GetValue(keyValuePair.Value);
         }

--- a/Runtime/Assist/ValueRetrievers/ULongValueRetriever.cs
+++ b/Runtime/Assist/ValueRetrievers/ULongValueRetriever.cs
@@ -17,9 +17,9 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
             return GetValue(keyValuePair.Value);
         }
 
-        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type type)
+        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type propertyType)
         {
-            return type == typeof(ulong);
+            return propertyType == typeof(ulong);
         }
     }
 }

--- a/Runtime/Assist/ValueRetrievers/ULongValueRetriever.cs
+++ b/Runtime/Assist/ValueRetrievers/ULongValueRetriever.cs
@@ -17,7 +17,7 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
             return GetValue(keyValuePair.Value);
         }
 
-        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type propertyType)
+        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type targetType, Type propertyType)
         {
             return propertyType == typeof(ulong);
         }

--- a/Runtime/Assist/ValueRetrievers/UShortValueRetriever.cs
+++ b/Runtime/Assist/ValueRetrievers/UShortValueRetriever.cs
@@ -17,7 +17,7 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
             return GetValue(keyValuePair.Value);
         }
 
-        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type propertyType)
+        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type targetType, Type propertyType)
         {
             return propertyType == typeof(ushort);
         }

--- a/Runtime/Assist/ValueRetrievers/UShortValueRetriever.cs
+++ b/Runtime/Assist/ValueRetrievers/UShortValueRetriever.cs
@@ -12,7 +12,7 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
             return returnValue;
         }
 
-        public object Retrieve(KeyValuePair<string, string> keyValuePair, Type targetType)
+        public object Retrieve(KeyValuePair<string, string> keyValuePair, Type targetType, Type propertyType)
         {
             return GetValue(keyValuePair.Value);
         }

--- a/Runtime/Assist/ValueRetrievers/UShortValueRetriever.cs
+++ b/Runtime/Assist/ValueRetrievers/UShortValueRetriever.cs
@@ -17,9 +17,9 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
             return GetValue(keyValuePair.Value);
         }
 
-        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type type)
+        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type propertyType)
         {
-            return type == typeof(ushort);
+            return propertyType == typeof(ushort);
         }
     }
 }

--- a/Tests/RuntimeTests/AssistTests/ServiceTests.cs
+++ b/Tests/RuntimeTests/AssistTests/ServiceTests.cs
@@ -160,7 +160,7 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests
         {
             throw new NotImplementedException();
         }
-        public object Retrieve(KeyValuePair<string, string> keyValuePair, Type targetType)
+        public object Retrieve(KeyValuePair<string, string> keyValuePair, Type targetType, Type propertyType)
         {
             throw new NotImplementedException();
         }

--- a/Tests/RuntimeTests/AssistTests/ServiceTests.cs
+++ b/Tests/RuntimeTests/AssistTests/ServiceTests.cs
@@ -164,7 +164,7 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests
         {
             throw new NotImplementedException();
         }
-        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type type)
+        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type targetType, Type type)
         {
             throw new NotImplementedException();
         }

--- a/Tests/RuntimeTests/AssistTests/ValueRetrieverTests/NullableTimespanValueRetrieverTests.cs
+++ b/Tests/RuntimeTests/AssistTests/ValueRetrieverTests/NullableTimespanValueRetrieverTests.cs
@@ -38,10 +38,10 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.ValueRetrieverTests
         {
             var retriever = new NullableTimeSpanValueRetriever();
             var empty = new System.Collections.Generic.KeyValuePair<string, string>();
-            retriever.CanRetrieve(empty, typeof(System.TimeSpan?)).Should().BeTrue();
-            retriever.CanRetrieve(empty, typeof(System.TimeSpan)).Should().BeFalse();
-            retriever.CanRetrieve(empty, typeof(System.String)).Should().BeFalse();
-            retriever.CanRetrieve(empty, typeof(System.Boolean)).Should().BeFalse();
+            retriever.CanRetrieve(empty, null, typeof(System.TimeSpan?)).Should().BeTrue();
+            retriever.CanRetrieve(empty, null, typeof(System.TimeSpan)).Should().BeFalse();
+            retriever.CanRetrieve(empty, null, typeof(System.String)).Should().BeFalse();
+            retriever.CanRetrieve(empty, null, typeof(System.Boolean)).Should().BeFalse();
         }
     }
 }

--- a/Tests/RuntimeTests/AssistTests/ValueRetrieverTests/StepTransformationValueRetrieverTests.cs
+++ b/Tests/RuntimeTests/AssistTests/ValueRetrieverTests/StepTransformationValueRetrieverTests.cs
@@ -26,10 +26,10 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.ValueRetrieverTests
         [Test]
         public void Retrieve_will_return_the_value_from_the_step_argument_type_converter()
         {
-            var dateTimeResult = Subject().Retrieve(new KeyValuePair<string, string> ("TheDate", "2009/10/06"), typeof(StepTransformationValueRetrieverExample));
+            var dateTimeResult = Subject().Retrieve(new KeyValuePair<string, string> ("TheDate", "2009/10/06"), typeof(StepTransformationValueRetrieverExample), typeof(DateTime));
             dateTimeResult.Should().Be(new DateTime(2009, 10, 6));
 
-            var stringResult = Subject().Retrieve(new KeyValuePair<string, string> ("TheString", "2009/10/06"), typeof(StepTransformationValueRetrieverExample));
+            var stringResult = Subject().Retrieve(new KeyValuePair<string, string> ("TheString", "2009/10/06"), typeof(StepTransformationValueRetrieverExample), typeof(string));
             stringResult.Should().Be("2009/10/06");
         }
 
@@ -48,7 +48,7 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.ValueRetrieverTests
 
             var french = new Object();
             stepArgumentTypeConverter.Setup(x => x.Convert(value, It.IsAny<IBindingType>(), frenchCultureInfo)).Returns(french);
-            frenchSubject.Retrieve(KeyValueFor(value), typeof(StepTransformationValueRetrieverExample)).Should().BeSameAs(french);
+            frenchSubject.Retrieve(KeyValueFor(value), typeof(StepTransformationValueRetrieverExample), typeof(DateTime)).Should().BeSameAs(french);
 
             //another culture
             var usSubject = Subject();
@@ -59,7 +59,7 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.ValueRetrieverTests
 
             var us = new Object();
             stepArgumentTypeConverter.Setup(x => x.Convert(value, It.IsAny<IBindingType>(), usCultureInfo)).Returns(us);
-            usSubject.Retrieve(KeyValueFor(value), typeof(StepTransformationValueRetrieverExample)).Should().BeSameAs(us);
+            usSubject.Retrieve(KeyValueFor(value), typeof(StepTransformationValueRetrieverExample), typeof(DateTime)).Should().BeSameAs(us);
         }
 
         [Test]

--- a/Tests/RuntimeTests/AssistTests/ValueRetrieverTests/StepTransformationValueRetrieverTests.cs
+++ b/Tests/RuntimeTests/AssistTests/ValueRetrieverTests/StepTransformationValueRetrieverTests.cs
@@ -65,9 +65,9 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.ValueRetrieverTests
         [Test]
         public void CanRetrieve_will_return_true_if_the_value_can_be_retrieved_from_a_step_argument_transformation()
         {
-            Subject().CanRetrieve(KeyValueFor("2009/10/06"), typeof(DateTime)).Should().BeTrue();
-            Subject().CanRetrieve(KeyValueFor("not a date"), typeof(DateTime)).Should().BeFalse();
-            Subject().CanRetrieve(KeyValueFor("not a date"), typeof(string)).Should().BeTrue();
+            Subject().CanRetrieve(KeyValueFor("2009/10/06"), null, typeof(DateTime)).Should().BeTrue();
+            Subject().CanRetrieve(KeyValueFor("not a date"), null, typeof(DateTime)).Should().BeFalse();
+            Subject().CanRetrieve(KeyValueFor("not a date"), null, typeof(string)).Should().BeTrue();
         }
 
         [Test]
@@ -79,9 +79,9 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.ValueRetrieverTests
             // which was not set, so... it will throw
             subject.ContainerToUseForThePurposeOfTesting = null;
 
-            subject.CanRetrieve(KeyValueFor("2009/10/06"), typeof(DateTime)).Should().BeFalse();
-            subject.CanRetrieve(KeyValueFor("not a date"), typeof(DateTime)).Should().BeFalse();
-            subject.CanRetrieve(KeyValueFor("not a date"), typeof(string)).Should().BeFalse();
+            subject.CanRetrieve(KeyValueFor("2009/10/06"), null, typeof(DateTime)).Should().BeFalse();
+            subject.CanRetrieve(KeyValueFor("not a date"), null, typeof(DateTime)).Should().BeFalse();
+            subject.CanRetrieve(KeyValueFor("not a date"), null, typeof(string)).Should().BeFalse();
         }
 
         [Test]
@@ -96,10 +96,10 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.ValueRetrieverTests
             RegisterBindingCulture(frenchCultureInfo, subject.ContainerToUseForThePurposeOfTesting);
 
             stepArgumentTypeConverter.Setup(x => x.CanConvert("2009/10/06", It.IsAny<IBindingType>(), frenchCultureInfo)).Returns(true);
-            subject.CanRetrieve(KeyValueFor("2009/10/06"), typeof(DateTime)).Should().BeTrue();
+            subject.CanRetrieve(KeyValueFor("2009/10/06"), null, typeof(DateTime)).Should().BeTrue();
 
             stepArgumentTypeConverter.Setup(x => x.CanConvert("2009/10/06", It.IsAny<IBindingType>(), frenchCultureInfo)).Returns(false);
-            subject.CanRetrieve(KeyValueFor("2009/10/06"), typeof(DateTime)).Should().BeFalse();
+            subject.CanRetrieve(KeyValueFor("2009/10/06"), null, typeof(DateTime)).Should().BeFalse();
 
             //another culture
             var subject2 = Subject();
@@ -108,10 +108,10 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.ValueRetrieverTests
             RegisterBindingCulture(usCultureInfo, subject2.ContainerToUseForThePurposeOfTesting);
 
             stepArgumentTypeConverter.Setup(x => x.CanConvert("2009/10/06", It.IsAny<IBindingType>(), usCultureInfo)).Returns(true);
-            subject2.CanRetrieve(KeyValueFor("2009/10/06"), typeof(DateTime)).Should().BeTrue();
+            subject2.CanRetrieve(KeyValueFor("2009/10/06"), null, typeof(DateTime)).Should().BeTrue();
 
             stepArgumentTypeConverter.Setup(x => x.CanConvert("2009/10/06", It.IsAny<IBindingType>(), usCultureInfo)).Returns(false);
-            subject2.CanRetrieve(KeyValueFor("2009/10/06"), typeof(DateTime)).Should().BeFalse();
+            subject2.CanRetrieve(KeyValueFor("2009/10/06"), null, typeof(DateTime)).Should().BeFalse();
         }
 
         private static KeyValuePair<string, string> KeyValueFor(string value)

--- a/Tests/RuntimeTests/AssistTests/ValueRetrieverTests/TimeSpanValueRetrieverTests.cs
+++ b/Tests/RuntimeTests/AssistTests/ValueRetrieverTests/TimeSpanValueRetrieverTests.cs
@@ -21,9 +21,9 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.ValueRetrieverTests
         {
             var retriever = new TimeSpanValueRetriever();
             var empty = new System.Collections.Generic.KeyValuePair<string, string>();
-            retriever.CanRetrieve(empty, typeof(System.TimeSpan)).Should().BeTrue();
-            retriever.CanRetrieve(empty, typeof(System.String)).Should().BeFalse();
-            retriever.CanRetrieve(empty, typeof(System.Boolean)).Should().BeFalse();
+            retriever.CanRetrieve(empty, null, typeof(System.TimeSpan)).Should().BeTrue();
+            retriever.CanRetrieve(empty, null, typeof(System.String)).Should().BeFalse();
+            retriever.CanRetrieve(empty, null, typeof(System.Boolean)).Should().BeFalse();
         }
     }
 }

--- a/Tests/RuntimeTests/AssistTests/WorkingExampleOfValueRetrieverAndComparerAddition.cs
+++ b/Tests/RuntimeTests/AssistTests/WorkingExampleOfValueRetrieverAndComparerAddition.cs
@@ -41,7 +41,7 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests
             return new Type[]{ typeof(FancyName) };
         }
 
-        public object Retrieve(KeyValuePair<string, string> keyValuePair, Type targetType)
+        public object Retrieve(KeyValuePair<string, string> keyValuePair, Type targetType, Type propertyType)
         {
             return FancyNameValueRetriever.Parse(keyValuePair.Value);
         }
@@ -140,7 +140,7 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests
             return new Type[]{ typeof(ProductCategory) };
         }
 
-        public object Retrieve(KeyValuePair<string, string> keyValuePair, Type targetType)
+        public object Retrieve(KeyValuePair<string, string> keyValuePair, Type targetType, Type propertyType)
         {
             return ProductCategoryValueRetriever.Parse(keyValuePair.Value);
         }

--- a/Tests/RuntimeTests/AssistTests/WorkingExampleOfValueRetrieverAndComparerAddition.cs
+++ b/Tests/RuntimeTests/AssistTests/WorkingExampleOfValueRetrieverAndComparerAddition.cs
@@ -46,7 +46,7 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests
             return FancyNameValueRetriever.Parse(keyValuePair.Value);
         }
 
-        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type type)
+        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type targetType, Type type)
         {
             return this.TypesForWhichIRetrieveValues().Contains(type);
         }
@@ -145,7 +145,7 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests
             return ProductCategoryValueRetriever.Parse(keyValuePair.Value);
         }
 
-        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type type)
+        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type targetType, Type type)
         {
             return this.TypesForWhichIRetrieveValues().Contains(type);
         }


### PR DESCRIPTION
A discussion in #527 with @gasparnagy made me realize that the signatures on the ```IValueRetriever``` was very confusing.

```CanRetrieve``` and ```Retrieve``` both received a single ```Type``` argument.  However, the argument for one was the property type, and the other was the type of the object that was passed to the table helper.

Very confusing!  So I made these two signatures match.  Now both receive two types, the two types above.