### PR TITLE
fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ For issues/bugs please use the [issue tracker on GitHub](https://github.com/tech
 ![Issues closed](http://issuestats.com/github/techtalk/specflow/badge/issue?style=flat-square)
 
 ## Build status
-Continious integration: [![Build status](https://ci.appveyor.com/api/projects/status/h9nb6vii9xj8vbtl?svg=true)](https://ci.appveyor.com/project/SpecFlow/specflow-kx1o3)
+Continuous integration: [![Build status](https://ci.appveyor.com/api/projects/status/h9nb6vii9xj8vbtl?svg=true)](https://ci.appveyor.com/project/SpecFlow/specflow-kx1o3)
 
 CI NuGet Package feed: https://ci.appveyor.com/nuget/specflow-ci
 


### PR DESCRIPTION
This commit fixes the spelling of 'continuous' in README.md