### PR TITLE
Enabled support for test categories with MSTest

### DIFF
--- a/TechTalk.SpecFlow.Generator/UnitTestProvider/MsTestGeneratorProvider.cs
+++ b/TechTalk.SpecFlow.Generator/UnitTestProvider/MsTestGeneratorProvider.cs
@@ -17,6 +17,7 @@ namespace TechTalk.SpecFlow.Generator.UnitTestProvider
         protected const string TESTTEARDOWN_ATTR = "Microsoft.VisualStudio.TestTools.UnitTesting.TestCleanupAttribute";
         protected const string IGNORE_ATTR = "Microsoft.VisualStudio.TestTools.UnitTesting.IgnoreAttribute";
         protected const string DESCRIPTION_ATTR = "Microsoft.VisualStudio.TestTools.UnitTesting.DescriptionAttribute";
+        protected const string TESTCATEGORY_ATTR = "Microsoft.VisualStudio.TestTools.UnitTesting.TestCategoryAttribute";
 
         protected const string FEATURE_TITILE_PROPERTY_NAME = "FeatureTitle";
 
@@ -46,7 +47,7 @@ namespace TechTalk.SpecFlow.Generator.UnitTestProvider
 
         public virtual void SetTestClassCategories(TestClassGenerationContext generationContext, IEnumerable<string> featureCategories)
         {
-            //MsTest does not support caregories... :(
+            CodeDomHelper.AddAttributeForEachValue(generationContext.TestClass, TESTCATEGORY_ATTR, featureCategories);
         }
 
         public void SetTestClassIgnore(TestClassGenerationContext generationContext)

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,7 @@
+2.2.0 - 2016-08-10
+New Features:
++ Support for test categories in the MSTest unit test provider
+
 2.1.0 - 2016-05-24
 
 Core changes:


### PR DESCRIPTION
This pull request includes some changes to enable support of test categories when using MSTest.

I have replaced a comment suggesting that MSTest does not support test categories - can anybody elaborate on this? From what I can gather categories have been [supported for a while](https://msdn.microsoft.com/en-us/library/microsoft.visualstudio.testtools.unittesting.testcategoryattribute.aspx).