### PR TITLE
Make tests run on vs2015 only machine

### DIFF
--- a/Tests/GeneratorTests/Data/sampleCsProjectfile.csproj
+++ b/Tests/GeneratorTests/Data/sampleCsProjectfile.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>

--- a/Tests/GeneratorTests/MsBuildProjectReaderTests.cs
+++ b/Tests/GeneratorTests/MsBuildProjectReaderTests.cs
@@ -11,7 +11,7 @@ namespace TechTalk.SpecFlow.GeneratorTests
     public class MsBuildProjectReaderTests
     {
         [Test]
-        public void Should_parse_csproj_file_correctly() 
+        public void Should_parse_csproj_file_correctly()
         {
             string text = Path.Combine(Directory.GetCurrentDirectory(), "Data\\sampleCsProjectfile.csproj");
             SpecFlowProject specflowProjectfile = MsBuildProjectReader.LoadSpecFlowProjectFromMsBuild(text);
@@ -32,7 +32,7 @@ namespace TechTalk.SpecFlow.GeneratorTests
             specflowProjectfile.Configuration.GeneratorConfiguration.AllowDebugGeneratedFiles.Should().BeFalse();
             specflowProjectfile.Configuration.GeneratorConfiguration.AllowRowTests.Should().BeTrue();
             specflowProjectfile.Configuration.GeneratorConfiguration.GeneratorUnitTestProvider.Should().Be("MSTest");
-            specflowProjectfile.Configuration.GeneratorConfiguration.FeatureLanguage.Name.Should().Be("en-US");            
+            specflowProjectfile.Configuration.GeneratorConfiguration.FeatureLanguage.Name.Should().Be("en-US");
         }
     }
 }

--- a/Tests/TechTalk.SpecFlow.Specs/Drivers/MsTestTestExecutionDriver.cs
+++ b/Tests/TechTalk.SpecFlow.Specs/Drivers/MsTestTestExecutionDriver.cs
@@ -20,7 +20,7 @@ namespace TechTalk.SpecFlow.Specs.Drivers
 
         public TestRunSummary Execute()
         {
-            string vsFolder = Environment.Is64BitProcess ? @"%ProgramFiles(x86)%\Microsoft Visual Studio 12.0\Common7\IDE" : @"%ProgramFiles%\Microsoft Visual Studio 12.0\Common7\IDE";
+            string vsFolder = Environment.Is64BitProcess ? @"%ProgramFiles(x86)%\Microsoft Visual Studio 14.0\Common7\IDE" : @"%ProgramFiles%\Microsoft Visual Studio 14.0\Common7\IDE";
             var nunitConsolePath = Path.Combine(AssemblyFolderHelper.GetTestAssemblyFolder(),
                 Environment.ExpandEnvironmentVariables(vsFolder + @"\MsTest.exe"));
 

--- a/Tests/TechTalk.SpecFlow.Specs/Drivers/MsTestTestExecutionDriver.cs
+++ b/Tests/TechTalk.SpecFlow.Specs/Drivers/MsTestTestExecutionDriver.cs
@@ -27,7 +27,7 @@ namespace TechTalk.SpecFlow.Specs.Drivers
             string resultsFilePath = Path.Combine(inputProjectDriver.DeploymentFolder, "mstest-result.trx");
 
             var provessHelper = new ProcessHelper();
-            provessHelper.RunProcess(nunitConsolePath, "\"/testcontainer:{0}\" \"/resultsfile:{1}\"", 
+            provessHelper.RunProcess(nunitConsolePath, "\"/testcontainer:{0}\" \"/resultsfile:{1}\"",
                 inputProjectDriver.CompiledAssemblyPath, resultsFilePath);
 
             XDocument logFile = XDocument.Load(resultsFilePath);


### PR DESCRIPTION
These changes *de facto* force people to use VS2015 when developing SpecFlow. Is that acceptable?

You can of course still use SpecFlow for BDD in all supported Visual Studio editions, not only VS2015.