### PR TITLE
[Discussion] Enable *Context.Current in multi thread execution

### DIFF
--- a/Runtime/FeatureContext.cs
+++ b/Runtime/FeatureContext.cs
@@ -1,9 +1,9 @@
 using System.Diagnostics;
 using System.Globalization;
+using System.Reflection;
 #if SILVERLIGHT
 using TechTalk.SpecFlow.Compatibility;
 #endif
-using System.Threading;
 
 namespace TechTalk.SpecFlow
 {
@@ -19,33 +19,8 @@ namespace TechTalk.SpecFlow
         }
 
         #region Singleton
-        private static bool isCurrentDisabled = false;
-        private static FeatureContext current;
-        public static FeatureContext Current
-        {
-            get
-            {
-                if (isCurrentDisabled)
-                    throw new SpecFlowException("The FeatureContext.Current static accessor cannot be used in multi-threaded execution. Try injecting the feature context to the binding class. See http://go.specflow.org/doc-multithreaded for details.");
-                if (current == null)
-                {
-                    Debug.WriteLine("Accessing NULL FeatureContext");
-                }
-                return current;
-            }
-            internal set
-            {
-                if (!isCurrentDisabled)
-                    current = value;
-            }
-        }
+        public static FeatureContext Current => TestRunnerManager.GetTestRunner(Assembly.GetCallingAssembly()).FeatureContext;
 
-        internal static void DisableSingletonInstance()
-        {
-            isCurrentDisabled = true;
-            Thread.MemoryBarrier();
-            current = null;
-        }
         #endregion
 
         public FeatureInfo FeatureInfo { get; private set; }

--- a/Runtime/Infrastructure/IContextManager.cs
+++ b/Runtime/Infrastructure/IContextManager.cs
@@ -172,7 +172,6 @@ namespace TechTalk.SpecFlow.Infrastructure
         {
             var newContext = new FeatureContext(featureInfo, bindingCulture);
             featureContextManager.Init(newContext);
-            FeatureContext.Current = newContext;
         }
 
         public void CleanupFeatureContext()
@@ -185,7 +184,6 @@ namespace TechTalk.SpecFlow.Infrastructure
             var scenarioContainer = containerBuilder.CreateScenarioContainer(testThreadContainer, scenarioInfo);
             var newContext = scenarioContainer.Resolve<ScenarioContext>();
             scenarioContextManager.Init(newContext);
-            ScenarioContext.Current = newContext;
         }
 
         public void CleanupScenarioContext()
@@ -197,13 +195,11 @@ namespace TechTalk.SpecFlow.Infrastructure
         {
             var newContext = new ScenarioStepContext(stepInfo);
             stepContextManager.Init(newContext);
-            ScenarioStepContext.Current = newContext;
         }
 
         public void CleanupStepContext()
         {
             stepContextManager.Cleanup();
-            ScenarioStepContext.Current = stepContextManager.Instance;
         }
 
         public void Dispose()

--- a/Runtime/ScenarioContext.cs
+++ b/Runtime/ScenarioContext.cs
@@ -2,6 +2,8 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using BoDi;
 using TechTalk.SpecFlow.Bindings;
