### PR TITLE
Add GitExtensions configuration file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ TechTalk.SpecFlow.Tools/app.config
 TechTalk.SpecFlow.Tools/plugincompability.config
 TechTalk.SpecFlow.sln.GhostDoc.xml
 Features.Generated/
+GitExtensions.settings.backup

--- a/GitExtensions.settings
+++ b/GitExtensions.settings
@@ -1,0 +1,126 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<dictionary>
+  <item>
+    <key>
+      <string>BuildServer.AppVeyor.AppVeyorAccountName</string>
+    </key>
+    <value>
+      <string>SpecFlow</string>
+    </value>
+  </item>
+  <item>
+    <key>
+      <string>BuildServer.AppVeyor.AppVeyorDisplayGitHubPullRequests</string>
+    </key>
+    <value>
+      <string>false</string>
+    </value>
+  </item>
+  <item>
+    <key>
+      <string>BuildServer.AppVeyor.AppVeyorLoadTestsResults</string>
+    </key>
+    <value>
+      <string>false</string>
+    </value>
+  </item>
+  <item>
+    <key>
+      <string>BuildServer.AppVeyor.AppVeyorProjectName</string>
+    </key>
+    <value>
+      <string>SpecFlow</string>
+    </value>
+  </item>
+  <item>
+    <key>
+      <string>BuildServer.EnableIntegration</string>
+    </key>
+    <value>
+      <string>true</string>
+    </value>
+  </item>
+  <item>
+    <key>
+      <string>BuildServer.ShowBuildSummaryInGrid</string>
+    </key>
+    <value>
+      <string>true</string>
+    </value>
+  </item>
+  <item>
+    <key>
+      <string>BuildServer.Type</string>
+    </key>
+    <value>
+      <string>AppVeyor</string>
+    </value>
+  </item>
+  <item>
+    <key>
+      <string>dictionary</string>
+    </key>
+    <value>
+      <string>en-US</string>
+    </value>
+  </item>
+  <item>
+    <key>
+      <string>RevisionLinkDefs</string>
+    </key>
+    <value>
+      <string>&lt;?xml version="1.0" encoding="utf-16"?&gt;
+&lt;ArrayOfGitExtLinkDef xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"&gt;
+  &lt;GitExtLinkDef&gt;
+    &lt;SearchInParts&gt;
+      &lt;RevisionPart&gt;Message&lt;/RevisionPart&gt;
+      &lt;RevisionPart&gt;LocalBranches&lt;/RevisionPart&gt;
+      &lt;RevisionPart&gt;RemoteBranches&lt;/RevisionPart&gt;
+    &lt;/SearchInParts&gt;
+    &lt;LinkFormats&gt;
+      &lt;GitExtLinkFormat&gt;
+        &lt;Caption&gt;Issue {0}&lt;/Caption&gt;
+        &lt;Format&gt;https://github.com/techtalk/SpecFlow/issues/{0}&lt;/Format&gt;
+      &lt;/GitExtLinkFormat&gt;
+    &lt;/LinkFormats&gt;
+    &lt;Name&gt;GitHub - issues&lt;/Name&gt;
+    &lt;SearchPattern&gt;(\s*(,|and)?\s*#\d+)+&lt;/SearchPattern&gt;
+    &lt;NestedSearchPattern&gt;(\d+)+&lt;/NestedSearchPattern&gt;
+    &lt;Enabled&gt;true&lt;/Enabled&gt;
+  &lt;/GitExtLinkDef&gt;
+  &lt;GitExtLinkDef&gt;
+    &lt;SearchInParts&gt;
+      &lt;RevisionPart&gt;Message&lt;/RevisionPart&gt;
+    &lt;/SearchInParts&gt;
+    &lt;LinkFormats&gt;
+      &lt;GitExtLinkFormat&gt;
+        &lt;Caption&gt;View on GitHub&lt;/Caption&gt;
+        &lt;Format&gt;https://github.com/techtalk/SpecFlow/commit/%COMMIT_HASH%&lt;/Format&gt;
+      &lt;/GitExtLinkFormat&gt;
+    &lt;/LinkFormats&gt;
+    &lt;Name&gt;GitHub - commit&lt;/Name&gt;
+    &lt;SearchPattern&gt;.*&lt;/SearchPattern&gt;
+    &lt;NestedSearchPattern /&gt;
+    &lt;Enabled&gt;true&lt;/Enabled&gt;
+  &lt;/GitExtLinkDef&gt;
+  &lt;GitExtLinkDef&gt;
+    &lt;SearchInParts&gt;
+      &lt;RevisionPart&gt;Message&lt;/RevisionPart&gt;
+      &lt;RevisionPart&gt;LocalBranches&lt;/RevisionPart&gt;
+      &lt;RevisionPart&gt;RemoteBranches&lt;/RevisionPart&gt;
+    &lt;/SearchInParts&gt;
+    &lt;LinkFormats&gt;
+      &lt;GitExtLinkFormat&gt;
+        &lt;Caption&gt;PR {0}&lt;/Caption&gt;
+        &lt;Format&gt;https://github.com/techtalk/SpecFlow/pull/{0}&lt;/Format&gt;
+      &lt;/GitExtLinkFormat&gt;
+    &lt;/LinkFormats&gt;
+    &lt;Name&gt;GitHub - PR&lt;/Name&gt;
+    &lt;SearchPattern&gt;Merge pull request (\s*(,|and)?\s*#\d+)+&lt;/SearchPattern&gt;
+    &lt;NestedSearchPattern&gt;(\d+)+&lt;/NestedSearchPattern&gt;
+    &lt;Enabled&gt;true&lt;/Enabled&gt;
+  &lt;/GitExtLinkDef&gt;
+&lt;/ArrayOfGitExtLinkDef&gt;</string>
+    </value>
+  </item>
+</dictionary>


### PR DESCRIPTION
add repository shared gitextensions settings file with configuration for
- github links
- github issues
- appveyor build status

Appveyor support for gitextensions is comming in a version after v2.49 but can be used today with a private build of gitextensions master branch.

![sepcflow-gitextensions-configuration](https://cloud.githubusercontent.com/assets/161882/26673492/62c05f90-46bd-11e7-9cac-5c299de76709.png)
