### PR TITLE
This resolves #638. This adds support for allowing disabling the para…

### DIFF
--- a/TechTalk.SpecFlow/EnvironmentVariableNames.cs
+++ b/TechTalk.SpecFlow/EnvironmentVariableNames.cs
@@ -1,0 +1,8 @@
+namespace TechTalk.SpecFlow
+{
+    public class EnvironmentVariableNames
+    {
+        public const string NCrunch = "NCrunch";
+        public const string SpecflowDisableParallelExecution = "SPECFLOW_DISABLE_PARALLEL";
+    }
+}

--- a/TechTalk.SpecFlow/TechTalk.SpecFlow.csproj
+++ b/TechTalk.SpecFlow/TechTalk.SpecFlow.csproj
@@ -156,6 +156,7 @@
     <Compile Include="Bindings\MethodBinding.cs" />
     <Compile Include="Bindings\StepDefinitionRegexCalculator.cs" />
     <Compile Include="BoDi\BoDi.cs" />
+    <Compile Include="EnvironmentVariableNames.cs" />
     <Compile Include="Infrastructure\BindingInstanceResolver.cs" />
     <Compile Include="Infrastructure\ContextManager.cs" />
     <Compile Include="Infrastructure\ContextManagerExtensions.cs" />

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/RuntimeTests.csproj
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/RuntimeTests.csproj
@@ -165,6 +165,7 @@
     <Compile Include="Infrastructure\TestExecutionEngineTests.cs" />
     <Compile Include="Infrastructure\TestRunContainerBuilderTests.cs" />
     <Compile Include="ScenarioContextExtensions.cs" />
+    <Compile Include="TestEnvironmentHelper.cs" />
     <Compile Include="TestRunnerManagerRunnerCreationTests.cs" />
     <Compile Include="ScenarioStepContextTests.cs" />
     <Compile Include="StepsTest.cs" />

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/TestEnvironmentHelper.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/TestEnvironmentHelper.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace TechTalk.SpecFlow.RuntimeTests
+{
+    public class TestEnvironmentHelper
+    {
+        public static bool IsBeingRunByNCrunch()
+        {
+            return !string.IsNullOrEmpty(Environment.GetEnvironmentVariable(EnvironmentVariableNames.NCrunch));
+        }
+    }
+}

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/TestRunnerManagerRunnerCreationTests.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/TestRunnerManagerRunnerCreationTests.cs
@@ -81,20 +81,29 @@ namespace TechTalk.SpecFlow.RuntimeTests
             testRunnerFake.Verify(tr => tr.OnTestRunStart());
         }
 
+
         [Test]
         public void Should_resolve_a_test_runner_specific_test_tracer()
         {
-            var testRunner1 = TestRunnerManager.GetTestRunner(anAssembly, 0);
-            testRunner1.OnFeatureStart(new FeatureInfo(new CultureInfo("en-US"), "sds", "sss"));
-            testRunner1.OnScenarioStart(new ScenarioInfo("foo"));
-            var tracer1 = testRunner1.ScenarioContext.ScenarioContainer.Resolve<ITestTracer>();
+            //This test can't run in NCrunch as when NCrunch runs the tests it will disable the ability to get different test runners for each thread 
+            //as it manages the parallelisation 
+            //see https://github.com/techtalk/SpecFlow/issues/638
+            if (!TestEnvironmentHelper.IsBeingRunByNCrunch())
+            {
+                var testRunner1 = TestRunnerManager.GetTestRunner(anAssembly, 0);
+                testRunner1.OnFeatureStart(new FeatureInfo(new CultureInfo("en-US"), "sds", "sss"));
+                testRunner1.OnScenarioStart(new ScenarioInfo("foo"));
+                var tracer1 = testRunner1.ScenarioContext.ScenarioContainer.Resolve<ITestTracer>();
 
-            var testRunner2 = TestRunnerManager.GetTestRunner(anAssembly, 1);
-            testRunner2.OnFeatureStart(new FeatureInfo(new CultureInfo("en-US"), "sds", "sss"));
-            testRunner2.OnScenarioStart(new ScenarioInfo("foo"));
-            var tracer2 = testRunner2.ScenarioContext.ScenarioContainer.Resolve<ITestTracer>();
+                var testRunner2 = TestRunnerManager.GetTestRunner(anAssembly, 1);
+                testRunner2.OnFeatureStart(new FeatureInfo(new CultureInfo("en-US"), "sds", "sss"));
+                testRunner2.OnScenarioStart(new ScenarioInfo("foo"));
+                var tracer2 = testRunner2.ScenarioContext.ScenarioContainer.Resolve<ITestTracer>();
 
-            tracer1.Should().NotBeSameAs(tracer2);
+                tracer1.Should().NotBeSameAs(tracer2);
+            }
+            
         }
     }
