### PR TITLE
Seanario Outline examples tags do not appear in ScenarioContext.ScenarioInfo.Tags - Fix issue 718

### DIFF
--- a/TechTalk.SpecFlow.Generator/UnitTestProvider/NUnitTestGeneratorProvider.cs
+++ b/TechTalk.SpecFlow.Generator/UnitTestProvider/NUnitTestGeneratorProvider.cs
@@ -105,9 +105,10 @@ namespace TechTalk.SpecFlow.Generator.UnitTestProvider
             // addressing ReSharper bug: TestCase attribute with empty string[] param causes inconclusive result - https://github.com/techtalk/SpecFlow/issues/116
             bool hasExampleTags = tags.Any();
             var exampleTagExpressionList = tags.Select(t => new CodePrimitiveExpression(t));
-            CodeExpression exampleTagsExpression = hasExampleTags ?
-                (CodeExpression)new CodePrimitiveExpression(null) :
-                new CodeArrayCreateExpression(typeof(string[]), exampleTagExpressionList.ToArray());
+            CodeExpression exampleTagsExpression = hasExampleTags
+                ? new CodeArrayCreateExpression(typeof(string[]), exampleTagExpressionList.ToArray())
+                : (CodeExpression) new CodePrimitiveExpression(null);
+                
             args.Add(new CodeAttributeArgument(exampleTagsExpression));
 
             // adds 'Category' named parameter so that NUnit also understands that this test case belongs to the given categories

--- a/Tests/TechTalk.SpecFlow.Specs/Features/TaggedExamples.feature
+++ b/Tests/TechTalk.SpecFlow.Specs/Features/TaggedExamples.feature
@@ -52,3 +52,41 @@ Scenario: Examples can be ignored
 	Then the execution summary should contain
 		| Total | Succeeded | Ignored |
 		| 3     | 2         | 1       |
+
+Scenario: Scenario Outline Examples can be tagged
+	Given there is a feature file in the project as
+		"""
+			Feature: Simple Feature
+			Scenario Outline: Scenario Outline with Tagged Examples
+				When I do <what>
+
+			@en-gb
+			Examples: 
+				| what           |
+				| something      |
+				| something else |
+
+			@fr-fr
+			Examples: 
+				| what           |
+				| something      |
+				| something else |
+		"""
+	And the following step definition
+         """
+			[BeforeScenario]
+			public void BeforeScenario()
+			{
+				var scenarioTags = ScenarioContext.Current.ScenarioInfo.Tags;
+
+				if (scenarioTags.Length == 0)
+				{
+					throw new Exception("Scenario tags list should not be empty");
+				}
+			}
+         """
+	And all steps are bound and pass
+	When I execute the tests
+	Then the execution summary should contain
+         | Succeeded |
+         | 4         |


### PR DESCRIPTION
Fixes issue #718 