@@ -16,33 +18,10 @@ namespace TechTalk.SpecFlow
     public class ScenarioContext : SpecFlowContext
     {
         #region Singleton
-        private static bool isCurrentDisabled = false;
-        private static ScenarioContext current;
-        public static ScenarioContext Current
-        {
-            get
-            {
-                if (isCurrentDisabled)
-                    throw new SpecFlowException("The ScenarioContext.Current static accessor cannot be used in multi-threaded execution. Try injecting the scenario context to the binding class. See http://go.specflow.org/doc-multithreaded for details.");
-                if (current == null)
-                {
-                    Debug.WriteLine("Accessing NULL ScenarioContext");
-                }
-                return current;
-            }
-            internal set
-            {
-                if (!isCurrentDisabled)
-                    current = value;
-            }
-        }
 
-        internal static void DisableSingletonInstance()
-        {
-            isCurrentDisabled = true;
-            Thread.MemoryBarrier();
-            current = null;
-        }
+        public static ScenarioContext Current => TestRunnerManager.GetTestRunner(Assembly.GetCallingAssembly()).ScenarioContext;
+
+     
         #endregion
 
         public ScenarioInfo ScenarioInfo { get; private set; }

--- a/Runtime/ScenarioStepContext.cs
+++ b/Runtime/ScenarioStepContext.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Diagnostics;
+using System.Reflection;
 using System.Threading;
 
 namespace TechTalk.SpecFlow
@@ -7,33 +8,8 @@ namespace TechTalk.SpecFlow
     public class ScenarioStepContext : SpecFlowContext
     {
         #region Singleton
-        private static bool isCurrentDisabled = false;
-        private static ScenarioStepContext current;
-        public static ScenarioStepContext Current
-        {
-            get
-            {
-                if (isCurrentDisabled)
-                    throw new SpecFlowException("The ScenarioStepContext.Current static accessor cannot be used in multi-threaded execution. Try injecting the scenario context to the binding class. See http://go.specflow.org/doc-multithreaded for details.");
-                if (current == null)
-                {
-                    Debug.WriteLine("Accessing NULL ScenarioStepContext");
-                }
-                return current;
-            }
-            internal set
-            {
-                if (!isCurrentDisabled)
-                    current = value;
-            }
-        }
+        public static ScenarioStepContext Current => TestRunnerManager.GetTestRunner(Assembly.GetCallingAssembly()).ScenarioContext.StepContext;
 
-        internal static void DisableSingletonInstance()
-        {
-            isCurrentDisabled = true;
-            Thread.MemoryBarrier();
-            current = null;
-        }
         #endregion
 
         public StepInfo StepInfo { get; private set; }

--- a/Runtime/TestRunnerManager.cs
+++ b/Runtime/TestRunnerManager.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using BoDi;
 using TechTalk.SpecFlow.Bindings.Discovery;
@@ -122,14 +123,7 @@ namespace TechTalk.SpecFlow
                     if (!testRunnerRegistry.TryGetValue(threadId, out testRunner))
                     {
                         testRunner = CreateTestRunner(threadId);
-                        testRunnerRegistry.Add(threadId, testRunner);
-
-                        if (IsMultiThreaded)
-                        {
-                            FeatureContext.DisableSingletonInstance();
-                            ScenarioContext.DisableSingletonInstance();
-                            ScenarioStepContext.DisableSingletonInstance();
-                        }
+                        testRunnerRegistry.Add(threadId, testRunner);                        
                     }
                 }
             }
@@ -174,6 +168,7 @@ namespace TechTalk.SpecFlow
             return testRunnerManager;
         }
 
+        [MethodImpl(MethodImplOptions.NoInlining)] //potential problem when getting inlined because of Assembly.GetCallingAssembly() - http://www.ticklishtechs.net/2010/03/04/be-careful-when-using-getcallingassembly-and-always-use-the-release-build-for-testing/
         public static ITestRunner GetTestRunner(Assembly testAssembly = null, int? managedThreadId = null)
         {
             testAssembly = testAssembly ?? Assembly.GetCallingAssembly();

--- a/Tests/TechTalk.SpecFlow.Specs/Features/InAppDomainParallelExecution.feature
+++ b/Tests/TechTalk.SpecFlow.Specs/Features/InAppDomainParallelExecution.feature
@@ -152,31 +152,3 @@ Scenario: TraceListener should be called synchronously
 		| Total | Succeeded |
 		| 25    | 25        |
 
-
-Scenario Outline: Current context cannot be used in multi-threaded execution
-	Given there is a feature file in the project as
-		"""
-		Feature: Feature with <context>.Current
-		Scenario: Simple Scenario
-	      When I use <context>.Current
-		"""
-	And the following step definition
-         """
-         [When(@"I use <context>.Current")]
-		 public void WhenIUseContextCurrent()
-		 {
-            System.Threading.Thread.Sleep(200);
-            Console.WriteLine(<context>.Current);
-		 }
-         """
-    When I execute the tests with NUnit
-    Then the execution log should contain text 'Was parallel'
-	And the execution summary should contain
-		| Failed |
-		| 1      |
-
-Examples: 
-    | context             |
-    | ScenarioContext     |
-    | FeatureContext      |
-    | ScenarioStepContext |

--- a/Tests/TechTalk.SpecFlow.Specs/Features/InAppDomainParallelExecution.feature.cs
+++ b/Tests/TechTalk.SpecFlow.Specs/Features/InAppDomainParallelExecution.feature.cs
@@ -254,57 +254,6 @@ this.FeatureBackground();
 #line hidden
             this.ScenarioCleanup();
         }
