### PR TITLE
Fix error caused by the Before/AfterStepBlock hook error handling and PR 626

### DIFF
--- a/TechTalk.SpecFlow/Infrastructure/ContextManager.cs
+++ b/TechTalk.SpecFlow/Infrastructure/ContextManager.cs
@@ -163,6 +163,15 @@ namespace TechTalk.SpecFlow.Infrastructure
             var newContext = scenarioContainer.Resolve<ScenarioContext>();
             scenarioContextManager.Init(newContext);
             ScenarioContext.Current = newContext;
+
+            ResetCurrentStepStack();
+        }
+
+        private void ResetCurrentStepStack()
+        {
+            stepDepth = 0;
+            CurrentTopLevelStep = null;
+            ScenarioStepContext.Current = null;
         }
 
         public void CleanupScenarioContext()

--- a/TechTalk.SpecFlow/Infrastructure/ContextManager.cs
+++ b/TechTalk.SpecFlow/Infrastructure/ContextManager.cs
@@ -121,15 +121,15 @@ namespace TechTalk.SpecFlow.Infrastructure
         private readonly IContainerBuilder containerBuilder;
 
         /// <summary>
-        /// Holds the ScenarioStepContext of the last step that was executed from the actual featrure file, and not any steps that were executed during the calling of a step
+        /// Holds the StepDefinitionType of the last step that was executed from the actual featrure file, excluding the types of the steps that were executed during the calling of a step
         /// </summary>
         public StepDefinitionType? CurrentTopLevelStepDefinitionType { get; private set; }
 
         public ContextManager(ITestTracer testTracer, IObjectContainer testThreadContainer, IContainerBuilder containerBuilder)
         {
-            featureContextManager = new InternalContextManager<FeatureContext>(testTracer);
-            scenarioContextManager = new InternalContextManager<ScenarioContext>(testTracer);
-            stepContextManager = new StackedInternalContextManager<ScenarioStepContext>(testTracer);
+            this.featureContextManager = new InternalContextManager<FeatureContext>(testTracer);
+            this.scenarioContextManager = new InternalContextManager<ScenarioContext>(testTracer);
+            this.stepContextManager = new StackedInternalContextManager<ScenarioStepContext>(testTracer);
             this.testThreadContainer = testThreadContainer;
             this.containerBuilder = containerBuilder;
         }

--- a/TechTalk.SpecFlow/Infrastructure/ContextManager.cs
+++ b/TechTalk.SpecFlow/Infrastructure/ContextManager.cs
@@ -100,11 +100,9 @@ namespace TechTalk.SpecFlow.Infrastructure
 
             public void Dispose()
             {
-                var instance = instances.Pop();
-                if (instance != null)
+                while (instances.Any())
                 {
-                    ((IDisposable)instance).Dispose();
-
+                    Cleanup();
                 }
             }
         }

--- a/TechTalk.SpecFlow/Infrastructure/IContextManager.cs
+++ b/TechTalk.SpecFlow/Infrastructure/IContextManager.cs
@@ -1,5 +1,6 @@
 ﻿using System.Globalization;
 using System.Text;
