### PR TITLE
Added functionality to allow the generated parameter names to be a bi…

### DIFF
--- a/Runtime/BindingSkeletons/ParameterNameExtensions.cs
+++ b/Runtime/BindingSkeletons/ParameterNameExtensions.cs
@@ -7,38 +7,6 @@ namespace TechTalk.SpecFlow.BindingSkeletons
 
     public static class ParameterNameExtensions
     {
-        public static bool IsSingleWordWithNoNumbers(this string value)
-        {
-            return Regex.IsMatch(value, @"^[a-zA-Z]+$");
-        }
-
-        public static bool IsSingleWordSurroundedByAngleBrackets(this string value)
-        {
-            if (value.StartsWith("<") && value.EndsWith(">"))
-            {
-                return value.Substring(1, value.Length - 2).IsSingleWordWithNoNumbers();
-            }
-            return false;
-        }
-
-        public static string WithoutSurroundingAngleBrackets(this string value)
-        {
-            return value.Substring(1, value.Length - 2);
-        }
-
-        public static string WithLowerCaseFirstLetter(this string value)
-        {
-            return value.Substring(0,1).ToLower() +  value.Substring(1);
-        }
-
-        public static string UniquelyIdentified(this string value, List<string> usedParameterNames, int parmIndex)
-        {
-            if (usedParameterNames.Contains(value))
-            {
-                return value + parmIndex;
-            }
-            usedParameterNames.Add(value);
-            return value;
-        }
+        
     }
 }

--- a/Runtime/BindingSkeletons/ParameterNameExtensions.cs
+++ b/Runtime/BindingSkeletons/ParameterNameExtensions.cs
@@ -1,0 +1,44 @@
+using System.Collections.Generic;
+using System.Text.RegularExpressions;
+
+namespace TechTalk.SpecFlow.BindingSkeletons
+{
+    using System.Linq;
+
+    public static class ParameterNameExtensions
+    {
+        public static bool IsSingleWordWithNoNumbers(this string value)
+        {
+            return Regex.IsMatch(value, @"^[a-zA-Z]+$");
+        }
+
+        public static bool IsSingleWordSurroundedByAngleBrackets(this string value)
+        {
+            if (value.StartsWith("<") && value.EndsWith(">"))
+            {
+                return value.Substring(1, value.Length - 2).IsSingleWordWithNoNumbers();
+            }
+            return false;
+        }
+
+        public static string WithoutSurroundingAngleBrackets(this string value)
+        {
+            return value.Substring(1, value.Length - 2);
+        }
+
+        public static string WithLowerCaseFirstLetter(this string value)
+        {
+            return value.Substring(0,1).ToLower() +  value.Substring(1);
+        }
+
+        public static string UniquelyIdentified(this string value, List<string> usedParameterNames, int parmIndex)
+        {
+            if (usedParameterNames.Contains(value))
+            {
+                return value + parmIndex;
+            }
+            usedParameterNames.Add(value);
+            return value;
+        }
+    }
+}

--- a/Runtime/BindingSkeletons/StepParameterNameGenerator.cs
+++ b/Runtime/BindingSkeletons/StepParameterNameGenerator.cs
@@ -2,15 +2,51 @@ using System.Collections.Generic;
 
 namespace TechTalk.SpecFlow.BindingSkeletons
 {
+    using System.Text.RegularExpressions;
+
     public class StepParameterNameGenerator
     {
         public static  string GenerateParameterName(string value,int paramIndex, List<string> usedParameterNames)
         {
-            if (value.IsSingleWordWithNoNumbers())
-                return value.WithLowerCaseFirstLetter().UniquelyIdentified(usedParameterNames,paramIndex);
-            if (value.IsSingleWordSurroundedByAngleBrackets())
-                return value.WithoutSurroundingAngleBrackets().WithLowerCaseFirstLetter().UniquelyIdentified(usedParameterNames, paramIndex);
+            if (IsSingleWordWithNoNumbers(value))
+                return UniquelyIdentified(LowerCaseFirstLetter(value),usedParameterNames,paramIndex);
+            if (IsSingleWordSurroundedByAngleBrackets(value))
+                return UniquelyIdentified(LowerCaseFirstLetter(RemoveSurroundingAngleBrackets(value)),usedParameterNames, paramIndex);
             return "p" + paramIndex;
+        }
+
+        public static bool IsSingleWordWithNoNumbers(string value)
+        {
+            return Regex.IsMatch(value, @"^[\p{L}]+$");
+        }
+
+        public static bool IsSingleWordSurroundedByAngleBrackets(string value)
+        {
+            if (value.StartsWith("<") && value.EndsWith(">"))
+            {
+                return IsSingleWordWithNoNumbers(value.Substring(1, value.Length - 2));
+            }
+            return false;
+        }
+
+        public static string RemoveSurroundingAngleBrackets(string value)
+        {
+            return value.Substring(1, value.Length - 2);
+        }
+
+        public static string LowerCaseFirstLetter(string value)
+        {
+            return value.Substring(0, 1).ToLower() + value.Substring(1);
+        }
+
+        public static string UniquelyIdentified(string value, List<string> usedParameterNames, int parmIndex)
+        {
+            if (usedParameterNames.Contains(value))
+            {
+                return value + parmIndex;
+            }
+            usedParameterNames.Add(value);
+            return value;
         }
     }
 }