-        
-        public virtual void CurrentContextCannotBeUsedInMulti_ThreadedExecution(string context, string[] exampleTags)
-        {
-            TechTalk.SpecFlow.ScenarioInfo scenarioInfo = new TechTalk.SpecFlow.ScenarioInfo("Current context cannot be used in multi-threaded execution", exampleTags);
-#line 156
-this.ScenarioSetup(scenarioInfo);
-#line 3
-this.FeatureBackground();
-#line hidden
-#line 157
- testRunner.Given("there is a feature file in the project as", string.Format("Feature: Feature with {0}.Current\nScenario: Simple Scenario\n     When I use {0}.C" +
-                        "urrent", context), ((TechTalk.SpecFlow.Table)(null)), "Given ");
-#line hidden
-#line 163
- testRunner.And("the following step definition", string.Format("[When(@\"I use {0}.Current\")]\npublic void WhenIUseContextCurrent()\n{{\n   System.Th" +
-                        "reading.Thread.Sleep(200);\n   Console.WriteLine({0}.Current);\r\n}}", context), ((TechTalk.SpecFlow.Table)(null)), "And ");
-#line 172
-    testRunner.When("I execute the tests with NUnit", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
-#line 173
-    testRunner.Then("the execution log should contain text \'Was parallel\'", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
-#line hidden
-            TechTalk.SpecFlow.Table table3 = new TechTalk.SpecFlow.Table(new string[] {
-                        "Failed"});
-            table3.AddRow(new string[] {
-                        "1"});
-#line 174
- testRunner.And("the execution summary should contain", ((string)(null)), table3, "And ");
-#line hidden
-            this.ScenarioCleanup();
-        }
-        
-        [NUnit.Framework.TestAttribute()]
-        [NUnit.Framework.DescriptionAttribute("Current context cannot be used in multi-threaded execution")]
-        public virtual void CurrentContextCannotBeUsedInMulti_ThreadedExecution_ScenarioContext()
-        {
-            this.CurrentContextCannotBeUsedInMulti_ThreadedExecution("ScenarioContext", ((string[])(null)));
-        }
-        
-        [NUnit.Framework.TestAttribute()]
-        [NUnit.Framework.DescriptionAttribute("Current context cannot be used in multi-threaded execution")]
-        public virtual void CurrentContextCannotBeUsedInMulti_ThreadedExecution_FeatureContext()
-        {
-            this.CurrentContextCannotBeUsedInMulti_ThreadedExecution("FeatureContext", ((string[])(null)));
-        }
-        
-        [NUnit.Framework.TestAttribute()]
-        [NUnit.Framework.DescriptionAttribute("Current context cannot be used in multi-threaded execution")]
-        public virtual void CurrentContextCannotBeUsedInMulti_ThreadedExecution_ScenarioStepContext()
-        {
-            this.CurrentContextCannotBeUsedInMulti_ThreadedExecution("ScenarioStepContext", ((string[])(null)));
-        }
     }
 }
 #pragma warning restore


### PR DESCRIPTION
This enables Scenario/Feature/ScenarioStep- Context.Current in multithreaded execution.

Currently it has the limitation, that it only works when you use it in the test assembly (the one with the features).
The reason is, that the TestRunnerManager is registered with test assembly as key in the testRunnerManagerRegistry. This is, because Assembly.GetCallingAssembly() in TestRunnerManager.GetTestRunner(...) is called in FeatureSetup of the Code-Behind-Class in the feature file.

*Context.Current is now implemented, that it tries to get the testRunner also with Assembly.GetCallingAssembly().

The only idea I have currently to solve this is, to look at the CallStack (new StackTrace().GetFrames) and search the test assembly in it.
Does somebody have a better idea? @samholder @darrencauthon @dirkrombauts @gasparnagy 
