### PR TITLE
Enhance CompareToSet by not using Exceptions through ThisItemIsAMatch

### DIFF
--- a/Runtime/Assist/InstanceComparisonExtensionMethods.cs
+++ b/Runtime/Assist/InstanceComparisonExtensionMethods.cs
@@ -1,11 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using TechTalk.SpecFlow.Infrastructure;
-using TechTalk.SpecFlow;
-using TechTalk.SpecFlow.Assist.ValueComparers;
-using TechTalk.SpecFlow.Assist.ValueRetrievers;
-using BoDi;
 
 namespace TechTalk.SpecFlow.Assist
 {
@@ -22,6 +17,19 @@ namespace TechTalk.SpecFlow.Assist
 
             if (ThereAreAnyDifferences(differences))
                 ThrowAnExceptionThatDescribesThoseDifferences(differences);
+        }
+
+        /// <summary>
+        /// Indicates whether the table is equivalent to the specified instance by comparing the values of all
+        /// columns against the properties of the instance.  Will return false after finding the first difference.
+        /// </summary>
+        public static bool IsEquivalentToInstance<T>(this Table table, T instance)
+        {
+            AssertThatTheInstanceExists(instance);
+
+            var instanceTable = TEHelpers.GetTheProperInstanceTable(table, typeof(T));
+
+            return HasDifference(instanceTable, instance) == false;
         }
 
         private static void AssertThatTheInstanceExists<T>(T instance)
@@ -58,9 +66,17 @@ namespace TechTalk.SpecFlow.Assist
                    select CreateDifferenceForThisRow(instance, row);
         }
 
+        private static bool HasDifference<T>(Table table, T instance)
+        {
+            // This method exists so it will stop evaluating the instance (hence stop using Reflection)
+            // after the first difference is found.
+            return (from row in table.Rows select row)
+                   .Any(row => ThePropertyDoesNotExist(instance, row) || TheValuesDoNotMatch(instance, row));
+        }
+
         private static bool ThereAreAnyDifferences(IEnumerable<Difference> differences)
         {
-            return differences.Count() > 0;
+            return differences.Any();
         }
 
         private static bool ThePropertyDoesNotExist<T>(T instance, TableRow row)