--- a/Runtime/BindingSkeletons/StepParameterNameGenerator.cs
+++ b/Runtime/BindingSkeletons/StepParameterNameGenerator.cs
@@ -1,0 +1,16 @@
+using System.Collections.Generic;
+
+namespace TechTalk.SpecFlow.BindingSkeletons
+{
+    public class StepParameterNameGenerator
+    {
+        public static  string GenerateParameterName(string value,int paramIndex, List<string> usedParameterNames)
+        {
+            if (value.IsSingleWordWithNoNumbers())
+                return value.WithLowerCaseFirstLetter().UniquelyIdentified(usedParameterNames,paramIndex);
+            if (value.IsSingleWordSurroundedByAngleBrackets())
+                return value.WithoutSurroundingAngleBrackets().WithLowerCaseFirstLetter().UniquelyIdentified(usedParameterNames, paramIndex);
+            return "p" + paramIndex;
+        }
+    }
+}

--- a/Runtime/BindingSkeletons/StepTextAnalyzer.cs
+++ b/Runtime/BindingSkeletons/StepTextAnalyzer.cs
@@ -33,6 +33,7 @@ namespace TechTalk.SpecFlow.BindingSkeletons
 
     public class StepTextAnalyzer : IStepTextAnalyzer
     {
+        private List<string> usedParameterNames = new List<string>();
         public AnalyzedStepText Analyze(string stepText, CultureInfo bindingCulture)
         {
             var result = new AnalyzedStepText();
@@ -77,9 +78,9 @@ namespace TechTalk.SpecFlow.BindingSkeletons
             return result;
         }
 
-        private static AnalyzedStepParameter AnalyzeParameter(string value, CultureInfo bindingCulture, int paramIndex, string regexPattern)
+        private AnalyzedStepParameter AnalyzeParameter(string value, CultureInfo bindingCulture, int paramIndex, string regexPattern)
         {
-            string paramName = "p" + paramIndex;
+            string paramName = StepParameterNameGenerator.GenerateParameterName(value, paramIndex, usedParameterNames);
 
             int intParamValue;
             if (int.TryParse(value, NumberStyles.Integer, bindingCulture, out intParamValue))

--- a/Runtime/TechTalk.SpecFlow.csproj
+++ b/Runtime/TechTalk.SpecFlow.csproj
@@ -113,8 +113,10 @@
     <Compile Include="Assist\ValueRetrievers\UShortValueRetriever.cs" />
     <Compile Include="BindingSkeletons\FileBasedSkeletonTemplateProvider.cs" />
     <Compile Include="BindingSkeletons\ISkeletonTemplateProvider.cs" />
+    <Compile Include="BindingSkeletons\ParameterNameExtensions.cs" />
     <Compile Include="BindingSkeletons\StepDefinitionSkeletonProvider.cs" />
     <Compile Include="BindingSkeletons\StepDefinitionSkeletonStyle.cs" />
+    <Compile Include="BindingSkeletons\StepParameterNameGenerator.cs" />
     <Compile Include="BindingSkeletons\StepTextAnalyzer.cs" />
     <Compile Include="Bindings\HookType.cs" />
     <Compile Include="Bindings\BindingScope.cs" />

--- a/Tests/RuntimeTests/BindingSkeletons/StepTextAnalyzerTests.cs
+++ b/Tests/RuntimeTests/BindingSkeletons/StepTextAnalyzerTests.cs
@@ -32,6 +32,7 @@ namespace TechTalk.SpecFlow.RuntimeTests.BindingSkeletons
 
             var result = sut.Analyze("I \"do\" something", bindingCulture);
             result.Parameters.Count.Should().Be(1);
+            result.Parameters[0].Name.Should().Be("do");
             result.TextParts.Count.Should().Be(2);
             result.TextParts[0].Should().Be("I \"");
             result.TextParts[1].Should().Be("\" something");
@@ -44,6 +45,7 @@ namespace TechTalk.SpecFlow.RuntimeTests.BindingSkeletons
 
             var result = sut.Analyze("I 'do' something", bindingCulture);
             result.Parameters.Count.Should().Be(1);
+            result.Parameters[0].Name.Should().Be("do");
             result.TextParts.Count.Should().Be(2);
             result.TextParts[0].Should().Be("I '");
             result.TextParts[1].Should().Be("' something");
@@ -56,6 +58,7 @@ namespace TechTalk.SpecFlow.RuntimeTests.BindingSkeletons
 
             var result = sut.Analyze("I <do> something", bindingCulture);
             result.Parameters.Count.Should().Be(1);
+            result.Parameters[0].Name.Should().Be("do");
             result.TextParts.Count.Should().Be(2);
             result.TextParts[0].Should().Be("I ");
             result.TextParts[1].Should().Be(" something");
@@ -68,6 +71,7 @@ namespace TechTalk.SpecFlow.RuntimeTests.BindingSkeletons
 
             var result = sut.Analyze("I 'do \" something' really \" strange", bindingCulture);
             result.Parameters.Count.Should().Be(1);
+            result.Parameters[0].Name.Should().Be("p0");
             result.TextParts.Count.Should().Be(2);
             result.TextParts[0].Should().Be("I '");
             result.TextParts[1].Should().Be("' really \" strange");
@@ -92,6 +96,7 @@ namespace TechTalk.SpecFlow.RuntimeTests.BindingSkeletons
 
             var result = sut.Analyze("I have 42 bars", bindingCulture);
             result.Parameters.Count.Should().Be(1);
+            result.Parameters[0].Name.Should().Be("p0");
             result.TextParts.Count.Should().Be(2);
             result.TextParts[0].Should().Be("I have ");
             result.TextParts[1].Should().Be(" bars");
@@ -105,10 +110,94 @@ namespace TechTalk.SpecFlow.RuntimeTests.BindingSkeletons
 
             var result = sut.Analyze("I have 4.2 bars", bindingCulture);
             result.Parameters.Count.Should().Be(1);
+            result.Parameters[0].Name.Should().Be("p0");
             result.TextParts.Count.Should().Be(2);
             result.TextParts[0].Should().Be("I have ");
             result.TextParts[1].Should().Be(" bars");
             result.Parameters[0].Type.Should().Be("Decimal");
+        }
+
+        [Test]
+        public void Should_recognize_quoted_strings_with_multiple_parameters()
+        {
+            var sut = new StepTextAnalyzer();
+
+            var result = sut.Analyze("I \"do\" something with \"multiple\" parameters", bindingCulture);
+            result.Parameters.Count.Should().Be(2);
+            result.Parameters[0].Name.Should().Be("do");
+            result.Parameters[1].Name.Should().Be("multiple");
+            result.TextParts.Count.Should().Be(3);
+            result.TextParts[0].Should().Be("I \"");
+            result.TextParts[1].Should().Be("\" something with \"");
+            result.TextParts[2].Should().Be("\" parameters");
+        }
+
+        [Test]
+        public void Should_not_use_smart_parameter_names_when_they_contain_spaces()
+        {
+            var sut = new StepTextAnalyzer();
+
+            var result = sut.Analyze("I \"do spaced parameter\" something", bindingCulture);
+            result.Parameters.Count.Should().Be(1);
+            result.Parameters[0].Name.Should().Be("p0");
+        }
+
+        [Test]
+        public void Should_not_use_smart_parameter_names_when_they_contain_non_alphabet_characters()
+        {
+            var sut = new StepTextAnalyzer();
+
+            var result = sut.Analyze("I \"do?\" something", bindingCulture);
+            result.Parameters.Count.Should().Be(1);
+            result.Parameters[0].Name.Should().Be("p0");
+        }
+
+        [Test]
+        public void Should_not_use_smart_parameter_names_when_they_contain_numeric_characters()
+        {
+            var sut = new StepTextAnalyzer();
+
+            var result = sut.Analyze("I \"do1\" something", bindingCulture);
+            result.Parameters.Count.Should().Be(1);
+            result.Parameters[0].Name.Should().Be("p0");
+        }
+
+        [Test]
+        public void Should_not_use_same_parameter_names_when_they_appear_multiple_times()
+        {
+            var sut = new StepTextAnalyzer();
+
+            var result = sut.Analyze("I \"do\" something and \"do\" something else", bindingCulture);
+            result.Parameters.Count.Should().Be(2);
+            result.Parameters[0].Name.Should().Be("do");
+            result.Parameters[1].Name.Should().Be("do1");
+        }
+
+        [Test]
+        public void Should_use_the_correct_param_index_when_they_appear_multiple_times()
+        {
+            var sut = new StepTextAnalyzer();
+
+            var result = sut.Analyze("I \"do\" something \"and\" then \"do\" something else", bindingCulture);
+            result.Parameters.Count.Should().Be(3);
+            result.Parameters[0].Name.Should().Be("do");
+            result.Parameters[1].Name.Should().Be("and");
+            result.Parameters[2].Name.Should().Be("do2");
+        }
+
+        [Test]
+        public void Should_correctly_case_parameter_names()
+        {
+            var sut = new StepTextAnalyzer();
+
+            var result = sut.Analyze("I \"Do\" something with \"MUlTiPLe\" parameters", bindingCulture);
+            result.Parameters.Count.Should().Be(2);
+            result.Parameters[0].Name.Should().Be("do");
+            result.Parameters[1].Name.Should().Be("mUlTiPLe");
+            result.TextParts.Count.Should().Be(3);
+            result.TextParts[0].Should().Be("I \"");
+            result.TextParts[1].Should().Be("\" something with \"");
+            result.TextParts[2].Should().Be("\" parameters");
         }
     }
 }

