### PR TITLE
Initial implementation of folder based generator

### DIFF
--- a/TechTalk.SpecFlow.Generator/Project/DirectoryProjectReader.cs
+++ b/TechTalk.SpecFlow.Generator/Project/DirectoryProjectReader.cs
@@ -1,0 +1,92 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using Newtonsoft.Json;
+using TechTalk.SpecFlow.Generator.Configuration;
+using TechTalk.SpecFlow.Generator.Interfaces;
+
+namespace TechTalk.SpecFlow.Generator.Project
+{
+    public class DirectoryProjectReader
+    {
+        public static SpecFlowProject LoadSpecFlowProject(string directoryName)
+        {
+            var settings = TryLoadSpecflowSettings(directoryName);
+            var projectFolder = new DirectoryInfo(directoryName);
+
+            //TODO: Need a cleaner way to express this.
+            var featureLanguage = settings.ContainsKey("featureLanguage") ? CultureInfo.GetCultureInfo(settings["featureLanguage"].ToString()) : CultureInfo.GetCultureInfo("en-us");
+            var toolLanguage = settings.ContainsKey("toolLanguage") ? CultureInfo.GetCultureInfo(settings["toolLanguage"].ToString()) : CultureInfo.GetCultureInfo("en-us");
+            var generatorUnitTestProvider = settings.ContainsKey("unittestProvider") ? settings["unittestProvider"].ToString() : "xUnit";
+            var defaultNamespace = settings.ContainsKey("defaultNamespace") ? settings["defaultNamespace"].ToString() : projectFolder.Name;
+
+            var project = new SpecFlowProject()
+            {
+                Configuration = new SpecFlowProjectConfiguration()
+                {
+                    GeneratorConfiguration = new GeneratorConfiguration()
+                    {
+                        FeatureLanguage = featureLanguage,
+                        GeneratorUnitTestProvider = generatorUnitTestProvider,
+                        ToolLanguage = toolLanguage,
+                        AllowDebugGeneratedFiles = true,
+                        AllowRowTests = true
+                    }
+                },
+                ProjectSettings = new ProjectSettings()
+                {
+                    ProjectFolder = directoryName,
+                    ProjectName = projectFolder.Name,
+                    AssemblyName = projectFolder.Name,
+                    DefaultNamespace = defaultNamespace,
+
+                    //TODO: plugins aren't supported because the XML is ignored.
+                    ConfigurationHolder = new SpecFlowConfigurationHolder(string.Empty)
+                }
+            };
+
+            var files = projectFolder.GetFiles("*.feature", SearchOption.AllDirectories);
+
+            foreach (var file in files)
+            {
+                project.FeatureFiles.Add(new FeatureFileInput(RelativeFilePath(projectFolder.FullName, file.FullName)));
+            }
+
+            return project;
+        }
+
+        private static string RelativeFilePath(string rootFolder, string filePath)
+        {
+            string fullFilePath = Path.GetFullPath(filePath);
+            string fullFolderPath = Path.GetFullPath(rootFolder);
+
+            if (!fullFilePath.StartsWith(fullFolderPath))
+            {
+                return fullFilePath;
+            }
+
+            string relativePath = fullFilePath.Substring(fullFolderPath.Length);
+
+            if (relativePath[0] == Path.DirectorySeparatorChar)
+            {
+                relativePath = relativePath.Substring(1);
+            }
+
+            return relativePath;
+        }
+        
+        private static Dictionary<string, object> TryLoadSpecflowSettings(string directoryName)
+        {
+            var configurationFileName = Path.Combine(directoryName, "specflow.json");
+
+            if (File.Exists(configurationFileName))
+            {
+                return JsonConvert.DeserializeObject<Dictionary<string, object>>(
+                    File.ReadAllText(configurationFileName));
+            }
+
+            return new Dictionary<string, object>();
+        }
+    }
+}

--- a/TechTalk.SpecFlow.Generator/project.json
+++ b/TechTalk.SpecFlow.Generator/project.json
@@ -1,15 +1,16 @@
-﻿{
+{
   "version": "1.0.0-*",
     "buildOptions": {
         "outputName": "TechTalk.SpecFlow.Generator",
         "keyFile": "../specflow.snk"
     },
-    "dependencies": {
-        "Gherkin": "4.0.0",
-        "TechTalk.SpecFlow": "*",
-        "TechTalk.SpecFlow.Parser": "*",
-        "TechTalk.SpecFlow.Utils": "*"
-    },
+  "dependencies": {
+    "Gherkin": "4.0.0",
+    "Newtonsoft.Json": "9.0.1",
+    "TechTalk.SpecFlow": "*",
+    "TechTalk.SpecFlow.Parser": "*",
+    "TechTalk.SpecFlow.Utils": "*"
+  },
 
     "frameworks": {
         "net45": {

--- a/TechTalk.SpecFlow.Tools/Program.cs
+++ b/TechTalk.SpecFlow.Tools/Program.cs
@@ -25,7 +25,7 @@ namespace TechTalk.SpecFlow.Tools
 
         [Action("Generate tests from all feature files in a project")]
         public static void GenerateAll(
-            [Required(Description = "Visual Studio Project File containing features")] string projectFile,
+            [Required(Description = "Directory containing the project files")] string directoryName,
             [Optional(false, "force", "f")] bool forceGeneration,
             [Optional(false, "verbose", "v")] bool verboseOutput,
             [Optional(false, "debug", Description = "Used for tool integration")] bool requestDebuggerToAttach)
@@ -33,7 +33,7 @@ namespace TechTalk.SpecFlow.Tools
             if (requestDebuggerToAttach)
                 Debugger.Launch();
 
-            SpecFlowProject specFlowProject = MsBuildProjectReader.LoadSpecFlowProjectFromMsBuild(Path.GetFullPath(projectFile));
+            SpecFlowProject specFlowProject = DirectoryProjectReader.LoadSpecFlowProject(Path.GetFullPath(directoryName));
             ITraceListener traceListener = verboseOutput ? (ITraceListener)new TextWriterTraceListener(Console.Out) : new NullListener();
             var batchGenerator = new BatchGenerator(traceListener, new TestGeneratorFactory());
 

--- a/TechTalk.SpecFlow.Tools/project.json
+++ b/TechTalk.SpecFlow.Tools/project.json
@@ -1,7 +1,7 @@
 ﻿{
   "version": "1.0.0-*",
     "buildOptions": {
-        "outputName": "specflow",
+        "outputName": "dotnet-specflow",
         "emitEntryPoint": true,
         "keyFile": "../specflow.snk",
         "platform": "x86"


### PR DESCRIPTION
Since .NET Core uses directories as a container for projects rather than a
csproj file the generator needed some fixing. It now supports the basics
for generating feature files in a folder.

You can use specflow.json to configure some settings. If you don't have it
in the directory the tool will assume that you want to use the defaults.