### PR TITLE
Create set overload with table row in callback

### DIFF
--- a/TechTalk.SpecFlow/Assist/TableExtensionMethods.cs
+++ b/TechTalk.SpecFlow/Assist/TableExtensionMethods.cs
@@ -55,5 +55,10 @@ namespace TechTalk.SpecFlow.Assist
 
             return list;
         }
+
+        public static IEnumerable<T> CreateSet<T>(this Table table, Func<TableRow, T> methodToCreateEachInstance)
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/TechTalk.SpecFlow/Assist/TableExtensionMethods.cs
+++ b/TechTalk.SpecFlow/Assist/TableExtensionMethods.cs
@@ -58,7 +58,18 @@ namespace TechTalk.SpecFlow.Assist
 
         public static IEnumerable<T> CreateSet<T>(this Table table, Func<TableRow, T> methodToCreateEachInstance)
         {
-            throw new NotImplementedException();
+            var list = new List<T>();
+
+            var pivotTable = new PivotTable(table);
+            for (var index = 0; index < table.Rows.Count(); index++)
+            {
+                var row = table.Rows[index];
+                var instance = methodToCreateEachInstance(row);
+                pivotTable.GetInstanceTable(index).FillInstance(instance);
+                list.Add(instance);
+            }
+
+            return list;
         }
     }
 }

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/TableHelperExtensionMethods/CreateSetHelperMethodTests_WithFuncAndTableRowArgument.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/TableHelperExtensionMethods/CreateSetHelperMethodTests_WithFuncAndTableRowArgument.cs
@@ -1,0 +1,94 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Threading;
+using FluentAssertions;
+using NUnit.Framework;
+using TechTalk.SpecFlow.Assist;
+using TechTalk.SpecFlow.RuntimeTests.AssistTests.ExampleEntities;
+
+namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.TableHelperExtensionMethods
+{
+    [TestFixture]
+    public class CreateSetHelperMethodTests_WithFuncAndTableRowArgument
+    {
+        [SetUp]
+        public void SetUp()
+        {
+            Thread.CurrentThread.CurrentCulture = new CultureInfo("en-US");
+        }
+
+        [Test]
+        public void Uses_the_instance_creation_method_when_passed_one_row()
+        {
+            var table = new Table("FirstName");
+            table.AddRow("John");
+
+            var expectedPerson = new Person();
+
+            var people = table.CreateSet(row => expectedPerson);
+
+            people.Single().Should().Be(expectedPerson);
+        }
+
+        [Test]
+        public void Calls_the_instance_creation_method_for_each_row()
+        {
+            var table = new Table("FirstName");
+            table.AddRow("one");
+            table.AddRow("two");
+
+            var first = new Person();
+            var second = new Person();
+
+            var queue = new Queue<Person>();
+            queue.Enqueue(first);
+            queue.Enqueue(second);
+
+            var people = table.CreateSet(row => queue.Dequeue());
+
+            people.Count().Should().Be(2);
+            people.First().Should().Be(first);
+            people.Last().Should().Be(second);
+        }
+
+        [Test]
+        public void Still_loads_the_instance_with_the_values_from_the_table()
+        {
+            var table = new Table("FirstName");
+            table.AddRow("John");
+            table.AddRow("Howard");
+
+            var john = new Person();
+            var howard = new Person();
+
+            var queue = new Queue<Person>();
+            queue.Enqueue(john);
+            queue.Enqueue(howard);
+
+            var people = table.CreateSet(row => queue.Dequeue());
+
+            people.First().FirstName.Should().Be("John");
+            people.Last().FirstName.Should().Be("Howard");
+        }
+
+        [Test]
+        public void The_correct_TableRow_is_passed_to_the_callback()
+        {
+            var table = new Table("FirstName", "_SpecialInfo");
+            table.AddRow("John", "John Info");
+            table.AddRow("Howard", "Howard Info");
+
+            var people = table.CreateSet(row => new Person() {LastName = row["_SpecialInfo"]});
+
+            foreach (var person in people)
+                LastNameString_ShouldStartWith_FirstNameString(person);
+        }
+
+        private static void LastNameString_ShouldStartWith_FirstNameString(Person person)
+        {
+            person.LastName.Should().StartWith(person.FirstName);
+        }
+    }
+}

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/RuntimeTests.csproj
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/RuntimeTests.csproj
@@ -92,6 +92,7 @@
     <Compile Include="AssistTests\TableHelperExtensionMethods\CreateInstanceHelperMethodTests_WithFunc.cs" />
     <Compile Include="AssistTests\TableHelperExtensionMethods\CreateInstanceHelperStandardTypesTests.cs" />
     <Compile Include="AssistTests\TableHelperExtensionMethods\CreateSetHelperMethodTests_WithFunc.cs" />
+    <Compile Include="AssistTests\TableHelperExtensionMethods\CreateSetHelperMethodTests_WithFuncAndTableRowArgument.cs" />
     <Compile Include="AssistTests\TableHelperExtensionMethods\FillInstanceHelperMethodTests.cs" />
     <Compile Include="AssistTests\TestInfrastructure\StandardTypesComparisonTestObject.cs" />
     <Compile Include="AssistTests\TestInfrastructure\InstanceComparisonTestObject.cs" />


### PR DESCRIPTION
I created an oveload of the CreateSet extension method that returns the corresponding TableRow as an argument. The overload can be helpfull, if you want to set constructor parameters based on table content.

I am not sure if returning the TableRow is the best idea, since you have to parse strings manually. Maybe you have a better idea.

Any suggestions are highly welcome.