### PR TITLE
Exclude missing DictionaryHelpers.cs

### DIFF
--- a/Runtime/TechTalk.SpecFlow.csproj
+++ b/Runtime/TechTalk.SpecFlow.csproj
@@ -174,7 +174,6 @@
     <Compile Include="PlatformSpecific\ConfigDefaults.cs" />
     <Compile Include="Configuration\MissingOrPendingStepsOutcome.cs" />
     <Compile Include="CultureInfoScope.cs" />
-    <Compile Include="DictionaryHelpers.cs" />
     <Compile Include="PlatformSpecific\UnitTestProviders.cs" />
     <Compile Include="ProgrammingLanguage.cs" />
     <Compile Include="ScenarioStepContext.cs" />


### PR DESCRIPTION
there is compile error ".\SpecFlow\Runtime\DictionaryHelpers.cs' could not be found" - file does not exists after last commit deletion