+using TechTalk.SpecFlow.Bindings;
 
 namespace TechTalk.SpecFlow.Infrastructure
 {
@@ -10,7 +11,7 @@ namespace TechTalk.SpecFlow.Infrastructure
         FeatureContext FeatureContext { get; }
         ScenarioContext ScenarioContext { get; }
         ScenarioStepContext StepContext { get; }
-        ScenarioStepContext CurrentTopLevelStep { get; }
+        StepDefinitionType? CurrentTopLevelStepDefinitionType { get; }
 
         void InitializeFeatureContext(FeatureInfo featureInfo, CultureInfo bindingCulture);
         void CleanupFeatureContext();

--- a/TechTalk.SpecFlow/Infrastructure/TestExecutionEngine.cs
+++ b/TechTalk.SpecFlow/Infrastructure/TestExecutionEngine.cs
@@ -233,6 +233,7 @@ namespace TechTalk.SpecFlow.Infrastructure
             testTracer.TraceStep(stepInstance, true);
 
             bool isStepSkipped = contextManager.ScenarioContext.TestStatus != TestStatus.OK;
+            bool onStepStartExecuted = false;
 
             BindingMatch match = null;
             object[] arguments = null;
@@ -247,6 +248,7 @@ namespace TechTalk.SpecFlow.Infrastructure
                 }
                 else
                 {
+                    onStepStartExecuted = true;
                     OnStepStart();
                     TimeSpan duration = ExecuteStepMatch(match, arguments);
                     if (runtimeConfiguration.TraceSuccessfulSteps)
@@ -293,7 +295,7 @@ namespace TechTalk.SpecFlow.Infrastructure
             }
             finally
             {
-                if (!isStepSkipped)
+                if (onStepStartExecuted)
                 {
                     OnStepEnd();
                 }

--- a/TechTalk.SpecFlow/Infrastructure/TestExecutionEngine.cs
+++ b/TechTalk.SpecFlow/Infrastructure/TestExecutionEngine.cs
@@ -297,7 +297,6 @@ namespace TechTalk.SpecFlow.Infrastructure
                 {
                     OnStepEnd();
                 }
-                contextManager.CleanupStepContext();
             }
         }
 
@@ -395,8 +394,15 @@ namespace TechTalk.SpecFlow.Infrastructure
             StepDefinitionType stepDefinitionType = (stepDefinitionKeyword == StepDefinitionKeyword.And || stepDefinitionKeyword == StepDefinitionKeyword.But)
                                           ? GetCurrentBindingType()
                                           : (StepDefinitionType) stepDefinitionKeyword;
-            contextManager.InitializeStepContext(new StepInfo(stepDefinitionType, text, tableArg, multilineTextArg)); 
-            ExecuteStep(new StepInstance(stepDefinitionType, stepDefinitionKeyword, keyword, text, multilineTextArg, tableArg,contextManager.GetStepContext()));
+            contextManager.InitializeStepContext(new StepInfo(stepDefinitionType, text, tableArg, multilineTextArg));
+            try
+            {
+                ExecuteStep(new StepInstance(stepDefinitionType, stepDefinitionKeyword, keyword, text, multilineTextArg, tableArg, contextManager.GetStepContext()));
+            }
+            finally
+            {
+                contextManager.CleanupStepContext();
+            }
         }
 
         private StepDefinitionType GetCurrentBindingType()

--- a/TechTalk.SpecFlow/Infrastructure/TestExecutionEngine.cs
+++ b/TechTalk.SpecFlow/Infrastructure/TestExecutionEngine.cs
@@ -409,7 +409,7 @@ namespace TechTalk.SpecFlow.Infrastructure
 
         private StepDefinitionType GetCurrentBindingType()
         {
-            return contextManager.CurrentTopLevelStep?.StepInfo.StepDefinitionType ?? StepDefinitionType.Given;
+            return contextManager.CurrentTopLevelStepDefinitionType ?? StepDefinitionType.Given;
         }
 
         #endregion

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/Infrastructure/TestExecutionEngineTests.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/Infrastructure/TestExecutionEngineTests.cs
@@ -276,7 +276,7 @@ namespace TechTalk.SpecFlow.RuntimeTests.Infrastructure
             try
             {
                 testExecutionEngine.Step(StepDefinitionKeyword.Given, null, "foo", null, null);
-                Assert.Fail("should throw simulated error");
+                Assert.Fail("execution of the step should have failed because of the exeption thrown by the before scenario block hook");
             }
             catch (Exception)
             {

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/ScenarioStepContextTests.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/ScenarioStepContextTests.cs
@@ -158,8 +158,6 @@ namespace TechTalk.SpecFlow.RuntimeTests
             var mockTracer = new Mock<ITestTracer>();
             TestObjectFactories.CreateTestRunner(out container, objectContainer => objectContainer.RegisterInstanceAs(mockTracer.Object));
             var contextManager = container.Resolve<IContextManager>();
-            //var firstStepInfo = new StepInfo(StepDefinitionType.Given, "I have called initialise once", null, string.Empty);
-            //contextManager.InitializeStepContext(firstStepInfo);
             Assert.IsNull(contextManager.CurrentTopLevelStep);
         }
 