--- a/Runtime/Assist/SetComparer.cs
+++ b/Runtime/Assist/SetComparer.cs
@@ -125,8 +125,7 @@ namespace TechTalk.SpecFlow.Assist
         {
             try
             {
-                expectedItem.CompareToInstance(actualItem);
-                return true;
+                return expectedItem.IsEquivalentToInstance(actualItem);
             }
             catch
             {

--- a/Tests/RuntimeTests/AssistTests/InstanceComparisonExtensionMethodsTests.cs
+++ b/Tests/RuntimeTests/AssistTests/InstanceComparisonExtensionMethodsTests.cs
@@ -384,19 +384,6 @@ IDoNotExist: Property does not exist".AgnosticLineBreak());
             return result;
         }
 
-        private static ComparisonException GetExceptionThrownByThisComparison(Table table, StandardTypesComparisonTestObject test)
-        {
-            try
-            {
-                table.CompareToInstance(test);
-            }
-            catch (ComparisonException ex)
-            {
-                return ex;
-            }
-            return null;
-        }
-
         private static ComparisonTestResult ExceptionWasThrownByThisComparison(Table table, StandardTypesComparisonTestObject test)
         {
             var result = new ComparisonTestResult { ExceptionWasThrown = false };

--- a/Tests/RuntimeTests/AssistTests/InstanceEquivalenceExtensionMethodTests.cs
+++ b/Tests/RuntimeTests/AssistTests/InstanceEquivalenceExtensionMethodTests.cs
@@ -1,0 +1,127 @@
+﻿using System;
+using System.Globalization;
+using System.Threading;
+using FluentAssertions;
+using NUnit.Framework;
+using TechTalk.SpecFlow.Assist;
+using TechTalk.SpecFlow.RuntimeTests.AssistTests.TestInfrastructure;
+
+namespace TechTalk.SpecFlow.RuntimeTests.AssistTests
+{
+    [TestFixture]
+    public class InstanceEquivalenceExtensionMethodTests
+    {
+        [SetUp]
+        public void Setup()
+        {
+            Thread.CurrentThread.CurrentCulture = new CultureInfo("en-US");
+        }
+
+        [Test]
+        public void throws_exception_with_descriptive_message_when_instance_is_null()
+        {
+            var table = new Table("Field", "Value");
+
+            var exception = GetExceptionThrownByThisComparison(table, null);
+
+            exception.Message.Should().Be("The item to compare was null.");
+        }
+
+        [Test]
+        public void returns_true_if_instance_matches_horizontal_table()
+        {
+            var table = new Table("IntProperty", "BoolProperty", "StringProperty", "DateTimeProperty");
+            table.AddRow("1", "true", "Test", "4/30/2016");
+
+            var test = new InstanceComparisonTestObject()
+            {
+                IntProperty = 1, 
+                BoolProperty = true,
+                StringProperty = "Test",
+                DateTimeProperty = new DateTime(2016, 4, 30)
+            };
+
+            var result = GetResultFromThisComparison(table, test);
+
+            result.Should().Be(true);
+        }
+
+        [Test]
+        public void returns_true_if_instance_matches_vertical_table()
+        {
+            var table = new Table("Field", "Value");
+            table.AddRow("IntProperty", "1");
+            table.AddRow("BoolProperty", "true");
+            table.AddRow("StringProperty", "Test");
+            table.AddRow("DateTimeProperty", "4/30/2016");
+
+            var test = new InstanceComparisonTestObject
+            {
+                IntProperty = 1,
+                BoolProperty = true,
+                StringProperty = "Test",
+                DateTimeProperty = new DateTime(2016, 4, 30)
+            };
+
+            var result = GetResultFromThisComparison(table, test);
+
+            result.Should().Be(true);
+        }
+
+        [Test]
+        public void returns_false_if_instance_values_do_not_match()
+        {
+            var table = new Table("IntProperty", "BoolProperty", "StringProperty", "DateTimeProperty");
+            table.AddRow("1", "true", "Test", "4/30/2016");
+
+            var test = new InstanceComparisonTestObject
+            {
+                IntProperty = 1,
+                BoolProperty = true,
+                StringProperty = "Test",
+                DateTimeProperty = new DateTime(2016, 4, 1)
+            };
+
+            var result = GetResultFromThisComparison(table, test);
+
+            result.Should().Be(false);
+        }
+
+        [Test]
+        public void returns_false_if_instance_does_not_have_property()
+        {
+            var table = new Table("IntProperty", "BoolProperty", "StringProperty", "DateTimeProperty", "SomeMissingProperty");
+            table.AddRow("1", "true", "Test", "4/30/2016", "MissingPropertyValue");
+
+            var test = new InstanceComparisonTestObject
+            {
+                IntProperty = 1,
+                BoolProperty = true,
+                StringProperty = "Test",
+                DateTimeProperty = new DateTime(2016, 4, 1)
+            };
+
+            var result = GetResultFromThisComparison(table, test);
+
+            result.Should().Be(false);
+        }
+
+        private static bool GetResultFromThisComparison(Table table, InstanceComparisonTestObject test)
+        {
+            return table.IsEquivalentToInstance(test);
+        }
+
+        private static ComparisonException GetExceptionThrownByThisComparison(Table table, InstanceComparisonTestObject test)
+        {
+            try
+            {
+                table.IsEquivalentToInstance(test);
+            }
+            catch (ComparisonException ex)
+            {
+                return ex;
+            }
+            return null;
+        }
+    }
+}

--- a/Tests/RuntimeTests/AssistTests/InstanceEquivalenceExtensionMethodTests.cs
+++ b/Tests/RuntimeTests/AssistTests/InstanceEquivalenceExtensionMethodTests.cs
@@ -98,7 +98,7 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests
                 IntProperty = 1,
                 BoolProperty = true,
                 StringProperty = "Test",
-                DateTimeProperty = new DateTime(2016, 4, 1)
+                DateTimeProperty = new DateTime(2016, 4, 30)
             };
 
             var result = GetResultFromThisComparison(table, test);

--- a/Tests/RuntimeTests/RuntimeTests.csproj
+++ b/Tests/RuntimeTests/RuntimeTests.csproj
@@ -74,6 +74,7 @@
     <Compile Include="AssistTests\CreateInstanceHelperMethodTests.cs" />
     <Compile Include="AssistTests\ExampleEntities\EntityWithPropertiesAndFields.cs" />
     <Compile Include="AssistTests\FormattingTableDiffExceptionBuilderTests.cs" />
+    <Compile Include="AssistTests\InstanceEquivalenceExtensionMethodTests.cs" />
     <Compile Include="AssistTests\PivotTableTests.cs" />
     <Compile Include="AssistTests\RowExtensionMethodTests_GetEnum.cs" />
     <Compile Include="AssistTests\ProjectionTests.cs" />


### PR DESCRIPTION

CompareToSet looks for a matching index, while it's doing that it doesn't need to generate ComparisonExceptions like CompareToInstance does, because prior to this commit they were swallowed just to indicate a non-match.  This caused a lot of gc events in large sets, so this commit dramatically increases performance of CompareToSet in large, un-ordered sets.  For my case it went from 4500 seconds to 23 seconds.

Will also stop evaluating each instance after the first difference is found when all we need to know is if they are different.