### PR TITLE
Double-clicking test in test explorer takes to correct feature file line

### DIFF
--- a/Generator/UnitTestFeatureGenerator.cs
+++ b/Generator/UnitTestFeatureGenerator.cs
@@ -703,7 +703,7 @@ namespace TechTalk.SpecFlow.Generator
 
         private void AddLineDirective(CodeStatementCollection statements, Background background)
         {
-            AddLineDirective(statements, background.FilePosition);
+            AddLineDirective(statements, background.FilePosition, suppressLineStatement: true);
         }
 
         private void AddLineDirective(CodeStatementCollection statements, Scenario scenario)
@@ -716,12 +716,12 @@ namespace TechTalk.SpecFlow.Generator
             AddLineDirective(statements, step.FilePosition);
         }
 
-        private void AddLineDirective(CodeStatementCollection statements, FilePosition filePosition)
+        private void AddLineDirective(CodeStatementCollection statements, FilePosition filePosition, bool suppressLineStatement = false)
         {
             if (filePosition == null || generatorConfiguration.AllowDebugGeneratedFiles)
                 return;
 
-            codeDomHelper.AddSourceLinePragmaStatement(statements, filePosition.Line, filePosition.Column);
+            codeDomHelper.AddSourceLinePragmaStatement(statements, filePosition.Line, filePosition.Column, suppressLineStatement);
         }
 
         #endregion

--- a/IdeIntegration/Vs2013Integration/source.extension.vsixmanifest
+++ b/IdeIntegration/Vs2013Integration/source.extension.vsixmanifest
@@ -5,7 +5,7 @@
     <DisplayName>SpecFlow for Visual Studio 2013</DisplayName>
     <Description xml:space="preserve">SpecFlow integration for Visual Studio 2013. Sponsored by TechTalk (http://www.techtalk.at).</Description>
     <MoreInfo>http://www.specflow.org</MoreInfo>
-    <License>LICENSE.txt</License>
+    <License>Shared\LICENSE.txt</License>
     <GettingStartedGuide>http://go.specflow.org/getting-started</GettingStartedGuide>
     <ReleaseNotes>changelog.txt</ReleaseNotes>
     <Icon>specflowsetup.ico</Icon>

--- a/Utils/CodeDomHelper.cs
+++ b/Utils/CodeDomHelper.cs
@@ -90,7 +90,7 @@ namespace TechTalk.SpecFlow.Utils
             }
         }
 
-        public void AddSourceLinePragmaStatement(CodeStatementCollection statements, int lineNo, int colNo)
+        public void AddSourceLinePragmaStatement(CodeStatementCollection statements, int lineNo, int colNo, bool suppressLineStatement = false)
         {
             if (currentBoundSourceCodeFile == null)
                 throw new InvalidOperationException("The generated code was not bound to a file!");
@@ -100,12 +100,16 @@ namespace TechTalk.SpecFlow.Utils
                 case CodeDomProviderLanguage.VB:
                     if (isExternalSourceBlockOpen)
                         AddDisableSourceLinePragmaStatement(statements);
-                    statements.Add(new CodeSnippetStatement(string.Format("#ExternalSource(\"{0}\",{1})", currentBoundSourceCodeFile, lineNo)));
+                    if (!suppressLineStatement) {
+                        statements.Add(new CodeSnippetStatement(string.Format("#ExternalSource(\"{0}\",{1})", currentBoundSourceCodeFile, lineNo)));
+                    }
                     isExternalSourceBlockOpen = true;
                     AddCommentStatement(statements, string.Format("#indentnext {0}", colNo - 1));
                     break;
                 case CodeDomProviderLanguage.CSharp:
-                    statements.Add(new CodeSnippetStatement(string.Format("#line {0}", lineNo)));
+                    if (!suppressLineStatement) {
+                        statements.Add(new CodeSnippetStatement(string.Format("#line {0}", lineNo)));
+                    }
                     AddCommentStatement(statements, string.Format("#indentnext {0}", colNo - 1));
                     break;
             }


### PR DESCRIPTION
It was incorrectly taking to "Context" line at the beginning of file, due to pragma #line x before this.FeatureBackground();

Reported in issue #361 