### PR TITLE
List all items from an enumerable in a table

### DIFF
--- a/TechTalk.SpecFlow/Assist/TableDiffExceptionBuilder.cs
+++ b/TechTalk.SpecFlow/Assist/TableDiffExceptionBuilder.cs
@@ -48,7 +48,7 @@ namespace TechTalk.SpecFlow.Assist
 
         private static string ConvertThisEnumerableToACommaDelimitedString(object propertyValue)
         {
-            return string.Join(",", ((IEnumerable) propertyValue).Cast<object>().Select(x => x.ToString()));
+            return string.Join(",", ((IEnumerable) propertyValue).Cast<object>().Select(x => x?.ToString() ?? ""));
         }
 
         private static bool ThisIsAnEnumerable(object propertyValue)

--- a/TechTalk.SpecFlow/Assist/TableDiffExceptionBuilder.cs
+++ b/TechTalk.SpecFlow/Assist/TableDiffExceptionBuilder.cs
@@ -31,9 +31,7 @@ namespace TechTalk.SpecFlow.Assist
             {
                 var line = "+ |";
                 foreach (var header in tableDifferenceResults.Table.Header)
-                {
                     line += $" {GetTheValue(item, header)} |";
-                }
                 realData.AppendLine(line);
             }
 

--- a/TechTalk.SpecFlow/Assist/TableDiffExceptionBuilder.cs
+++ b/TechTalk.SpecFlow/Assist/TableDiffExceptionBuilder.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections;
+using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 
@@ -29,7 +31,15 @@ namespace TechTalk.SpecFlow.Assist
             {
                 var line = "+ |";
                 foreach (var header in tableDifferenceResults.Table.Header)
-                    line += $" {item.GetPropertyValue(header)} |";
+                {
+                    var propertyValue = item.GetPropertyValue(header);
+                    if (propertyValue is IEnumerable && !(propertyValue is string))
+                    {
+                        var things = (propertyValue as IEnumerable).Cast<object>().ToList();
+                        propertyValue = string.Join(",", things.Select(x => x.ToString()));
+                    }
+                    line += $" {propertyValue} |";
+                }
                 realData.AppendLine(line);
             }
 

--- a/TechTalk.SpecFlow/Assist/TableDiffExceptionBuilder.cs
+++ b/TechTalk.SpecFlow/Assist/TableDiffExceptionBuilder.cs
@@ -32,18 +32,30 @@ namespace TechTalk.SpecFlow.Assist
                 var line = "+ |";
                 foreach (var header in tableDifferenceResults.Table.Header)
                 {
-                    var propertyValue = item.GetPropertyValue(header);
-                    if (propertyValue is IEnumerable && !(propertyValue is string))
-                    {
-                        var things = (propertyValue as IEnumerable).Cast<object>().ToList();
-                        propertyValue = string.Join(",", things.Select(x => x.ToString()));
-                    }
-                    line += $" {propertyValue} |";
+                    line += $" {GetTheValue(item, header)} |";
                 }
                 realData.AppendLine(line);
             }
 
             return realData.ToString();
+        }
+
+        private static object GetTheValue(T item, string header)
+        {
+            var propertyValue = item.GetPropertyValue(header);
+            return ThisIsAnEnumerable(propertyValue)
+                ? ConvertThisEnumerableToACommaDelimitedString(propertyValue)
+                : propertyValue;
+        }
+
+        private static string ConvertThisEnumerableToACommaDelimitedString(object propertyValue)
+        {
+            return string.Join(",", ((IEnumerable) propertyValue).Cast<object>().Select(x => x.ToString()));
+        }
+
+        private static bool ThisIsAnEnumerable(object propertyValue)
+        {
+            return propertyValue is IEnumerable && !(propertyValue is string);
         }
     }
 }

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/TableDiffExceptionBuilderTests.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/TableDiffExceptionBuilderTests.cs
@@ -1,4 +1,5 @@
-﻿using NUnit.Framework;
+﻿using System;
+using NUnit.Framework;
 using FluentAssertions;
 using TechTalk.SpecFlow.Assist;
 
@@ -110,12 +111,38 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests
 ".AgnosticLineBreak());
         }
 
+        [Test]
+        public void It_should_report_the_enumerables_as_lists()
+        {
+            var table = new Table("Doubles");
+            table.AddRow("1,2,3");
+
+            var builder = new TableDiffExceptionBuilder<TestObject>();
+
+            var remainingItems = new[]
+                                     {
+                                         new TestObject {Doubles = new [] {1D, 2D, 5D}},
+                                     };
+            var tableDifferenceResults = new TableDifferenceResults<TestObject>(table, new int[] {}, remainingItems);
+            var message = builder.GetTheTableDiffExceptionMessage(tableDifferenceResults);
+
+            message.Should().NotContain("System.Double[]");
+        }
+
         public class TestObject
         {
             public string One { get; set; }
             public int? Two { get; set; }
             public string Three { get; set; }
             public string TheFourthProperty { get; set; }
+            public Double[] Doubles { get; set; }
+        }
+
+        public class TestObjectWithArrays
+        {
+            public string Name { get; set; }
+            public int[] Numbers { get; set; }
+            public string[] Strings { get; set; }
         }
     }
 }

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/TableDiffExceptionBuilderTests.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/TableDiffExceptionBuilderTests.cs
@@ -127,6 +127,7 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests
             var message = builder.GetTheTableDiffExceptionMessage(tableDifferenceResults);
 
             message.Should().NotContain("System.Double[]");
+            message.Should().Contain("1,2,3");
         }
 
         public class TestObject

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/TableDiffExceptionBuilderTests.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/TableDiffExceptionBuilderTests.cs
@@ -155,7 +155,7 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests
             public int? Two { get; set; }
             public string Three { get; set; }
             public string TheFourthProperty { get; set; }
-            public Double[] Doubles { get; set; }
+            public double[] Doubles { get; set; }
             public object[] Objects { get; set; }
         }
 

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/TableDiffExceptionBuilderTests.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/TableDiffExceptionBuilderTests.cs
@@ -130,6 +130,25 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests
             message.Should().Contain("1,2,3");
         }
 
+        [Test]
+        public void It_should_treat_nulls_as_empty_spots()
+        {
+            var table = new Table("Objects");
+            table.AddRow("1,2,d");
+
+            var builder = new TableDiffExceptionBuilder<TestObject>();
+
+            var remainingItems = new[]
+                                     {
+                                         new TestObject {Objects = new object[] {1,null,"2","d"}},
+                                     };
+            var tableDifferenceResults = new TableDifferenceResults<TestObject>(table, new int[] {}, remainingItems);
+            var message = builder.GetTheTableDiffExceptionMessage(tableDifferenceResults);
+
+            message.Should().NotContain("Object[]");
+            message.Should().Contain("1,,2,d");
+        }
+
         public class TestObject
         {
             public string One { get; set; }
@@ -137,6 +156,7 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests
             public string Three { get; set; }
             public string TheFourthProperty { get; set; }
             public Double[] Doubles { get; set; }
+            public object[] Objects { get; set; }
         }
 
         public class TestObjectWithArrays

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,9 @@
+2.?.? - ????-??-??
+
+Smaller Improvements/fixes:
++ The results of comparisons made against sets will be displayed as a comma-delimited list.
+
+
 2.1.0 - 2016-05-24
 
 Core changes:


### PR DESCRIPTION
Before this change, table differences against enumerables would look something like this:

```
  | Doubles         |
  | System.Double[] |
```

With this change, they will now look like this:

```
  | Doubles |
  | 1,2,3   |
```