@@ -177,6 +175,34 @@ namespace TechTalk.SpecFlow.RuntimeTests
             contextManager.InitializeScenarioContext(new ScenarioInfo("my scenario"));
 
             Assert.IsNull(contextManager.CurrentTopLevelStep);
+        }
+
+        [Test]
+        public void ShouldBeAbleToDisposeContextManagerAfterAnConsistentState()
+        {
+            IObjectContainer container;
+            var mockTracer = new Mock<ITestTracer>();
+            TestObjectFactories.CreateTestRunner(out container, objectContainer => objectContainer.RegisterInstanceAs(mockTracer.Object));
+            var contextManager = container.Resolve<IContextManager>();
+            var firstStepInfo = new StepInfo(StepDefinitionType.Given, "I have called initialise once", null, string.Empty);
+            contextManager.InitializeStepContext(firstStepInfo);
+            // do not call CleanupStepContext to simulate inconsistent state
+
+            ((IDisposable)contextManager).Dispose();
+        }
+
+        [Test]
+        public void ShouldBeAbleToDisposeContextManagerAfterAnInconsistentState()
+        {
+            IObjectContainer container;
+            var mockTracer = new Mock<ITestTracer>();
+            TestObjectFactories.CreateTestRunner(out container, objectContainer => objectContainer.RegisterInstanceAs(mockTracer.Object));
+            var contextManager = container.Resolve<IContextManager>();
+            var firstStepInfo = new StepInfo(StepDefinitionType.Given, "I have called initialise once", null, string.Empty);
+            contextManager.InitializeStepContext(firstStepInfo);
+            contextManager.CleanupStepContext();
+
+            ((IDisposable)contextManager).Dispose();
         }
 
         [Test]

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/ScenarioStepContextTests.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/ScenarioStepContextTests.cs
@@ -152,6 +152,34 @@ namespace TechTalk.SpecFlow.RuntimeTests
         }
 
         [Test]