--- a/Tests/RuntimeTests/BindingSkeletons/StepTextAnalyzerTests.cs
+++ b/Tests/RuntimeTests/BindingSkeletons/StepTextAnalyzerTests.cs
@@ -199,5 +199,18 @@ namespace TechTalk.SpecFlow.RuntimeTests.BindingSkeletons
             result.TextParts[1].Should().Be("\" something with \"");
             result.TextParts[2].Should().Be("\" parameters");
         }
+
+        [Test]
+        public void Should_support_accented_characters()
+        {
+            var sut = new StepTextAnalyzer();
+
+            var result = sut.Analyze("I \"dö\" something ", bindingCulture);
+            result.Parameters.Count.Should().Be(1);
+            result.Parameters[0].Name.Should().Be("dö");
+            result.TextParts.Count.Should().Be(2);
+            result.TextParts[0].Should().Be("I \"");
+            result.TextParts[1].Should().Be("\" something ");
+        }
     }
 }

--- a/changelog.txt
+++ b/changelog.txt
@@ -7,6 +7,7 @@ New Features:
 Smaller Improvements/fixes:
 + Update reports to use latest parser
 + Allow customizing binding class resolution with IBindingInstanceResolver
++ Added support for generating better argument names in step methods.
 
 
 2.1.0-preview20160412-* - 2016/04/12


### PR DESCRIPTION
…t better that the p0 p1 that currently exists

This PR addresses the feature request https://github.com/techtalk/SpecFlow/issues/587 and allows the generated argument names to be the same or similar to the parameter names in scenario steps. 

generated names will only be used if the scenario step parameter is a single word (ie no spaces) which contains only letter (no numbers or punctuation) and handles the case where multiple parameters which are the same are used. If these conditions are not met then the traditional 'p0' 'p1' parameters will be used.