### PR TITLE
Fix a problem "xcopy ... exited with code 4" in post build action.

### DIFF
--- a/Tests/TechTalk.SpecFlow.IntegrationTests/TechTalk.SpecFlow.IntegrationTests.csproj
+++ b/Tests/TechTalk.SpecFlow.IntegrationTests/TechTalk.SpecFlow.IntegrationTests.csproj
@@ -283,25 +283,17 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>xcopy $(SolutionDir)Installer\SpecFlowBinPackage\bin\package\*.* $(TargetDir)SpecFlow\ /s /y
-
-xcopy $(SolutionDir)packages\NUnit.2.6.4\*.* $(TargetDir)NUnit\ /s /y
-
-xcopy $(SolutionDir)packages\NUnit.Runners.2.6.4\*.* $(TargetDir)NUnit.Runners\ /s /y
-
-xcopy $(SolutionDir)packages\xunit.1.9.2\lib\net20\*.* $(TargetDir)xunit\lib\ /s /y
-
-xcopy $(SolutionDir)packages\xunit.extensions.1.9.2\lib\net20\*.* $(TargetDir)xunit.extensions\lib\ /s /y
-
-xcopy $(SolutionDir)packages\xunit.runner.console.2.0.0\*.* $(TargetDir)xunit.runner.console\ /s /y
-
-xcopy $(SolutionDir)lib\xunit.2.0.0\*.* $(TargetDir)xUnit2\ /s /y
-xcopy "$(SolutionDir)lib\Microsoft F#\*.*" $(TargetDir)FSharp\ /s /y
-xcopy $(SolutionDir)packages\NUnit.2.6.0.12054\*.* $(TargetDir)NUnit\ /s /y
-
-xcopy $(SolutionDir)lib\NUnit3-Runner\*.* $(TargetDir)NUnit3-Runner\ /s /y
-
-xcopy $(SolutionDir)lib\mbunit.3.3.442.0\*.* $(TargetDir)mbUnit3\ /s /y
+    <PostBuildEvent>xcopy "$(SolutionDir)Installer\SpecFlowBinPackage\bin\package\*.*" "$(TargetDir)SpecFlow\" /s /y
+xcopy "$(SolutionDir)packages\NUnit.2.6.4\*.*" "$(TargetDir)NUnit\" /s /y
+xcopy "$(SolutionDir)packages\NUnit.Runners.2.6.4\*.*" "$(TargetDir)NUnit.Runners\" /s /y
+xcopy "$(SolutionDir)packages\xunit.1.9.2\lib\net20\*.*" "$(TargetDir)xunit\lib\" /s /y
+xcopy "$(SolutionDir)packages\xunit.extensions.1.9.2\lib\net20\*.*" "$(TargetDir)xunit.extensions\lib\" /s /y
+xcopy "$(SolutionDir)packages\xunit.runner.console.2.0.0\*.*" "$(TargetDir)xunit.runner.console\" /s /y
+xcopy "$(SolutionDir)lib\xunit.2.0.0\*.*" "$(TargetDir)xUnit2\" /s /y
+xcopy "$(SolutionDir)lib\Microsoft F#\*.*" "$(TargetDir)FSharp\" /s /y
+xcopy "$(SolutionDir)packages\NUnit.2.6.0.12054\*.*" "$(TargetDir)NUnit\" /s /y
+xcopy "$(SolutionDir)lib\NUnit3-Runner\*.*" "$(TargetDir)NUnit3-Runner\" /s /y
+xcopy "$(SolutionDir)lib\mbunit.3.3.442.0\*.*" "$(TargetDir)mbUnit3\" /s /y
 </PostBuildEvent>
   </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/Tests/TechTalk.SpecFlow.Specs/TechTalk.SpecFlow.Specs.csproj
+++ b/Tests/TechTalk.SpecFlow.Specs/TechTalk.SpecFlow.Specs.csproj
@@ -334,25 +334,17 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>xcopy $(SolutionDir)Installer\SpecFlowBinPackage\bin\package\*.* $(TargetDir)SpecFlow\ /s /y
-
-xcopy $(SolutionDir)packages\NUnit.2.6.4\*.* $(TargetDir)NUnit\ /s /y
-
-xcopy $(SolutionDir)packages\NUnit.Runners.2.6.4\*.* $(TargetDir)NUnit.Runners\ /s /y
-
-xcopy $(SolutionDir)packages\xunit.1.9.2\lib\net20\*.* $(TargetDir)xunit\lib\ /s /y
-
-xcopy $(SolutionDir)packages\xunit.extensions.1.9.2\lib\net20\*.* $(TargetDir)xunit.extensions\lib\ /s /y
-
-xcopy $(SolutionDir)packages\xunit.runner.console.2.0.0\*.* $(TargetDir)xunit.runner.console\ /s /y
-
-xcopy $(SolutionDir)lib\xunit.2.0.0\*.* $(TargetDir)xUnit2\ /s /y
-xcopy "$(SolutionDir)lib\Microsoft F#\*.*" $(TargetDir)FSharp\ /s /y
-xcopy $(SolutionDir)packages\NUnit.2.6.0.12054\*.* $(TargetDir)NUnit\ /s /y
-
-xcopy $(SolutionDir)lib\NUnit3-Runner\*.* $(TargetDir)NUnit3-Runner\ /s /y
-
-xcopy $(SolutionDir)lib\mbunit.3.3.442.0\*.* $(TargetDir)mbUnit3\ /s /y
+    <PostBuildEvent>xcopy "$(SolutionDir)Installer\SpecFlowBinPackage\bin\package\*.*" "$(TargetDir)SpecFlow\" /s /y
+xcopy "$(SolutionDir)packages\NUnit.2.6.4\*.*" "$(TargetDir)NUnit\" /s /y
+xcopy "$(SolutionDir)packages\NUnit.Runners.2.6.4\*.*" "$(TargetDir)NUnit.Runners\" /s /y
+xcopy "$(SolutionDir)packages\xunit.1.9.2\lib\net20\*.*" "$(TargetDir)xunit\lib\" /s /y
+xcopy "$(SolutionDir)packages\xunit.extensions.1.9.2\lib\net20\*.*" "$(TargetDir)xunit.extensions\lib\" /s /y
+xcopy "$(SolutionDir)packages\xunit.runner.console.2.0.0\*.*" "$(TargetDir)xunit.runner.console\" /s /y
+xcopy "$(SolutionDir)lib\xunit.2.0.0\*.*" "$(TargetDir)xUnit2\" /s /y
+xcopy "$(SolutionDir)lib\Microsoft F#\*.*" "$(TargetDir)FSharp\" /s /y
+xcopy "$(SolutionDir)packages\NUnit.2.6.0.12054\*.*" "$(TargetDir)NUnit\" /s /y
+xcopy "$(SolutionDir)lib\NUnit3-Runner\*.*" "$(TargetDir)NUnit3-Runner\" /s /y
+xcopy "$(SolutionDir)lib\mbunit.3.3.442.0\*.*" "$(TargetDir)mbUnit3\" /s /y
 </PostBuildEvent>
   </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 


### PR DESCRIPTION
The error was occurred when solution path contains a space character. I
escaped xcopy parameters with double quotes and error has gone.

https://github.com/techtalk/SpecFlow/commit/31959da8e82368f599de17c9770e0b1600326659#commitcomment-17040890