### PR TITLE
Performance improvements to set comparison for large sets.

### DIFF
--- a/Runtime/Assist/EnumerableProjection.cs
+++ b/Runtime/Assist/EnumerableProjection.cs
@@ -1,19 +1,18 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 
 namespace TechTalk.SpecFlow.Assist
 {
     public class EnumerableProjection<T> : IEnumerable<Projection<T>>
     {
-        private IEnumerable<T> collection;
-        private IEnumerable<string> properties;
+        private readonly IEnumerable<T> collection;
+        private readonly IEnumerable<string> properties;
 
         public EnumerableProjection(Table table, IEnumerable<T> collection = null)
         {
             if (table == null && collection == null)
-                throw new ArgumentNullException("table", "Either table or projectCollection must be specified");
+                throw new ArgumentNullException(nameof(table), "Either table or projectCollection must be specified");
 
             if (table != null)
                 properties = table.Header;
@@ -38,10 +37,7 @@ namespace TechTalk.SpecFlow.Assist
                 {
                     return new Projection<T>(collection.First(), properties).Equals(obj);
                 }
-                else
-                {
-                    return false;
-                }
+                return false;
             }
             return base.Equals(obj);
         }
@@ -54,8 +50,8 @@ namespace TechTalk.SpecFlow.Assist
 
     public class ProjectionEnumerator<T> : IEnumerator<Projection<T>>
     {
-        private IEnumerator<T> collectionEnumerator;
-        private IEnumerable<string> properties;
+        private readonly IEnumerator<T> collectionEnumerator;
+        private readonly IEnumerable<string> properties;
 
         public ProjectionEnumerator(IEnumerable<T> collection, IEnumerable<string> properties)
         {
@@ -63,26 +59,14 @@ namespace TechTalk.SpecFlow.Assist
             this.properties = properties;
         }
 
-        public Projection<T> Current
-        {
-            get
-            {
-                return new Projection<T>(collectionEnumerator.Current, properties);
-            }
-        }
+        public Projection<T> Current => new Projection<T>(collectionEnumerator.Current, properties);
 
         public void Dispose()
         {
             collectionEnumerator.Dispose();
         }
 
-        object System.Collections.IEnumerator.Current
-        {
-            get
-            {
-                return Current;
-            }
-        }
+        object System.Collections.IEnumerator.Current => Current;
 
         public bool MoveNext()
         {
@@ -98,7 +82,7 @@ namespace TechTalk.SpecFlow.Assist
     public class Projection<T>
     {
         private readonly T item;
-        private IEnumerable<string> properties;
+        private readonly IEnumerable<string> properties;
 
         public Projection(T item, IEnumerable<string> properties)
         {
@@ -116,10 +100,7 @@ namespace TechTalk.SpecFlow.Assist
                     IEnumerable<string> properties = this.properties;
                     if (otherProjection.properties != null)
                     {
-                        if (properties == null)
-                            properties = otherProjection.properties;
-                        else
-                            properties = properties.Intersect(otherProjection.properties);
+                        properties = properties?.Intersect(otherProjection.properties) ?? otherProjection.properties;
                     }
                     if (properties != null)
                     {

--- a/Runtime/Assist/InstanceComparisonExtensionMethods.cs
+++ b/Runtime/Assist/InstanceComparisonExtensionMethods.cs
@@ -13,7 +13,7 @@ namespace TechTalk.SpecFlow.Assist
 
             var instanceTable = TEHelpers.GetTheProperInstanceTable(table, typeof(T));
 
-            var differences = FindAnyDifferences(instanceTable, instance).ToArray();
+            var differences = FindAnyDifferences(instanceTable, instance);
 
             if (ThereAreAnyDifferences(differences))
                 ThrowAnExceptionThatDescribesThoseDifferences(differences);
@@ -43,11 +43,11 @@ namespace TechTalk.SpecFlow.Assist
                 : $"{difference.Property}: Expected <{difference.Expected}>, Actual <{difference.Actual}>";
         }
 
-        private static IEnumerable<Difference> FindAnyDifferences<T>(Table table, T instance)
+        private static Difference[] FindAnyDifferences<T>(Table table, T instance)
         {
-            return from row in table.Rows
+            return (from row in table.Rows
                    where ThePropertyDoesNotExist(instance, row) || TheValuesDoNotMatch(instance, row)
-                   select CreateDifferenceForThisRow(instance, row);
+                   select CreateDifferenceForThisRow(instance, row)).ToArray();
         }
 
         private static bool ThereAreAnyDifferences(IEnumerable<Difference> differences)

--- a/Runtime/Assist/InstanceComparisonExtensionMethods.cs
+++ b/Runtime/Assist/InstanceComparisonExtensionMethods.cs
@@ -13,7 +13,7 @@ namespace TechTalk.SpecFlow.Assist
 
             var instanceTable = TEHelpers.GetTheProperInstanceTable(table, typeof(T));
 
-            var differences = FindAnyDifferences(instanceTable, instance);
+            var differences = FindAnyDifferences(instanceTable, instance).ToArray();
 
             if (ThereAreAnyDifferences(differences))
                 ThrowAnExceptionThatDescribesThoseDifferences(differences);

--- a/Runtime/Assist/InstanceComparisonExtensionMethods.cs
+++ b/Runtime/Assist/InstanceComparisonExtensionMethods.cs
@@ -1,11 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using TechTalk.SpecFlow.Infrastructure;
-using TechTalk.SpecFlow;
-using TechTalk.SpecFlow.Assist.ValueComparers;
-using TechTalk.SpecFlow.Assist.ValueRetrievers;
-using BoDi;
 
 namespace TechTalk.SpecFlow.Assist
 {
@@ -43,12 +38,9 @@ namespace TechTalk.SpecFlow.Assist
 
         private static string DescribeTheErrorForThisDifference(Difference difference)
         {
-            if (difference.DoesNotExist)
-                return string.Format("{0}: Property does not exist", difference.Property);
-
-            return string.Format("{0}: Expected <{1}>, Actual <{2}>",
-                                 difference.Property, difference.Expected,
-                                 difference.Actual);
+            return difference.DoesNotExist 
+                ? $"{difference.Property}: Property does not exist" 
+                : $"{difference.Property}: Expected <{difference.Expected}>, Actual <{difference.Actual}>";
         }
 
         private static IEnumerable<Difference> FindAnyDifferences<T>(Table table, T instance)
@@ -60,7 +52,7 @@ namespace TechTalk.SpecFlow.Assist
 
         private static bool ThereAreAnyDifferences(IEnumerable<Difference> differences)
         {
-            return differences.Count() > 0;
+            return differences.Any();
         }
 
         private static bool ThePropertyDoesNotExist<T>(T instance, TableRow row)
@@ -74,7 +66,7 @@ namespace TechTalk.SpecFlow.Assist
             var expected = GetTheExpectedValue(row);
             var propertyValue = instance.GetPropertyValue(row.Id());
 
-            var valueComparers = Assist.Service.Instance.ValueComparers;
+            var valueComparers = Service.Instance.ValueComparers;
 
             return valueComparers
                 .FirstOrDefault(x => x.CanCompare(propertyValue))

--- a/Runtime/Assist/RowExtensionMethods.cs
+++ b/Runtime/Assist/RowExtensionMethods.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Reflection;
 
 namespace TechTalk.SpecFlow.Assist
 {
@@ -99,7 +98,7 @@ namespace TechTalk.SpecFlow.Assist
                                 select property.PropertyType).FirstOrDefault();
 
             if (propertyType == null)
-                throw new InvalidOperationException(string.Format("No enum with value {0} found in type {1}", value, typeof(T).Name));
+                throw new InvalidOperationException($"No enum with value {value} found in type {typeof(T).Name}");
 
             return propertyType;
         }
@@ -147,13 +146,13 @@ namespace TechTalk.SpecFlow.Assist
         {
             var acceptedValues = new[] { "true", "false" };
             if (acceptedValues.Contains(row[id]) == false)
-                throw new InvalidCastException(string.Format("You must use 'true' or 'false' when setting bools for {0}", id));
+                throw new InvalidCastException($"You must use 'true' or 'false' when setting bools for {id}");
         }
 
         private static void AssertThatAValueWithThisIdExistsInThisRow(TableRow row, string id)
         {
             if (AValueWithThisIdExists(row, id) == false)
-                throw new InvalidOperationException(string.Format("{0} could not be found in the row.", id));
+                throw new InvalidOperationException($"{id} could not be found in the row.");
         }
 
         private static bool AValueWithThisIdExists(IEnumerable<KeyValuePair<string, string>> row, string id)

--- a/Runtime/Assist/Service.cs
+++ b/Runtime/Assist/Service.cs
@@ -1,9 +1,5 @@
 ﻿using System;
-using System.Collections;
 using System.Collections.Generic;
-using BoDi;
-using System.Linq;
-using TechTalk.SpecFlow.Assist;
 using TechTalk.SpecFlow.Assist.ValueComparers;
 using TechTalk.SpecFlow.Assist.ValueRetrievers;
 
@@ -15,8 +11,8 @@ namespace TechTalk.SpecFlow.Assist
         private List<IValueComparer> _registeredValueComparers;
         private List<IValueRetriever> _registeredValueRetrievers;
 
-        public IEnumerable<IValueComparer> ValueComparers { get { return _registeredValueComparers; } }
-        public IEnumerable<IValueRetriever> ValueRetrievers { get { return _registeredValueRetrievers; } }
+        public IEnumerable<IValueComparer> ValueComparers => _registeredValueComparers;
+        public IEnumerable<IValueRetriever> ValueRetrievers => _registeredValueRetrievers;
 
         public static Service Instance { get; internal set; }
 

--- a/Runtime/Assist/SetComparer.cs
+++ b/Runtime/Assist/SetComparer.cs
@@ -141,9 +141,12 @@ namespace TechTalk.SpecFlow.Assist
 
         private void AssertThatAllColumnsInTheTableMatchToPropertiesOnTheType()
         {
-            var propertiesThatDoNotExist = (from columnHeader in table.Header
-                                           where (typeof (T).GetProperties().Any(property => TEHelpers.IsMemberMatchingToColumnName(property, columnHeader)) == false)
-                                           select columnHeader).ToArray();
+            var normalizedPropertyNames = new HashSet<string>(from property in typeof(T).GetProperties()
+                                                              select TEHelpers.NormalizePropertyNameToMatchAgainstAColumnName(property.Name));
+            var normalizedColumnNames = new HashSet<string>(from columnHeader in table.Header
+                                                            select TEHelpers.NormalizePropertyNameToMatchAgainstAColumnName(TEHelpers.RemoveAllCharactersThatAreNotValidInAPropertyName(columnHeader)));
+
+            var propertiesThatDoNotExist = normalizedColumnNames.Except(normalizedPropertyNames, StringComparer.OrdinalIgnoreCase).ToArray();
 
             if (propertiesThatDoNotExist.Any())
                 throw new ComparisonException($@"The following fields do not exist:{Environment.NewLine}{string.Join(Environment.NewLine, propertiesThatDoNotExist)}");

--- a/Runtime/Assist/SetComparer.cs
+++ b/Runtime/Assist/SetComparer.cs
@@ -146,7 +146,7 @@ namespace TechTalk.SpecFlow.Assist
                                            select columnHeader).ToArray();
 
             if (propertiesThatDoNotExist.Any())
-                throw new ComparisonException($@"The following fields do not exist:{ string.Join(Environment.NewLine, propertiesThatDoNotExist)}");
+                throw new ComparisonException($@"The following fields do not exist:{Environment.NewLine}{string.Join(Environment.NewLine, propertiesThatDoNotExist)}");
         }
     }
 }

--- a/Runtime/Assist/SetComparer.cs
+++ b/Runtime/Assist/SetComparer.cs
@@ -54,12 +54,12 @@ namespace TechTalk.SpecFlow.Assist
 
         private bool ThereAreResultsWhenThereShouldBeNone(IEnumerable<T> set)
         {
-            return set.Count() > 0 && table.Rows.Count() == 0;
+            return set.Any() && !table.Rows.Any();
         }
 
         private bool ThereAreNoResultsAndNoExpectedResults(IEnumerable<T> set)
         {
-            return set.Count() == 0 && table.Rows.Count() == 0;
+            return !set.Any() && !table.Rows.Any();
         }
 
         private void AssertThatTheItemsMatchTheExpectedResults(IEnumerable<T> set)
@@ -111,7 +111,7 @@ namespace TechTalk.SpecFlow.Assist
         private static int GetTheIndexOfTheMatchingItem(Table expectedItem,
                                                         IList<T> actualItems)
         {
-            for (var actualItemIndex = 0; actualItemIndex < actualItems.Count(); actualItemIndex++)
+            for (var actualItemIndex = 0; actualItemIndex < actualItems.Count; actualItemIndex++)
             {
                 var actualItem = actualItems[actualItemIndex];
 
@@ -141,14 +141,12 @@ namespace TechTalk.SpecFlow.Assist
 
         private void AssertThatAllColumnsInTheTableMatchToPropertiesOnTheType()
         {
-            var propertiesThatDoNotExist = from columnHeader in table.Header
+            var propertiesThatDoNotExist = (from columnHeader in table.Header
                                            where (typeof (T).GetProperties().Any(property => TEHelpers.IsMemberMatchingToColumnName(property, columnHeader)) == false)
-                                           select columnHeader;
+                                           select columnHeader).ToArray();
 
             if (propertiesThatDoNotExist.Any())
-                throw new ComparisonException(
-                    propertiesThatDoNotExist.Aggregate(@"The following fields do not exist:",
-                                                       (running, next) => running + string.Format("{0}{1}", Environment.NewLine, next)));
+                throw new ComparisonException($@"The following fields do not exist:{ string.Join(Environment.NewLine, propertiesThatDoNotExist)}");
         }
     }
 }

--- a/Runtime/Assist/TEHelpers.cs
+++ b/Runtime/Assist/TEHelpers.cs
@@ -3,8 +3,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Text.RegularExpressions;
-using TechTalk.SpecFlow.Assist.ValueRetrievers;
-using System.Collections.Generic;
 
 namespace TechTalk.SpecFlow.Assist
 {
@@ -21,7 +19,7 @@ namespace TechTalk.SpecFlow.Assist
         {
             var constructor = GetConstructorMatchingToColumnNames<T>(table);
             if (constructor == null)
-                throw new MissingMethodException(string.Format("Unable to find a suitable constructor to create instance of {0}", typeof(T).Name));
+                throw new MissingMethodException($"Unable to find a suitable constructor to create instance of {typeof(T).Name}");
 
             var membersThatNeedToBeSet = GetMembersThatNeedToBeSet(table, typeof(T));
 
@@ -41,9 +39,7 @@ namespace TechTalk.SpecFlow.Assist
 
         internal static bool ThisTypeHasADefaultConstructor<T>()
         {
-            return typeof(T).GetConstructors()
-                       .Where(c => c.GetParameters().Length == 0)
-                       .Count() > 0;
+            return typeof(T).GetConstructors().Any(c => c.GetParameters().Length == 0);
         }
 
         internal static ConstructorInfo GetConstructorMatchingToColumnNames<T>(Table table)
@@ -54,9 +50,9 @@ namespace TechTalk.SpecFlow.Assist
                                          select property.Name;
 
             return (from constructor in typeof(T).GetConstructors()
-                    where projectedPropertyNames.Except(
+                    where !projectedPropertyNames.Except(
                         from parameter in constructor.GetParameters()
-                        select parameter.Name).Count() == 0
+                        select parameter.Name).Any()
                     select constructor).FirstOrDefault();
         }
 
@@ -151,12 +147,12 @@ namespace TechTalk.SpecFlow.Assist
         {
             if (TheHeaderIsTheOldFieldValuePair(table))
                 return true;
-            return (table.Rows.Count() != 1) || (table.Header.Count() == 2 && TheFirstRowValueIsTheNameOfAProperty(table, type));
+            return (table.Rows.Count() != 1) || (table.Header.Count == 2 && TheFirstRowValueIsTheNameOfAProperty(table, type));
         }
 
         private static bool TheHeaderIsTheOldFieldValuePair(Table table)
         {
-            return table.Header.Count() == 2 && table.Header.First() == "Field" && table.Header.Last() == "Value";
+            return table.Header.Count == 2 && table.Header.First() == "Field" && table.Header.Last() == "Value";
         }
 
         private static bool TheFirstRowValueIsTheNameOfAProperty(Table table, Type type)

--- a/Runtime/Assist/TableDiffExceptionBuilder.cs
+++ b/Runtime/Assist/TableDiffExceptionBuilder.cs
@@ -25,11 +25,11 @@ namespace TechTalk.SpecFlow.Assist
                 index++;
             }
 
-            foreach (var item in  tableDifferenceResults.ItemsInTheDataThatWereNotFoundInTheTable)
+            foreach (var item in tableDifferenceResults.ItemsInTheDataThatWereNotFoundInTheTable)
             {
                 var line = "+ |";
                 foreach (var header in tableDifferenceResults.Table.Header)
-                    line += string.Format(" {0} |", item.GetPropertyValue(header));
+                    line += $" {item.GetPropertyValue(header)} |";
                 realData.AppendLine(line);
             }
 

--- a/Runtime/Assist/TableDifferenceResults.cs
+++ b/Runtime/Assist/TableDifferenceResults.cs
@@ -4,30 +4,17 @@ namespace TechTalk.SpecFlow.Assist
 {
     public class TableDifferenceResults<TT>
     {
-        private readonly Table table;
-        private readonly IEnumerable<int> indexesOfTableRowsThatWereNotMatched;
-        private readonly IEnumerable<TT> itemsInTheDataThatWereNotFoundInTheTable;
-
         public TableDifferenceResults(Table table, IEnumerable<int> indexesOfTableRowsThatWereNotMatched, IEnumerable<TT> itemsInTheDataThatWereNotFoundInTheTable)
         {
-            this.table = table;
-            this.indexesOfTableRowsThatWereNotMatched = indexesOfTableRowsThatWereNotMatched;
-            this.itemsInTheDataThatWereNotFoundInTheTable = itemsInTheDataThatWereNotFoundInTheTable;
+            this.Table = table;
+            this.IndexesOfTableRowsThatWereNotMatched = indexesOfTableRowsThatWereNotMatched;
+            this.ItemsInTheDataThatWereNotFoundInTheTable = itemsInTheDataThatWereNotFoundInTheTable;
         }
 
-        public Table Table
-        {
-            get { return table; }
-        }
+        public Table Table { get; }
 
-        public IEnumerable<int> IndexesOfTableRowsThatWereNotMatched
-        {
-            get { return indexesOfTableRowsThatWereNotMatched; }
-        }
+        public IEnumerable<int> IndexesOfTableRowsThatWereNotMatched { get; }
 
-        public IEnumerable<TT> ItemsInTheDataThatWereNotFoundInTheTable
-        {
-            get { return itemsInTheDataThatWereNotFoundInTheTable; }
-        }
+        public IEnumerable<TT> ItemsInTheDataThatWereNotFoundInTheTable { get; }
     }
 }

--- a/Runtime/Assist/ValueComparers/BoolValueComparer.cs
+++ b/Runtime/Assist/ValueComparers/BoolValueComparer.cs
@@ -1,12 +1,10 @@
-﻿using System;
-
-namespace TechTalk.SpecFlow.Assist.ValueComparers
+﻿namespace TechTalk.SpecFlow.Assist.ValueComparers
 {
     public class BoolValueComparer : IValueComparer
     {
         public bool CanCompare(object actualValue)
         {
-            return actualValue != null && actualValue.GetType() == typeof (bool);
+            return actualValue is bool;
         }
 
         public bool Compare(string expectedValue, object actualValue)

--- a/Runtime/Assist/ValueComparers/DateTimeValueComparer.cs
+++ b/Runtime/Assist/ValueComparers/DateTimeValueComparer.cs
@@ -6,7 +6,7 @@ namespace TechTalk.SpecFlow.Assist.ValueComparers
     {
         public bool CanCompare(object actualValue)
         {
-            return actualValue != null && actualValue.GetType() == typeof (DateTime);
+            return actualValue is DateTime;
         }
 
         public bool Compare(string expectedValue, object actualValue)

--- a/Runtime/Assist/ValueComparers/DecimalValueComparer.cs
+++ b/Runtime/Assist/ValueComparers/DecimalValueComparer.cs
@@ -6,7 +6,7 @@ namespace TechTalk.SpecFlow.Assist.ValueComparers
     {
         public bool CanCompare(object actualValue)
         {
-            return actualValue != null && actualValue.GetType() == typeof (decimal);
+            return actualValue is decimal;
         }
 
         public bool Compare(string expectedValue, object actualValue)

--- a/Runtime/Assist/ValueComparers/DefaultValueComparer.cs
+++ b/Runtime/Assist/ValueComparers/DefaultValueComparer.cs
@@ -11,7 +11,7 @@ namespace TechTalk.SpecFlow.Assist.ValueComparers
 
         public bool Compare(string expectedValue, object actualValue)
         {
-            var actual = actualValue == null ? String.Empty : actualValue.ToString();
+            var actual = actualValue?.ToString() ?? String.Empty;
 
             return expectedValue == actual;
         }

--- a/Runtime/Assist/ValueComparers/DoubleValueComparer.cs
+++ b/Runtime/Assist/ValueComparers/DoubleValueComparer.cs
@@ -6,7 +6,7 @@ namespace TechTalk.SpecFlow.Assist.ValueComparers
     {
         public bool CanCompare(object actualValue)
         {
-            return actualValue != null && actualValue.GetType() == typeof (double);
+            return actualValue is double;
         }
 
         public bool Compare(string expectedValue, object actualValue)
@@ -14,7 +14,7 @@ namespace TechTalk.SpecFlow.Assist.ValueComparers
             Double expected;
             if (Double.TryParse(expectedValue, out expected) == false)
                 return false;
-            return expected == (double) actualValue;
+            return Math.Abs(expected - (double) actualValue) < double.Epsilon;
         }
     }
 }

--- a/Runtime/Assist/ValueComparers/FloatValueComparer.cs
+++ b/Runtime/Assist/ValueComparers/FloatValueComparer.cs
@@ -6,7 +6,7 @@ namespace TechTalk.SpecFlow.Assist.ValueComparers
     {
         public bool CanCompare(object actualValue)
         {
-            return actualValue != null && actualValue.GetType() == typeof (float);
+            return actualValue is float;
         }
 
         public bool Compare(string expectedValue, object actualValue)
@@ -14,7 +14,7 @@ namespace TechTalk.SpecFlow.Assist.ValueComparers
             float expected;
             if (float.TryParse(expectedValue, out expected) == false)
                 return false;
-            return expected == (float) actualValue;
+            return Math.Abs(expected - (float) actualValue) < float.Epsilon;
         }
     }
 }

--- a/Runtime/Assist/ValueComparers/GuidValueComparer.cs
+++ b/Runtime/Assist/ValueComparers/GuidValueComparer.cs
@@ -14,7 +14,7 @@ namespace TechTalk.SpecFlow.Assist.ValueComparers
 
         public bool CanCompare(object actualValue)
         {
-            return actualValue != null && actualValue.GetType() == typeof (Guid);
+            return actualValue is Guid;
         }
 
         public bool Compare(string expectedValue, object actualValue)

--- a/Runtime/Assist/ValueRetrievers/EnumValueRetriever.cs
+++ b/Runtime/Assist/ValueRetrievers/EnumValueRetriever.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Linq;
 using System.Collections.Generic;
 
 namespace TechTalk.SpecFlow.Assist.ValueRetrievers
@@ -46,7 +45,7 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
             }
             catch
             {
-                throw new InvalidOperationException(string.Format("No enum with value {0} found", value));
+                throw new InvalidOperationException($"No enum with value {value} found");
             }
         }
 