+
 }

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/TestRunnerManagerTest.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/TestRunnerManagerTest.cs
@@ -1,4 +1,6 @@
+using System;
 using System.Reflection;
+using System.Threading;
 using NUnit.Framework;
 using TechTalk.SpecFlow.Infrastructure;
 
@@ -49,8 +51,80 @@ namespace TechTalk.SpecFlow.RuntimeTests
         }
 
         [Test]
+        public void GetTestRunner_should_return_same_instance_when_parallel_running_is_disabled_by_environment_variable()
+        {
+            Environment.SetEnvironmentVariable(EnvironmentVariableNames.SpecflowDisableParallelExecution,"1");
+            ITestRunner testRunner1 = null;
+            ITestRunner testRunner2 =null;
+            var thread1 = new Thread(() =>
+            {
+                Thread.CurrentThread.IsBackground = true;                
+                testRunner1 = TestRunnerManager.GetTestRunner();
+            });
+
+            var thread2 = new Thread(() =>
+            {
+                Thread.CurrentThread.IsBackground = true;
+                /* run your code here */
+                testRunner2 = TestRunnerManager.GetTestRunner();
+            });
+            thread1.Start();
+            thread2.Start();
+
+            thread1.Join();
+            thread2.Join();
+            Assert.IsNotNull(testRunner1);
+            Assert.IsNotNull(testRunner2);
+            Assert.AreEqual(testRunner1, testRunner2);
+        }
+        
+        [Test]        
+        public void GetTestRunner_should_return_different_instances_when_executed_by_different_threads()
+        {
+            //This test can't run in NCrunch as when NCrunch runs the tests it will disable the ability to get different test runners for each thread 
+            //as it manages the parallelisation 
+            //see https://github.com/techtalk/SpecFlow/issues/638
+            if (!TestEnvironmentHelper.IsBeingRunByNCrunch())
+            {
+                ITestRunner testRunner1 = null;
+                ITestRunner testRunner2 = null;
+                var thread1 = new Thread(() =>
+                {
+                    Thread.CurrentThread.IsBackground = true;
+                    testRunner1 = TestRunnerManager.GetTestRunner();
+                });
+
+
+                var thread2 = new Thread(() =>
+                {
+                    Thread.CurrentThread.IsBackground = true;
+                    /* run your code here */
+                    testRunner2 = TestRunnerManager.GetTestRunner();
+                });
+                thread1.Start();
+                thread2.Start();
+
+                thread1.Join();
+                thread2.Join();
+                Assert.IsNotNull(testRunner1);
+                Assert.IsNotNull(testRunner2);
+                Assert.AreNotEqual(testRunner1, testRunner2);
+            }
+        }
+
+        [Test]
         public void Should_return_different_instances_for_different_thread_ids()
         {
+            var testRunner1 = testRunnerManager.GetTestRunner(threadId: 1);
+            var testRunner2 = testRunnerManager.GetTestRunner(threadId: 2);
+
+            Assert.AreNotEqual(testRunner1, testRunner2);
+        }
+
+        [Test]
+        public void Should_return_same_instances_for_different_thread_ids_if_parallel_running_is_disabled_by_environment_variable()
+        {
+            Environment.SetEnvironmentVariable(EnvironmentVariableNames.SpecflowDisableParallelExecution, "1");
             var testRunner1 = testRunnerManager.GetTestRunner(threadId: 1);
             var testRunner2 = testRunnerManager.GetTestRunner(threadId: 2);
 


### PR DESCRIPTION
…llel running option by an environment variable. The environment variable is 'SPECFLOW_DISABLE_PARALLEL', but this also disables parallel running if the environment variable 'NCrunch' is defined so that issues with current NCrunch clients can be fixed. As a result of this change some tests do not run in NCrunch. these tests have been skipped in the code if the NCrunch environment is defined