### PR TITLE
Resolves #575

### DIFF
--- a/TechTalk.SpecFlow.Generator/UnitTestProvider/XUnit2TestGeneratorProvider.cs
+++ b/TechTalk.SpecFlow.Generator/UnitTestProvider/XUnit2TestGeneratorProvider.cs
@@ -16,6 +16,10 @@ namespace TechTalk.SpecFlow.Generator.UnitTestProvider
         private const string INLINEDATA_ATTRIBUTE = "Xunit.InlineDataAttribute";
         private const string SKIP_REASON = "Ignored";
         private const string ICLASSFIXTURE_INTERFACE = "Xunit.IClassFixture";
+        private const string OUTPUT_INTERFACE = "Xunit.Abstractions.ITestOutputHelper";
+        private const string OUTPUT_INTERFACE_PARAMETER_NAME = "testOutputHelper";
+        private const string OUTPUT_INTERFACE_FIELD_NAME = "_testOutputHelper";
+        private const string FIXTUREDATA_PARAMETER_NAME = "fixtureData";
 
         public XUnit2TestGeneratorProvider(CodeDomHelper codeDomHelper)
             :base(codeDomHelper)
@@ -28,8 +32,14 @@ namespace TechTalk.SpecFlow.Generator.UnitTestProvider
             return UnitTestGeneratorTraits.RowTests | UnitTestGeneratorTraits.ParallelExecution;
         }
 
-        protected override CodeTypeReference CreateFixtureInterface(CodeTypeReference fixtureDataType)
+        protected override CodeTypeReference CreateFixtureInterface(TestClassGenerationContext generationContext, CodeTypeReference fixtureDataType)
         {
+            // Add a field for the ITestOutputHelper
+            generationContext.TestClass.Members.Add(new CodeMemberField(OUTPUT_INTERFACE, OUTPUT_INTERFACE_FIELD_NAME));
+
+            // Store the fixture data type for later use in constructor
+            generationContext.CustomData.Add(FIXTUREDATA_PARAMETER_NAME, fixtureDataType);
+
             return new CodeTypeReference(ICLASSFIXTURE_INTERFACE, fixtureDataType);
         }
 
@@ -60,6 +70,20 @@ namespace TechTalk.SpecFlow.Generator.UnitTestProvider
             CodeDomHelper.AddAttribute(testMethod, INLINEDATA_ATTRIBUTE, args.ToArray());
         }
 
+        protected override void SetTestConstructor(TestClassGenerationContext generationContext, CodeConstructor ctorMethod) {
+            ctorMethod.Parameters.Add(
+                new CodeParameterDeclarationExpression((CodeTypeReference)generationContext.CustomData[FIXTUREDATA_PARAMETER_NAME], FIXTUREDATA_PARAMETER_NAME));
+            ctorMethod.Parameters.Add(
+                new CodeParameterDeclarationExpression(OUTPUT_INTERFACE, OUTPUT_INTERFACE_PARAMETER_NAME));
+
+            base.SetTestConstructor(generationContext, ctorMethod);
+
+            ctorMethod.Statements.Add(
+                new CodeAssignStatement(
+                    new CodeFieldReferenceExpression(new CodeThisReferenceExpression(), OUTPUT_INTERFACE_FIELD_NAME), 
+                    new CodeVariableReferenceExpression(OUTPUT_INTERFACE_PARAMETER_NAME)));
+        }
+
         public override void SetTestMethodIgnore(TestClassGenerationContext generationContext, CodeMemberMethod testMethod)
         {
             var factAttr = testMethod.CustomAttributes.OfType<CodeAttributeDeclaration>()
@@ -85,6 +109,23 @@ namespace TechTalk.SpecFlow.Generator.UnitTestProvider
                         new CodeAttributeArgument(THEORY_ATTRIBUTE_SKIP_PROPERTY_NAME, new CodePrimitiveExpression(SKIP_REASON))
                     );
             }
+        }
+
+        public override void FinalizeTestClass(TestClassGenerationContext generationContext) {
+            base.FinalizeTestClass(generationContext);
+
+            // testRunner.ScenarioContext.ScenarioContainer.RegisterInstanceAs<ITestOutputHelper>(_testOutputHelper);
+            generationContext.ScenarioInitializeMethod.Statements.Add(
+                new CodeMethodInvokeExpression(
+                    new CodeMethodReferenceExpression(
+                        new CodePropertyReferenceExpression(
+                            new CodePropertyReferenceExpression(
+                                new CodeFieldReferenceExpression(null, generationContext.TestRunnerField.Name),
+                                "ScenarioContext"),
+                            "ScenarioContainer"),
+                        "RegisterInstanceAs",
+                        new CodeTypeReference(OUTPUT_INTERFACE)),
+                    new CodeVariableReferenceExpression(OUTPUT_INTERFACE_FIELD_NAME)));
         }
     }
 }

