### PR TITLE
xUnit: Support friendly test name

### DIFF
--- a/Generator/UnitTestProvider/XUnitTestGeneratorProvider.cs
+++ b/Generator/UnitTestProvider/XUnitTestGeneratorProvider.cs
@@ -107,7 +107,7 @@ namespace TechTalk.SpecFlow.Generator.UnitTestProvider
 
         public void SetTestMethod(TestClassGenerationContext generationContext, CodeMemberMethod testMethod, string friendlyTestName)
         {
-            CodeDomHelper.AddAttribute(testMethod, FACT_ATTRIBUTE);
+            CodeDomHelper.AddAttribute(testMethod, FACT_ATTRIBUTE, new CodeAttributeArgument("DisplayName", new CodePrimitiveExpression(friendlyTestName)));
 
             SetProperty(testMethod, FEATURE_TITLE_PROPERTY_NAME, generationContext.Feature.Name);
             SetDescription(testMethod, friendlyTestName);

--- a/Tests/GeneratorTests/XUnitTestGeenratorProviderTests.cs
+++ b/Tests/GeneratorTests/XUnitTestGeenratorProviderTests.cs
@@ -41,5 +41,57 @@ namespace TechTalk.SpecFlow.GeneratorTests
             Assert.That(primitiveExpression, Is.Not.Null);
             Assert.That(primitiveExpression.Value, Is.EqualTo(XUnitTestGeneratorProvider.SKIP_REASON));
         }
+
+        /*
+         * Based on w1ld's `Should_set_skip_attribute_for_theory`,
+         * refactor as appropriate.
+         */
+        [Test]
+        public void Should_set_displayname_attribute()
+        {
+            // Arrange
+            var provider = new XUnitTestGeneratorProvider(new CodeDomHelper(new CSharpCodeProvider())); // TODO: what about XUnit2TestGeneratorProvider ?
+            var context = new Generator.TestClassGenerationContext(
+                unitTestGeneratorProvider: null,
+                feature: new Parser.SpecFlowFeature(
+                    tags: null,
+                    location: null,
+                    language: null,
+                    keyword: null,
+                    name: "",
+                    description: null,
+                    background: null,
+                    scenarioDefinitions: null,
+                    comments: null,
+                    sourceFilePath: null),
+                ns: null,
+                testClass: null,
+                testRunnerField: null,
+                testClassInitializeMethod: null,
+                testClassCleanupMethod: null,
+                testInitializeMethod: null,
+                testCleanupMethod: null,
+                scenarioInitializeMethod: null,
+                scenarioCleanupMethod: null,
+                featureBackgroundMethod: null,
+                generateRowTests: false);
+            var codeMemberMethod = new CodeMemberMethod();
+
+            // Act
+            provider.SetTestMethod(context, codeMemberMethod, "Foo");
+
+            // Assert
+            var modifiedAttribute = codeMemberMethod.CustomAttributes.OfType<CodeAttributeDeclaration>()
+                .FirstOrDefault(a => a.Name == "Xunit.FactAttribute");
+
+            Assert.That(modifiedAttribute, Is.Not.Null);
+            var attribute = modifiedAttribute.Arguments.OfType<CodeAttributeArgument>()
+                .FirstOrDefault(a => a.Name == "DisplayName");
+            Assert.That(attribute, Is.Not.Null);
+
+            var primitiveExpression = attribute.Value as CodePrimitiveExpression;
+            Assert.That(primitiveExpression, Is.Not.Null);
+            Assert.That(primitiveExpression.Value, Is.EqualTo("Foo"));
+        }
     }
 }


### PR DESCRIPTION
We use the `DisplayName` argument of the `Fact` attribute to specify a friendly test name to appear in the various reports and tools (e.g. in the VS Test Explorer).

**Warning:** This is a tentative (read: quick & dirty) patch, I'd be happy to take pointers on how to do this better or obviously let you do it better.

**Warning:** I have been unable to test this properly, I'd be grateful for some information on how to generate a build that I can use (ideally an alternate set of nuget packages). I essentially based a unit test off of existing ones to get some confirmation, I didn't dive deep into the project.