### PR TITLE
Add global namespace alais to FeatureSetup call

### DIFF
--- a/TechTalk.SpecFlow.Generator/UnitTestProvider/MsTestGeneratorProvider.cs
+++ b/TechTalk.SpecFlow.Generator/UnitTestProvider/MsTestGeneratorProvider.cs
@@ -113,8 +113,9 @@ namespace TechTalk.SpecFlow.Generator.UnitTestProvider
                     new CodeExpressionStatement(
                         new CodeMethodInvokeExpression(
                             new CodeTypeReferenceExpression(
-                                generationContext.Namespace.Name + "." + generationContext.TestClass.Name
-                                ),
+                                new CodeTypeReference(
+                                    generationContext.Namespace.Name + "." + generationContext.TestClass.Name, 
+                                    CodeTypeReferenceOptions.GlobalReference)),
                             generationContext.TestClassInitializeMethod.Name,
                             new CodePrimitiveExpression(null)))));
         }


### PR DESCRIPTION
Fix for issue #333 Generated code fails to compile if there is a name
collision between a namespace and a class