--- a/TechTalk.SpecFlow.Generator/UnitTestProvider/XUnitTestGeneratorProvider.cs
+++ b/TechTalk.SpecFlow.Generator/UnitTestProvider/XUnitTestGeneratorProvider.cs
@@ -59,23 +59,11 @@ namespace TechTalk.SpecFlow.Generator.UnitTestProvider
             var fixtureDataType =
                 CodeDomHelper.CreateNestedTypeReference(generationContext.TestClass, _currentFixtureDataTypeDeclaration.Name);
 
-            var useFixtureType = CreateFixtureInterface(fixtureDataType);
+            var useFixtureType = CreateFixtureInterface(generationContext, fixtureDataType);
 
             CodeDomHelper.SetTypeReferenceAsInterface(useFixtureType);
 
             generationContext.TestClass.BaseTypes.Add(useFixtureType);
-
-            // public void SetFixture(T) { } // explicit interface implementation for generic interfaces does not work with codedom
-
-            CodeMemberMethod setFixtureMethod = new CodeMemberMethod();
-            setFixtureMethod.Attributes = MemberAttributes.Public;
-            setFixtureMethod.Name = "SetFixture";
-            setFixtureMethod.Parameters.Add(new CodeParameterDeclarationExpression(fixtureDataType, "fixtureData"));
-            if (ImplmentInterfaceExplicit)
-            {
-                setFixtureMethod.ImplementationTypes.Add(useFixtureType);
-            }
-            generationContext.TestClass.Members.Add(setFixtureMethod);
 
             // public <_currentFixtureTypeDeclaration>() { <fixtureSetupMethod>(); }
             CodeConstructor ctorMethod = new CodeConstructor();
@@ -158,10 +146,7 @@ namespace TechTalk.SpecFlow.Generator.UnitTestProvider
             ctorMethod.Attributes = MemberAttributes.Public;
             generationContext.TestClass.Members.Add(ctorMethod);
 
-            ctorMethod.Statements.Add(
-                new CodeMethodInvokeExpression(
-                    new CodeThisReferenceExpression(),
-                    generationContext.TestInitializeMethod.Name));
+            SetTestConstructor(generationContext, ctorMethod);
         }
 
         public void SetTestCleanupMethod(TestClassGenerationContext generationContext)
@@ -215,6 +200,13 @@ namespace TechTalk.SpecFlow.Generator.UnitTestProvider
             }
         }
 
+        protected virtual void SetTestConstructor(TestClassGenerationContext generationContext, CodeConstructor ctorMethod) {
+          ctorMethod.Statements.Add(
+              new CodeMethodInvokeExpression(
+                  new CodeThisReferenceExpression(),
+                  generationContext.TestInitializeMethod.Name));
+        }
+
         protected void SetProperty(CodeTypeMember codeTypeMember, string name, string value)
         {
             CodeDomHelper.AddAttribute(codeTypeMember, TRAIT_ATTRIBUTE, name, value);
@@ -226,9 +218,19 @@ namespace TechTalk.SpecFlow.Generator.UnitTestProvider
             SetProperty(codeTypeMember, DESCRIPTION_PROPERTY_NAME, description);
         }
 
-        protected virtual CodeTypeReference CreateFixtureInterface(CodeTypeReference fixtureDataType)
+        protected virtual CodeTypeReference CreateFixtureInterface(TestClassGenerationContext generationContext, CodeTypeReference fixtureDataType)
         {
-            return new CodeTypeReference(IUSEFIXTURE_INTERFACE, fixtureDataType);
+            var useFixtureType = new CodeTypeReference(IUSEFIXTURE_INTERFACE, fixtureDataType);
+            // public void SetFixture(T) { } // explicit interface implementation for generic interfaces does not work with codedom
+
+            CodeMemberMethod setFixtureMethod = new CodeMemberMethod();
+            setFixtureMethod.Attributes = MemberAttributes.Public;
+            setFixtureMethod.Name = "SetFixture";
+            setFixtureMethod.Parameters.Add(new CodeParameterDeclarationExpression(fixtureDataType, "fixtureData"));
+            setFixtureMethod.ImplementationTypes.Add(useFixtureType);
+            generationContext.TestClass.Members.Add(setFixtureMethod);
+
+            return useFixtureType;
         }
 
         public virtual void FinalizeTestClass(TestClassGenerationContext generationContext)


### PR DESCRIPTION
Changed `XUnit2TestGeneratorProvider` (and `XUnitTestGeneratorProvider` extensibility points) to register the `ITestOutputHelper` in the `ScenarioContainer`.

Also, the generated class now uses the constructor parameter to receive the testdata instance generated by the xUnit framework as documented in https://xunit.github.io/docs/shared-context.html#class-fixture which makes the `FeatureSetup` and `FeatureTearDown` work correctly in xUnit 2.
