### PR TITLE
Regexless stepdef fixes

### DIFF
--- a/TechTalk.SpecFlow/Bindings/StepDefinitionRegexCalculator.cs
+++ b/TechTalk.SpecFlow/Bindings/StepDefinitionRegexCalculator.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Reflection;
 using System.Text;
 using System.Text.RegularExpressions;
 using TechTalk.SpecFlow.Bindings.Reflection;
@@ -28,7 +27,7 @@ namespace TechTalk.SpecFlow.Bindings
         // any non-word character (including empty)
         // but - sign can only stand at the end of the connecting text if the next character is not digit
 
-        private const string nonWordRe = @"[^\w\p{Sc}]*(?!(?<=-)\d)";
+        private const string NonWordRe = @"[^\w\p{Sc}]*(?!(?<=-)\d)";
 
         private readonly RuntimeConfiguration runtimeConfiguration;
 
@@ -42,9 +41,7 @@ namespace TechTalk.SpecFlow.Bindings
         {
             // if method name seems to contain regex, we use it as-is
             if (nonIdentifierRe.Match(bindingMethod.Name).Success)
-            {
                 return bindingMethod.Name;
-            }
 
             string methodName = bindingMethod.Name;
             methodName = RemoveStepPrefix(stepDefinitionType, methodName);
@@ -63,7 +60,7 @@ namespace TechTalk.SpecFlow.Bindings
                 processedPosition = paramPosition.Position + paramPosition.Length;
             }
 
-            reBuilder.Append(CalculateRegex(methodName.Substring(processedPosition, methodName.Length - processedPosition)));
+            reBuilder.Append(CalculateRegex(methodName.Substring(processedPosition)));
 
             return reBuilder.ToString();
         }
@@ -116,16 +113,16 @@ namespace TechTalk.SpecFlow.Bindings
         private string CalculateRegex(string methodNamePart)
         {
             if (string.IsNullOrEmpty(methodNamePart))
-                return nonWordRe;
+                return NonWordRe;
 
-            return wordBoundaryRe.Replace("_" + methodNamePart + "_", match => nonWordRe);
+            return wordBoundaryRe.Replace("_" + methodNamePart + "_", match => NonWordRe);
         }
 
         private class ParamSearchResult
         {
-            public int Position { get; private set; }
-            public int Length { get; private set; }
-            public int ParamIndex { get; private set; }
+            public int Position { get; }
+            public int Length { get; }
+            public int ParamIndex { get; }
 
             public ParamSearchResult(int position, int length, int paramIndex)
             {

--- a/TechTalk.SpecFlow/Bindings/StepDefinitionRegexCalculator.cs
+++ b/TechTalk.SpecFlow/Bindings/StepDefinitionRegexCalculator.cs
@@ -25,7 +25,7 @@ namespace TechTalk.SpecFlow.Bindings
         // any non-word character (including empty)
         // but - sign can only stand at the end of the connecting text if the next character is not digit
 
-        private const string NonWordRe = @"[^\w\p{Sc}]*(?!(?<=-)\d)";
+        private const string WordConnectorRe = @"[^\w\p{Sc}]*(?!(?<=-)\d)";
 
         private readonly RuntimeConfiguration runtimeConfiguration;
 
@@ -56,15 +56,15 @@ namespace TechTalk.SpecFlow.Bindings
                 if (paramPosition.Position > processedPosition)
                 { 
                     reBuilder.Append(CalculateWordRegex(methodName.Substring(processedPosition, paramPosition.Position - processedPosition)));
-                    reBuilder.Append(NonWordRe);
+                    reBuilder.Append(WordConnectorRe);
                 }
                 reBuilder.Append(CalculateParamRegex(parameters[paramPosition.ParamIndex]));
-                reBuilder.Append(NonWordRe);
+                reBuilder.Append(WordConnectorRe);
                 processedPosition = paramPosition.Position + paramPosition.Length;
             }
 
             reBuilder.Append(CalculateWordRegex(methodName.Substring(processedPosition)));
-            reBuilder.Append(NonWordRe);
+            reBuilder.Append(WordConnectorRe);
 
             return reBuilder.ToString();
         }