@@ -69,9 +68,6 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
             return value;
         }
 
-        private InvalidOperationException GetInvalidOperationException(string value)
-        {
-            return new InvalidOperationException(string.Format("No enum with value {0} found", value));
-        }
+        private InvalidOperationException GetInvalidOperationException(string value) => new InvalidOperationException($"No enum with value {value} found");
     }
 }

--- a/Runtime/Assist/ValueRetrievers/NullableTimeSpanValueRetriever.cs
+++ b/Runtime/Assist/ValueRetrievers/NullableTimeSpanValueRetriever.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 
 namespace TechTalk.SpecFlow.Assist.ValueRetrievers
 {

--- a/Runtime/Assist/ValueRetrievers/TimeSpanValueRetriever.cs
+++ b/Runtime/Assist/ValueRetrievers/TimeSpanValueRetriever.cs
@@ -17,7 +17,7 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
 
         public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type targetType, Type propertyType)
         {
-            return propertyType == typeof(System.TimeSpan);
+            return propertyType == typeof(TimeSpan);
         }
     }
 }


### PR DESCRIPTION
Resubmitted as a performance improvement.

- As discussed, rocknet's performance improvements are much larger (4500 seconds to 23 seconds), but it involves a semantic change.

- These changes still improve the performance significantly, from 50 seconds to 27 seconds, but without any semantic change as all differences are still reported in the comparison exception. Attached is the test code (zipped linqpad query)
[MeasureSetComparison.zip](https://github.com/techtalk/SpecFlow/files/245128/MeasureSetComparison.zip)
. Note that I should serialize the test case to a file for repeatably and do multiple runs of course. I did 4 runs; two with each version.

Original:
Finished comparison in 54925 ms.
Finished comparison in 48328 ms.

This branch:
Finished comparison in 26380 ms.
Finished comparison in 28246 ms.

As you recommended I pushed the ToArray() call into FindAnyDifferences(). I like that style better too.

Thanks!