### PR TITLE
Fix generation of App.config and plugincompability.config

### DIFF
--- a/Tools/config.template
+++ b/Tools/config.template
@@ -4,19 +4,19 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="TechTalk.SpecFlow.Generator" publicKeyToken="0778194805d6db41" culture="neutral" />
-        <bindingRedirect oldVersion="2.0.0.0-[CURRENT_VERSION]" newVersion="[CURRENT_VERSION]" />
+        <bindingRedirect oldVersion="2.0.0.0-[CURRENT_VERSION].0" newVersion="[CURRENT_VERSION].0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="TechTalk.SpecFlow.Parser" publicKeyToken="0778194805d6db41" culture="neutral" />
-        <bindingRedirect oldVersion="2.0.0.0-[CURRENT_VERSION]" newVersion="[CURRENT_VERSION]" />
+        <bindingRedirect oldVersion="2.0.0.0-[CURRENT_VERSION].0" newVersion="[CURRENT_VERSION].0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="TechTalk.SpecFlow.Utils" publicKeyToken="0778194805d6db41" culture="neutral" />
-        <bindingRedirect oldVersion="2.0.0.0-[CURRENT_VERSION]" newVersion="[CURRENT_VERSION]" />
+        <bindingRedirect oldVersion="2.0.0.0-[CURRENT_VERSION].0" newVersion="[CURRENT_VERSION].0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="TechTalk.SpecFlow" publicKeyToken="0778194805d6db41" culture="neutral" />
-        <bindingRedirect oldVersion="2.0.0.0-[CURRENT_VERSION]" newVersion="[CURRENT_VERSION]" />
+        <bindingRedirect oldVersion="2.0.0.0-[CURRENT_VERSION].0" newVersion="[CURRENT_VERSION].0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>


### PR DESCRIPTION
Currently the binding redirects are created this way:
<bindingRedirect oldVersion="2.0.0.0-2.1.0" newVersion="2.1.0" />

Which is wrong, because the build number is missing.
<bindingRedirect oldVersion="2.0.0.0-2.1.0.0" newVersion="2.1.0.0" />

This fixes the generation