@@ -119,7 +119,7 @@ namespace TechTalk.SpecFlow.Bindings
             if (string.IsNullOrEmpty(methodNamePart))
                 return string.Empty;
 
-            return wordBoundaryRe.Replace(methodNamePart.Trim('_'), match => NonWordRe);
+            return wordBoundaryRe.Replace(methodNamePart.Trim('_'), match => WordConnectorRe);
         }
 
         private class ParamSearchResult

--- a/TechTalk.SpecFlow/Bindings/StepDefinitionRegexCalculator.cs
+++ b/TechTalk.SpecFlow/Bindings/StepDefinitionRegexCalculator.cs
@@ -111,16 +111,14 @@ namespace TechTalk.SpecFlow.Bindings
             return string.Format(@"(?:""(?<{0}>[^""]*)""|'(?<{0}>[^']*)'|(?<{0}>.*?))", parameterInfo.ParameterName);
         }
 
-        private static readonly Regex wordBoundaryRe = new Regex(@"(?<=[\d\p{L}])\p{Lu}|(?<=\p{L})\d"); //mathces on boundaries of: 0A, aA, AA, a0, A0
+        private static readonly Regex wordBoundaryRe = new Regex(@"_+|(?<=[\d\p{L}])(?=\p{Lu})|(?<=\p{L})(?=\d)"); //mathces on underscores and boundaries of: 0A, aA, AA, a0, A0
 
         private string CalculateRegex(string text)
         {
             if (string.IsNullOrEmpty(text))
                 return nonWordRe;
 
-            text = wordBoundaryRe.Replace(text, match => nonWordRe + match.Value[0]);
-            text = text.Replace("_", nonWordRe); //get one or more non-word characters until we find one which is not a - that is followed by a number
-            return nonWordRe + text + nonWordRe;
+            return wordBoundaryRe.Replace("_" + text + "_", match => nonWordRe);
         }
 
         private class ParamSearchResult