+        public void TopLevelStepShouldBeNullInitially()
+        {
+            IObjectContainer container;
+            var mockTracer = new Mock<ITestTracer>();
+            TestObjectFactories.CreateTestRunner(out container, objectContainer => objectContainer.RegisterInstanceAs(mockTracer.Object));
+            var contextManager = container.Resolve<IContextManager>();
+            //var firstStepInfo = new StepInfo(StepDefinitionType.Given, "I have called initialise once", null, string.Empty);
+            //contextManager.InitializeStepContext(firstStepInfo);
+            Assert.IsNull(contextManager.CurrentTopLevelStep);
+        }
+
+        [Test]
+        public void ScenarioStartShouldResetTopLevelStep()
+        {
+            IObjectContainer container;
+            var mockTracer = new Mock<ITestTracer>();
+            TestObjectFactories.CreateTestRunner(out container, objectContainer => objectContainer.RegisterInstanceAs(mockTracer.Object));
+            var contextManager = container.Resolve<IContextManager>();
+            var firstStepInfo = new StepInfo(StepDefinitionType.Given, "I have called initialise once", null, string.Empty);
+            contextManager.InitializeStepContext(firstStepInfo);
+            // do not call CleanupStepContext to simulate inconsistent state
+
+            contextManager.InitializeScenarioContext(new ScenarioInfo("my scenario"));
+
+            Assert.IsNull(contextManager.CurrentTopLevelStep);
+        }
+
+        [Test]
         public void ShouldReportSetValuesCorrectly()
         {
             var table = new Table("header1","header2");

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/ScenarioStepContextTests.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/ScenarioStepContextTests.cs
@@ -93,14 +93,14 @@ namespace TechTalk.SpecFlow.RuntimeTests
             var contextManager = container.Resolve<IContextManager>();
             var firstStepInfo = new StepInfo(StepDefinitionType.Given, "I have called initialise once", null, string.Empty);
             contextManager.InitializeStepContext(firstStepInfo);
-            Assert.AreEqual(firstStepInfo, contextManager.CurrentTopLevelStep.StepInfo);
+            Assert.AreEqual(StepDefinitionType.Given, contextManager.CurrentTopLevelStepDefinitionType); // firstStepInfo
             var secondStepInfo = new StepInfo(StepDefinitionType.When, "I have called initialise twice", null, string.Empty);
             contextManager.InitializeStepContext(secondStepInfo);
-            Assert.AreEqual(firstStepInfo, contextManager.CurrentTopLevelStep.StepInfo);
-            contextManager.CleanupStepContext();
-            Assert.AreEqual(firstStepInfo, contextManager.CurrentTopLevelStep.StepInfo);
-            contextManager.CleanupStepContext();
-            Assert.AreEqual(firstStepInfo, contextManager.CurrentTopLevelStep.StepInfo);
+            Assert.AreEqual(StepDefinitionType.Given, contextManager.CurrentTopLevelStepDefinitionType); // firstStepInfo
+            contextManager.CleanupStepContext(); // remove second
+            Assert.AreEqual(StepDefinitionType.Given, contextManager.CurrentTopLevelStepDefinitionType); // firstStepInfo
+            contextManager.CleanupStepContext(); // remove first
+            Assert.AreEqual(StepDefinitionType.Given, contextManager.CurrentTopLevelStepDefinitionType); // firstStepInfo
         }
 
         [Test]
@@ -112,13 +112,13 @@ namespace TechTalk.SpecFlow.RuntimeTests
             var contextManager = container.Resolve<IContextManager>();
             var firstStepInfo = new StepInfo(StepDefinitionType.Given, "I have called initialise once", null, string.Empty);
             contextManager.InitializeStepContext(firstStepInfo);
-            Assert.AreEqual(firstStepInfo, contextManager.CurrentTopLevelStep.StepInfo);
+            Assert.AreEqual(StepDefinitionType.Given, contextManager.CurrentTopLevelStepDefinitionType); // firstStepInfo
             contextManager.CleanupStepContext();
             var secondStepInfo = new StepInfo(StepDefinitionType.When, "I have called initialise twice", null, string.Empty);
             contextManager.InitializeStepContext(secondStepInfo);
-            Assert.AreEqual(secondStepInfo, contextManager.CurrentTopLevelStep.StepInfo);
+            Assert.AreEqual(StepDefinitionType.When, contextManager.CurrentTopLevelStepDefinitionType); // secondStepInfo
             contextManager.CleanupStepContext();
-            Assert.AreEqual(secondStepInfo, contextManager.CurrentTopLevelStep.StepInfo);
+            Assert.AreEqual(StepDefinitionType.When, contextManager.CurrentTopLevelStepDefinitionType); // secondStepInfo
         }
 
         [Test]
@@ -130,25 +130,25 @@ namespace TechTalk.SpecFlow.RuntimeTests
             var contextManager = container.Resolve<IContextManager>();
             var firstStepInfo = new StepInfo(StepDefinitionType.Given, "I have called initialise once", null, string.Empty);
             contextManager.InitializeStepContext(firstStepInfo);
-            Assert.AreEqual(firstStepInfo, contextManager.CurrentTopLevelStep.StepInfo);
+            Assert.AreEqual(StepDefinitionType.Given, contextManager.CurrentTopLevelStepDefinitionType); // firstStepInfo
             contextManager.CleanupStepContext();
             var secondStepInfo = new StepInfo(StepDefinitionType.When, "I have called initialise twice", null, string.Empty);
             contextManager.InitializeStepContext(secondStepInfo);
