### PR TITLE
Parse Enums consistently for step arguments and tables

### DIFF
--- a/Runtime/Bindings/StepArgumentTypeConverter.cs
+++ b/Runtime/Bindings/StepArgumentTypeConverter.cs
@@ -112,7 +112,7 @@ namespace TechTalk.SpecFlow.Bindings
         private static object ConvertSimple(Type typeToConvertTo, object value, CultureInfo cultureInfo)
         {
             if (typeToConvertTo.IsEnum && value is string)
-                return Enum.Parse(typeToConvertTo, (string)value, true);
+                return Enum.Parse(typeToConvertTo, RemoveWhitespace((string) value), true);
 
             if (typeToConvertTo == typeof(Guid?) && string.IsNullOrEmpty(value as string))
                 return null;
@@ -121,6 +121,11 @@ namespace TechTalk.SpecFlow.Bindings
                 return new GuidValueRetriever().GetValue(value as string);
 
             return System.Convert.ChangeType(value, typeToConvertTo, cultureInfo);
+        }
+
+        private static string RemoveWhitespace(string value)
+        {
+            return value.Replace(" ", string.Empty);
         }
 
         public static bool CanConvertSimple(IBindingType typeToConvertTo, object value, CultureInfo cultureInfo)

--- a/Tests/RuntimeTests/StepArgumentTypeConverterTest.cs
+++ b/Tests/RuntimeTests/StepArgumentTypeConverterTest.cs
@@ -75,6 +75,13 @@ namespace TechTalk.SpecFlow.RuntimeTests
         }
 
         [Test]
+        public void ShouldConvertStringToEnumerationTypeWithWhitespace()
+        {
+            var result = _stepArgumentTypeConverter.Convert("Value 1", typeof(TestEnumeration), _enUSCulture);
+            Assert.That(result, Is.EqualTo(TestEnumeration.Value1));
+        }
+
+        [Test]
         public void ShouldConvertGuidToGuidType()
         {
             var result = _stepArgumentTypeConverter.Convert("{EF338B79-FD29-488F-8CA7-39C67C2B8874}", typeof (Guid), _enUSCulture);


### PR DESCRIPTION
Make sure StepArgumentTypeConverter and EnumValueRetriever (for tables) parse Enums the same way (both now remove whitespaces from string input).