--- a/TechTalk.SpecFlow/Bindings/StepDefinitionRegexCalculator.cs
+++ b/TechTalk.SpecFlow/Bindings/StepDefinitionRegexCalculator.cs
@@ -86,7 +86,7 @@ namespace TechTalk.SpecFlow.Bindings
         {
             yield return stepDefinitionType.ToString();
 
-            var cultureToSearch = runtimeConfiguration.BindingCulture ?? runtimeConfiguration.FeatureLanguage;
+            var cultureToSearch = runtimeConfiguration.FeatureLanguage;
 
             foreach (var keyword in LanguageHelper.GetKeywords(cultureToSearch, stepDefinitionType))
             {

--- a/Tests/TechTalk.SpecFlow.GeneratorTests/GeneratorTests.csproj
+++ b/Tests/TechTalk.SpecFlow.GeneratorTests/GeneratorTests.csproj
@@ -41,12 +41,12 @@
       <HintPath>..\..\packages\Castle.Core.3.3.3\lib\net45\Castle.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="FluentAssertions, Version=4.9.0.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\FluentAssertions.4.9.0\lib\net45\FluentAssertions.dll</HintPath>
+    <Reference Include="FluentAssertions, Version=4.19.0.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\FluentAssertions.4.19.0\lib\net45\FluentAssertions.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="FluentAssertions.Core, Version=4.9.0.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\FluentAssertions.4.9.0\lib\net45\FluentAssertions.Core.dll</HintPath>
+    <Reference Include="FluentAssertions.Core, Version=4.19.0.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\FluentAssertions.4.19.0\lib\net45\FluentAssertions.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Gherkin, Version=1.0.0.0, Culture=neutral, PublicKeyToken=86496cfa5b4a5851, processorArchitecture=MSIL">

--- a/Tests/TechTalk.SpecFlow.GeneratorTests/packages.config
+++ b/Tests/TechTalk.SpecFlow.GeneratorTests/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Castle.Core" version="3.3.3" targetFramework="net45" />
-  <package id="FluentAssertions" version="4.9.0" targetFramework="net45" />
+  <package id="FluentAssertions" version="4.19.0" targetFramework="net45" />
   <package id="Gherkin" version="4.0.0" targetFramework="net45" />
   <package id="Moq" version="4.5.9" targetFramework="net45" />
   <package id="NUnit" version="3.2.1" targetFramework="net45" />

--- a/Tests/TechTalk.SpecFlow.IntegrationTests/TechTalk.SpecFlow.IntegrationTests.csproj
+++ b/Tests/TechTalk.SpecFlow.IntegrationTests/TechTalk.SpecFlow.IntegrationTests.csproj
@@ -36,12 +36,12 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="FluentAssertions, Version=4.9.0.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\FluentAssertions.4.9.0\lib\net45\FluentAssertions.dll</HintPath>
+    <Reference Include="FluentAssertions, Version=4.19.0.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\FluentAssertions.4.19.0\lib\net45\FluentAssertions.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="FluentAssertions.Core, Version=4.9.0.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\FluentAssertions.4.9.0\lib\net45\FluentAssertions.Core.dll</HintPath>
+    <Reference Include="FluentAssertions.Core, Version=4.19.0.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\FluentAssertions.4.19.0\lib\net45\FluentAssertions.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Build" />

--- a/Tests/TechTalk.SpecFlow.IntegrationTests/packages.config
+++ b/Tests/TechTalk.SpecFlow.IntegrationTests/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="FluentAssertions" version="4.9.0" targetFramework="net45" />
+  <package id="FluentAssertions" version="4.19.0" targetFramework="net45" />
   <package id="NUnit" version="3.2.1" targetFramework="net45" />
   <package id="SpecFlow" version="2.1.0" targetFramework="net45" />
   <package id="xunit" version="1.9.2" targetFramework="net45" />

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/Bindings/StepDefinitionRegexCalculatorTests.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/Bindings/StepDefinitionRegexCalculatorTests.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using FluentAssertions;
+using NUnit.Framework;
+using TechTalk.SpecFlow.Bindings;
+using TechTalk.SpecFlow.Bindings.Reflection;
+using TechTalk.SpecFlow.Configuration;
+
+namespace TechTalk.SpecFlow.RuntimeTests.Bindings
+{
+    [TestFixture, Category("wip_gn")]
+    public class StepDefinitionRegexCalculatorTests
+    {
+        private StepDefinitionRegexCalculator CreateSut()
+        {
+            return new StepDefinitionRegexCalculator(new RuntimeConfiguration());
+        }
+
+        private IBindingMethod CreateBindingMethod(string name)
+        {
+            return new BindingMethod(new BindingType("SomeSteps", "SomeSteps"), name, new IBindingParameter[0], new RuntimeBindingType(typeof(void)));
+        }
+
+        private Regex AssertRegex(string regexText)
+        {
+            regexText.Should().NotBeNullOrWhiteSpace("null, empty or whitespace-only regex is not valid for step definitions");
+            return RegexFactory.Create(regexText); // uses the same regex creation as real step definitions
+        }
+
+        private Regex CallCalculateRegexFromMethodAndAssertRegex(StepDefinitionRegexCalculator sut, StepDefinitionType stepDefinitionType, IBindingMethod bindingMethod)
+        {
+            var result = sut.CalculateRegexFromMethod(stepDefinitionType, bindingMethod);
+            return AssertRegex(result);
+        }
+
+        private Match AssertMatches(Regex regex, string text)
+        {
+            var match = regex.Match(text);
+            match.Success.Should().BeTrue($"the calculated regex ({regex}) should match text <{text}>");
+            return match;
+        }
+
+        [Test]
+        public void RecognizeSimpleText_Underscores()
+        {
+            var sut = CreateSut();
+
+            var result = CallCalculateRegexFromMethodAndAssertRegex(sut, StepDefinitionType.When, 
+                CreateBindingMethod("When_I_do_something"));
+
+            AssertMatches(result, "I do something");
+        }
+    }
+}

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/Bindings/StepDefinitionRegexCalculatorTests.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/Bindings/StepDefinitionRegexCalculatorTests.cs
@@ -255,5 +255,19 @@ namespace TechTalk.SpecFlow.RuntimeTests.Bindings
 
             AssertMatches(result, "ich Knopf drücke");
         }
+
+        [TestCase("Допустим_я_не_авторизован")]
+        [TestCase("я_не_авторизован")]
+        [TestCase("Given_я_не_авторизован")]
+        public void Issue715(string methodName)
+        {
+            runtimeConfiguration.FeatureLanguage = new CultureInfo("ru");
+            var sut = CreateSut();
+
+            var result = CallCalculateRegexFromMethodAndAssertRegex(sut, StepDefinitionType.Given,
+                CreateBindingMethod(methodName));
+
+            AssertMatches(result, "я не авторизован");
+        }
     }
 }

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/Bindings/StepDefinitionRegexCalculatorTests.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/Bindings/StepDefinitionRegexCalculatorTests.cs
@@ -54,7 +54,7 @@ namespace TechTalk.SpecFlow.RuntimeTests.Bindings
         private Match AssertMatches(Regex regex, string text)
         {
             var match = regex.Match(text);
-            match.Success.Should().BeTrue($"the calculated regex ({regex}) should match text <{text}>");
+            match.Success.Should().BeTrue("the calculated regex ({0}) should match text <{1}>", regex.ToString().Replace("{", "<").Replace("}", ">"), text);
             return match;
         }
 

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/Bindings/StepDefinitionRegexCalculatorTests.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/Bindings/StepDefinitionRegexCalculatorTests.cs
@@ -163,7 +163,6 @@ namespace TechTalk.SpecFlow.RuntimeTests.Bindings
         [TestCase("!that Joe does something")]
         [TestCase("that -Joe - does -something-")]
         [TestCase("that' Joe does \"something\"")]