-            Assert.AreEqual(secondStepInfo, contextManager.CurrentTopLevelStep.StepInfo);
-            var thirdStepInfo = new StepInfo(StepDefinitionType.When, "I have called initialise a third time", null, string.Empty);
+            Assert.AreEqual(StepDefinitionType.When, contextManager.CurrentTopLevelStepDefinitionType); // secondStepInfo
+            var thirdStepInfo = new StepInfo(StepDefinitionType.Given, "I have called initialise a third time", null, string.Empty);
             contextManager.InitializeStepContext(thirdStepInfo); //Call sub step
-            Assert.AreEqual(secondStepInfo, contextManager.CurrentTopLevelStep.StepInfo);
-            var fourthStepInfo = new StepInfo(StepDefinitionType.When, "I have called initialise a forth time", null, string.Empty);
+            Assert.AreEqual(StepDefinitionType.When, contextManager.CurrentTopLevelStepDefinitionType); // secondStepInfo
+            var fourthStepInfo = new StepInfo(StepDefinitionType.Then, "I have called initialise a forth time", null, string.Empty);
             contextManager.InitializeStepContext(fourthStepInfo); //call sub step of sub step
             contextManager.CleanupStepContext(); // return from sub step of sub step
-            Assert.AreEqual(secondStepInfo, contextManager.CurrentTopLevelStep.StepInfo);
+            Assert.AreEqual(StepDefinitionType.When, contextManager.CurrentTopLevelStepDefinitionType); // secondStepInfo
             contextManager.CleanupStepContext(); // return from sub step
-            Assert.AreEqual(secondStepInfo, contextManager.CurrentTopLevelStep.StepInfo);
+            Assert.AreEqual(StepDefinitionType.When, contextManager.CurrentTopLevelStepDefinitionType); // secondStepInfo
             contextManager.CleanupStepContext(); // finish 2nd step
-            Assert.AreEqual(secondStepInfo, contextManager.CurrentTopLevelStep.StepInfo);
-            var fifthStepInfo = new StepInfo(StepDefinitionType.When, "I have called initialise a fifth time", null, string.Empty);
+            Assert.AreEqual(StepDefinitionType.When, contextManager.CurrentTopLevelStepDefinitionType); // secondStepInfo
+            var fifthStepInfo = new StepInfo(StepDefinitionType.Then, "I have called initialise a fifth time", null, string.Empty);
             contextManager.InitializeStepContext(fifthStepInfo);
-            Assert.AreEqual(fifthStepInfo, contextManager.CurrentTopLevelStep.StepInfo);
+            Assert.AreEqual(StepDefinitionType.Then, contextManager.CurrentTopLevelStepDefinitionType); // fifthStepInfo
         }
 
         [Test]
@@ -158,7 +158,7 @@ namespace TechTalk.SpecFlow.RuntimeTests
             var mockTracer = new Mock<ITestTracer>();
             TestObjectFactories.CreateTestRunner(out container, objectContainer => objectContainer.RegisterInstanceAs(mockTracer.Object));
             var contextManager = container.Resolve<IContextManager>();
-            Assert.IsNull(contextManager.CurrentTopLevelStep);
+            Assert.IsNull(contextManager.CurrentTopLevelStepDefinitionType);
         }
 
         [Test]
@@ -174,7 +174,7 @@ namespace TechTalk.SpecFlow.RuntimeTests
 
             contextManager.InitializeScenarioContext(new ScenarioInfo("my scenario"));
 
-            Assert.IsNull(contextManager.CurrentTopLevelStep);
+            Assert.IsNull(contextManager.CurrentTopLevelStepDefinitionType);
         }
 
         [Test]


### PR DESCRIPTION
PR #626 tracks the current step block by maintaining a recursion nesting counter. This relies on the proper calling of the step context initialization / cleanup, otherwise the counter goes off.
In case of an error in the before/after step block hook, the cleanup is not called, so the "current step block" remains as it was even for further scenarios.

This PR fixes this by moving the clanup call to the right level. Also fixing a small issue, that the afterstep hook is called even if the step was undefined.  