### PR TITLE
make DialectProvider public for other Assemblies

### DIFF
--- a/Parser/SpecFlowGherkinParser.cs
+++ b/Parser/SpecFlowGherkinParser.cs
@@ -37,7 +37,7 @@ namespace TechTalk.SpecFlow.Parser
             }
         }
 
-        internal GherkinDialectProvider DialectProvider
+        public GherkinDialectProvider DialectProvider
         {
             get { return dialectProvider; }
         }


### PR DESCRIPTION
This is a change needed for SpecFlow+Excel to be upgraded to SpecFlow 2.0.

We need to access the DialectProvider that is used by the SpecFlowGherkinParser.