-        [TestCase("that Joe doe's something")]
         public void SupportsPunctuation(string stepText)
         {
             var sut = CreateSut();
@@ -173,6 +172,20 @@ namespace TechTalk.SpecFlow.RuntimeTests.Bindings
 
             var match = AssertMatches(result, stepText);
             AssertParamMatch(match, "Joe");
+        }
+
+        [TestCase("this doesn't work", "this_doesnt_work", false)]
+        [TestCase("this doesn't work", "this_doesn_t_work", true)]
+        [TestCase("this does not work", "this_does_not_work", true)]
+        public void DoesNotSupportApostrophedShortenings(string stepText, string methodName, bool shouldMatch)
+        {
+            var sut = CreateSut();
+
+            var result = CallCalculateRegexFromMethodAndAssertRegex(sut, StepDefinitionType.When,
+                CreateBindingMethod(methodName));
+
+            var match = result.Match(stepText);
+            match.Success.Should().Be(shouldMatch);
         }
 
         [TestCase("When_WHO_does_WHAT_with")]

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/Bindings/StepDefinitionRegexCalculatorTests.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/Bindings/StepDefinitionRegexCalculatorTests.cs
@@ -13,7 +13,7 @@ using TechTalk.SpecFlow.Configuration;
 
 namespace TechTalk.SpecFlow.RuntimeTests.Bindings
 {
-    [TestFixture, Category("wip_gn")]
+    [TestFixture]
     public class StepDefinitionRegexCalculatorTests
     {
         private RuntimeConfiguration runtimeConfiguration;

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/Bindings/StepDefinitionRegexCalculatorTests.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/Bindings/StepDefinitionRegexCalculatorTests.cs
@@ -160,7 +160,6 @@ namespace TechTalk.SpecFlow.RuntimeTests.Bindings
 
         [TestCase("that:Joe,does;something.?!")]
         [TestCase("that : Joe , does ; something .?! ")]
-        [TestCase("!that Joe does something")]
         [TestCase("that -Joe - does -something-")]
         [TestCase("that' Joe does \"something\"")]
         public void SupportsPunctuation(string stepText)
@@ -172,6 +171,19 @@ namespace TechTalk.SpecFlow.RuntimeTests.Bindings
 
             var match = AssertMatches(result, stepText);
             AssertParamMatch(match, "Joe");
+        }
+
+        [TestCase("!that does not work")]
+        [TestCase(" that does not work")]
+        public void DoesNotSupportWhitespaceOrPunctuationInFrontOfStepText(string stepText)
+        {
+            var sut = CreateSut();
+
+            var result = CallCalculateRegexFromMethodAndAssertRegex(sut, StepDefinitionType.When,
+                CreateBindingMethod("When_that_does_not_work", "who"));
+
+            var match = result.Match(stepText);
+            match.Success.Should().BeFalse();
         }
 
         [TestCase("this doesn't work", "this_doesnt_work", false)]

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/RuntimeTests.csproj
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/RuntimeTests.csproj
@@ -42,12 +42,12 @@
       <HintPath>..\..\packages\Castle.Core.3.3.3\lib\net45\Castle.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="FluentAssertions, Version=4.9.0.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\FluentAssertions.4.9.0\lib\net45\FluentAssertions.dll</HintPath>
+    <Reference Include="FluentAssertions, Version=4.19.0.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\FluentAssertions.4.19.0\lib\net45\FluentAssertions.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="FluentAssertions.Core, Version=4.9.0.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\FluentAssertions.4.9.0\lib\net45\FluentAssertions.Core.dll</HintPath>
+    <Reference Include="FluentAssertions.Core, Version=4.19.0.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\FluentAssertions.4.19.0\lib\net45\FluentAssertions.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Moq, Version=4.5.9.0, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/RuntimeTests.csproj
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/RuntimeTests.csproj
@@ -157,6 +157,7 @@
     <Compile Include="BindingSkeletons\StepTextAnalyzerTests.cs" />
     <Compile Include="BindingSkeletons\StringHelpers.cs" />
     <Compile Include="Bindings\BindingRegistryTests.cs" />
+    <Compile Include="Bindings\StepDefinitionRegexCalculatorTests.cs" />
     <Compile Include="Infrastructure\StepDefinitionMatchServiceTest.cs" />
     <Compile Include="RuntimeBindingRegistryBuilderTests.cs" />
     <Compile Include="BindingSourceProcessorStub.cs" />

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/packages.config
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Castle.Core" version="3.3.3" targetFramework="net45" />
-  <package id="FluentAssertions" version="4.9.0" targetFramework="net45" />
+  <package id="FluentAssertions" version="4.19.0" targetFramework="net45" />
   <package id="Moq" version="4.5.9" targetFramework="net45" />
   <package id="NUnit" version="3.2.1" targetFramework="net45" />
   <package id="RhinoMocks" version="3.6.1" targetFramework="net45" />

--- a/Tests/TechTalk.SpecFlow.Specs/Features/StepDefinitionsWithoutRegex.feature
+++ b/Tests/TechTalk.SpecFlow.Specs/Features/StepDefinitionsWithoutRegex.feature
@@ -1,4 +1,5 @@
-﻿Feature: Step definitions can be matched based on the method name (without Regex)
+﻿@wip_gn
+Feature: Step definitions can be matched based on the method name (without Regex)
 
 Scenario: Parameterless steps 
 	Given a scenario 'Simple Scenario' as

--- a/Tests/TechTalk.SpecFlow.Specs/Features/StepDefinitionsWithoutRegex.feature
+++ b/Tests/TechTalk.SpecFlow.Specs/Features/StepDefinitionsWithoutRegex.feature
@@ -1,5 +1,4 @@
-﻿@wip_gn
-Feature: Step definitions can be matched based on the method name (without Regex)
+﻿Feature: Step definitions can be matched based on the method name (without Regex)
 
 Scenario: Parameterless steps 
 	Given a scenario 'Simple Scenario' as

--- a/Tests/TechTalk.SpecFlow.Specs/Features/StepDefinitionsWithoutRegex.feature
+++ b/Tests/TechTalk.SpecFlow.Specs/Features/StepDefinitionsWithoutRegex.feature
@@ -30,6 +30,7 @@ Scenario Outline: Steps with parameters
 		 """
 	When I execute the tests
 	Then the binding method 'When_WHO_does_something' is executed
+	And the scenario should pass
 
 Examples: 
 	| case        | parameter |
@@ -40,7 +41,7 @@ Examples:
 Scenario: Steps with parameters referred by index
 	Given a scenario 'Simple Scenario' as
          """
-			When Joe does something with:
+			When Joe does something with
          """
 	And the following step definitions
 		 """
@@ -53,22 +54,21 @@ Scenario: Steps with parameters referred by index
 	Then the binding method 'When_P0_does_P1_with' is executed
 
 
-Scenario: Steps with multiple parameters and punctuation
+Scenario: Supports punctuation
 	Given a scenario 'Simple Scenario' as
          """
-			When Joe does - something with:
+			When Joe, the man does something with:
 				| table |
          """
 	And the following step definitions
 		 """
 			[When]
-			public void When_WHO_does_WHAT_with(string who, string what, Table table)
+			public void When_WHO_the_man_does_something_with(string who, Table table)
 			{
-				if (what != "something") throw new Exception("invalid parameter: " + what);
 			}
 		 """
 	When I execute the tests
-	Then the binding method 'When_WHO_does_WHAT_with' is executed
+	Then the binding method 'When_WHO_the_man_does_something_with' is executed
 
 
 Scenario: Keyword prefix can be omitted
@@ -123,22 +123,6 @@ Examples:
 	| case                  | method                             |
 	| embedded param        | WhenIDoSomethingHOWMUCHImportant   |
 	| param with underscore | WhenIDoSomething_HOWMUCH_Important |
-	| mixed underscores     | WhenI_Do_SomethingHOWMUCHImportant |
-
-Scenario: Underscore in parameter name
-	Given a scenario 'Simple Scenario' as
-         """
-			When Joe does something
-         """
-	And the following step definitions
-		 """
-			[When]
-			public void When_W_H_O_does_something(string w_h_o)
-			{
-			}
-		 """
-	When I execute the tests
-	Then the binding method 'When_W_H_O_does_something' is executed
 
 @fsharp
 Scenario Outline: F# method name can be used as a regex
@@ -186,14 +170,13 @@ Scenario Outline: Non-English keywords
 			{}
 		 """
 	And the specflow configuration is
-         """
-		<specFlow>
-			<!-- the localized prefixes are detected if the 
-				 feature language or the binding culture is set in the config -->
-			<language feature="de-DE" /> 
-			<!--<bindingCulture name="de-DE" />-->
-		</specFlow>
-         """
+        """
+        <specFlow>
+            <!-- the localized prefixes are detected if the feature language 
+                 is set in the config -->
+            <language feature="de-DE" /> 
+        </specFlow>
+        """
 	When I execute the tests
 	Then the binding method '<method prefix>ich_Knopf_drücke' is executed
 
@@ -204,36 +187,3 @@ Examples:
 	| Single word licalized prefix   | Angenommen  | Angenommen_   |
 	| Multiple word licalized prefix | Gegeben sei | Gegeben_sei_  |
 	| Mixed keyword variants         | Gegeben sei | Angenommen_   |
-
-
-Scenario: Steps with parameters with negative values
-	Given a scenario 'Simple Scenario' as
-         """
-			Given MinimumAmount is -0.01
-         """
-	And the following step definitions
-		 """
-			[Given]
-			public void Given_MinimumAmount_is_P0(decimal p0)
-			{
-			    if (p0 != Convert.ToDecimal(-0.01)) throw new Exception("the parameter passed was not negative");
-			}
-		 """
-	When I execute the tests
-	Then the binding method 'Given_MinimumAmount_is_P0' is executed
-
-Scenario: Steps with currency amounts
-	Given a scenario 'Simple Scenario' as
-         """
-			Given I pay £0.01
-         """
-	And the following step definitions
-		 """
-			[Given]
-			public void Given_I_pay_P0(decimal p0)
-			{
-			    if (p0 != Convert.ToDecimal(0.01)) throw new Exception("the parameter passed was not a number");
-			}
-		 """
-	When I execute the tests
-	Then the binding method 'Given_I_pay_P0' is executed

--- a/Tests/TechTalk.SpecFlow.Specs/StepDefinitions/ExecutionResultSteps.cs
+++ b/Tests/TechTalk.SpecFlow.Specs/StepDefinitions/ExecutionResultSteps.cs
@@ -28,6 +28,7 @@ namespace TechTalk.SpecFlow.Specs.StepDefinitions
         }
 
         [Then(@"all tests should pass")]
+        [Then(@"the scenario should pass")]
         public void ThenAllTestsShouldPass()
         {
             testExecutionResult.LastExecutionSummary.Should().NotBeNull();

--- a/Tests/TechTalk.SpecFlow.Specs/TechTalk.SpecFlow.Specs.csproj
+++ b/Tests/TechTalk.SpecFlow.Specs/TechTalk.SpecFlow.Specs.csproj
@@ -35,12 +35,12 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="FluentAssertions, Version=4.9.0.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\FluentAssertions.4.9.0\lib\net45\FluentAssertions.dll</HintPath>
+    <Reference Include="FluentAssertions, Version=4.19.0.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\FluentAssertions.4.19.0\lib\net45\FluentAssertions.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="FluentAssertions.Core, Version=4.9.0.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\FluentAssertions.4.9.0\lib\net45\FluentAssertions.Core.dll</HintPath>
+    <Reference Include="FluentAssertions.Core, Version=4.19.0.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\FluentAssertions.4.19.0\lib\net45\FluentAssertions.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Gherkin, Version=1.0.0.0, Culture=neutral, PublicKeyToken=86496cfa5b4a5851, processorArchitecture=MSIL">

--- a/Tests/TechTalk.SpecFlow.Specs/packages.config
+++ b/Tests/TechTalk.SpecFlow.Specs/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="FluentAssertions" version="4.9.0" targetFramework="net45" />
+  <package id="FluentAssertions" version="4.19.0" targetFramework="net45" />
   <package id="Gherkin" version="4.0.0" targetFramework="net45" />
   <package id="NUnit" version="3.2.1" targetFramework="net45" />
   <package id="NUnit.ConsoleRunner" version="3.2.1" targetFramework="net45" />

--- a/changelog.txt
+++ b/changelog.txt
@@ -4,6 +4,7 @@ Fixes:
 + Removed obsolete marked StepScopeAttribute - use the ScopeAttribute for it
 + Fixed: Projection<T>.Equals() returns false unnecessarily if table headers differ from property name by casing
 + Fixed regex-less step definition support, see StepDefinitionsWithoutRegex.feature for details
++ Fixed regex-less step definition support for russian language (Issue #715)
 
 
 2.2.0-preview20161020 - 2016-10-20

--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,7 @@
 Fixes:
 + Removed obsolete marked StepScopeAttribute - use the ScopeAttribute for it
 + Fixed: Projection<T>.Equals() returns false unnecessarily if table headers differ from property name by casing
++ Fixed regex-less step definition support, see StepDefinitionsWithoutRegex.feature for details
 
 
 2.2.0-preview20161020 - 2016-10-20

--- a/changelog.txt
+++ b/changelog.txt
@@ -3,8 +3,7 @@
 Fixes:
 + Removed obsolete marked StepScopeAttribute - use the ScopeAttribute for it
 + Fixed: Projection<T>.Equals() returns false unnecessarily if table headers differ from property name by casing
-+ Fixed regex-less step definition support, see StepDefinitionsWithoutRegex.feature for details
-+ Fixed regex-less step definition support for russian language (Issue #715)
++ Fixed regex-less step definition support, see StepDefinitionsWithoutRegex.feature for details (Issues #715, #301)
 
 
 2.2.0-preview20161020 - 2016-10-20


### PR DESCRIPTION
Fix various issues related to step definitions without regex (underscore, pascal case naming).

Added unit tests, removed "tests" from specs
Also fixes #715 #301