### PR TITLE
Adds support for xUnit2 ITestOutputHelper #575

### DIFF
--- a/TechTalk.SpecFlow.Generator/UnitTestProvider/XUnit2TestGeneratorProvider.cs
+++ b/TechTalk.SpecFlow.Generator/UnitTestProvider/XUnit2TestGeneratorProvider.cs
@@ -77,12 +77,12 @@ namespace TechTalk.SpecFlow.Generator.UnitTestProvider
             ctorMethod.Parameters.Add(
                 new CodeParameterDeclarationExpression(OUTPUT_INTERFACE, OUTPUT_INTERFACE_PARAMETER_NAME));
 
-            base.SetTestConstructor(generationContext, ctorMethod);
-
             ctorMethod.Statements.Add(
                 new CodeAssignStatement(
-                    new CodeFieldReferenceExpression(new CodeThisReferenceExpression(), OUTPUT_INTERFACE_FIELD_NAME), 
+                    new CodeFieldReferenceExpression(new CodeThisReferenceExpression(), OUTPUT_INTERFACE_FIELD_NAME),
                     new CodeVariableReferenceExpression(OUTPUT_INTERFACE_PARAMETER_NAME)));
+
+            base.SetTestConstructor(generationContext, ctorMethod);
         }
 
         public override void SetTestMethodIgnore(TestClassGenerationContext generationContext, CodeMemberMethod testMethod)
@@ -111,13 +111,13 @@ namespace TechTalk.SpecFlow.Generator.UnitTestProvider
                     );
             }
         }
-        
+
         public override void SetTestClassParallelize(TestClassGenerationContext generationContext)
         {
             CodeDomHelper.AddAttribute(generationContext.TestClass, COLLECTION_ATTRIBUTE, new CodeAttributeArgument(new CodePrimitiveExpression(Guid.NewGuid())));
         }
 
-        public override void FinalizeTestClass(TestClassGenerationContext generationContext) 
+        public override void FinalizeTestClass(TestClassGenerationContext generationContext)
         {
             base.FinalizeTestClass(generationContext);
 

--- a/Tests/TechTalk.SpecFlow.GeneratorTests/XUnit2TestGeneratorProviderTests.cs
+++ b/Tests/TechTalk.SpecFlow.GeneratorTests/XUnit2TestGeneratorProviderTests.cs
@@ -1,4 +1,6 @@
 ﻿using System.CodeDom;
+using System.Globalization;
+using System.IO;
 using System.Linq;
 
 using NUnit.Framework;
@@ -8,12 +10,22 @@ using TechTalk.SpecFlow.Utils;
 using TechTalk.SpecFlow.Parser;
 using TechTalk.SpecFlow.Generator.UnitTestProvider;
 
+using FluentAssertions;
 
 namespace TechTalk.SpecFlow.GeneratorTests
 {
     [TestFixture]
     public class XUnit2TestGeneratorProviderTests
     {
+        private const string SampleFeatureFile = @"
+            Feature: Sample feature file
+
+            Scenario: Simple scenario
+                Given there is something
+                When I do something
+                Then something should happen";
+
+        
         [Test]
         public void Should_set_displayname_theory_attribute()
         {
@@ -62,5 +74,84 @@ namespace TechTalk.SpecFlow.GeneratorTests
             Assert.That(primitiveExpression, Is.Not.Null);
             Assert.That(primitiveExpression.Value, Is.EqualTo("Foo"));
         }
+
+        [Test]
+        public void Should_initialize_testOutputHelper_field_in_constructor()
+        {
+            SpecFlowGherkinParser parser = new SpecFlowGherkinParser(new CultureInfo("en-US"));
+            using (var reader = new StringReader(SampleFeatureFile))
+            {
+                SpecFlowDocument document = parser.Parse(reader, null);
+                Assert.IsNotNull(document);
+
+                var provider = new XUnit2TestGeneratorProvider(new CodeDomHelper(CodeDomProviderLanguage.CSharp));
+
+                var converter = provider.CreateUnitTestConverter();
+                CodeNamespace code = converter.GenerateUnitTestFixture(document, "TestClassName", "Target.Namespace");
+
+                Assert.IsNotNull(code);
+                var classContructor = code.Class().Members().Single(m => m.Name == ".ctor");
+                classContructor.Should().NotBeNull();
+                classContructor.Parameters.Count.Should().Be(2);
+                classContructor.Parameters[1].Type.BaseType.Should().Be("Xunit.Abstractions.ITestOutputHelper");
+                classContructor.Parameters[1].Name.Should().Be("testOutputHelper");
+
+                var initOutputHelper = classContructor.Statements.OfType<CodeAssignStatement>().First();
+                initOutputHelper.Should().NotBeNull();
+                ((CodeFieldReferenceExpression)(initOutputHelper.Left)).FieldName.Should().Be("_testOutputHelper");
+                ((CodeVariableReferenceExpression)(initOutputHelper.Right)).VariableName.Should().Be("testOutputHelper");
+            }
+        }
+        
+        [Test]
+        public void Should_add_testOutputHelper_field_in_class()
+        {
+            SpecFlowGherkinParser parser = new SpecFlowGherkinParser(new CultureInfo("en-US"));
+            using (var reader = new StringReader(SampleFeatureFile))
+            {
+                SpecFlowDocument document = parser.Parse(reader, null);
+                Assert.IsNotNull(document);
+
+                var provider = new XUnit2TestGeneratorProvider(new CodeDomHelper(CodeDomProviderLanguage.CSharp));
+
+                var converter = provider.CreateUnitTestConverter();
+                CodeNamespace code = converter.GenerateUnitTestFixture(document, "TestClassName", "Target.Namespace");
+
+                Assert.IsNotNull(code);
+                var loggerInstance = code.Class().Members.OfType<CodeMemberField>().First(m => m.Name == @"_testOutputHelper");
+                loggerInstance.Type.BaseType.Should().Be("Xunit.Abstractions.ITestOutputHelper");
+                loggerInstance.Attributes.Should().Be(MemberAttributes.Private | MemberAttributes.Final);
+            }
+        }
+
+        [Test]
+        public void Should_register_testOutputHelper_on_scenario_setup()
+        {
+            SpecFlowGherkinParser parser = new SpecFlowGherkinParser(new CultureInfo("en-US"));
+            using (var reader = new StringReader(SampleFeatureFile))
+            {
+                SpecFlowDocument document = parser.Parse(reader, null);
+                Assert.IsNotNull(document);
+
+                var provider = new XUnit2TestGeneratorProvider(new CodeDomHelper(CodeDomProviderLanguage.CSharp));
+
+                var converter = provider.CreateUnitTestConverter();
+                CodeNamespace code = converter.GenerateUnitTestFixture(document, "TestClassName", "Target.Namespace");
+
+                Assert.IsNotNull(code);
+                var scenarioStartMethod = code.Class().Members().Single(m => m.Name == @"ScenarioSetup");
+
+                scenarioStartMethod.Statements.Count.Should().Be(2);
+                var expression = (scenarioStartMethod.Statements[1] as CodeExpressionStatement).Expression;
+                var method = (expression as CodeMethodInvokeExpression).Method;
+                (method.TargetObject as CodePropertyReferenceExpression).PropertyName.Should().Be("ScenarioContainer");
+                method.MethodName.Should().Be("RegisterInstanceAs");
+                method.TypeArguments.Should().NotBeNullOrEmpty();
+                method.TypeArguments[0].BaseType.Should().Be("Xunit.Abstractions.ITestOutputHelper");
+
+                ((expression as CodeMethodInvokeExpression).Parameters[0] as CodeVariableReferenceExpression).VariableName.Should().Be("_testOutputHelper");
+            }
+        }
+
     }
 }

--- a/Tests/TechTalk.SpecFlow.Specs/Drivers/XUnitTestExecutionDriver.cs
+++ b/Tests/TechTalk.SpecFlow.Specs/Drivers/XUnitTestExecutionDriver.cs
@@ -26,27 +26,26 @@ namespace TechTalk.SpecFlow.Specs.Drivers
             var xunitConsolePath = Path.Combine(AssemblyFolderHelper.GetTestAssemblyFolder(), @"xunit.runner.console\tools\xunit.console.exe");
 
             var provessHelper = new ProcessHelper();
-            provessHelper.RunProcess(xunitConsolePath, "\"{0}\" -nunit \"{1}\"",
+            provessHelper.RunProcess(xunitConsolePath, "\"{0}\" -xml \"{1}\"",
                 inputProjectDriver.CompiledAssemblyPath, resultFilePath);
-           
+
             File.WriteAllText(logFilePath, provessHelper.ConsoleOutput);
-            return ProcessNUnitResult(logFilePath, resultFilePath);
+            return ProcessXUnitResult(logFilePath, resultFilePath);
         }
 
-        private TestRunSummary ProcessNUnitResult(string logFilePath, string resultFilePath)
+        private TestRunSummary ProcessXUnitResult(string logFilePath, string resultFilePath)
         {
             XDocument resultFileXml = XDocument.Load(resultFilePath);
 
             TestRunSummary summary = new TestRunSummary();
 
-            summary.Total = resultFileXml.XPathSelectElements("//test-case").Count();
-            summary.Succeeded = resultFileXml.XPathSelectElements("//test-case[@executed = 'True' and @success='True']").Count();
+            summary.Total = resultFileXml.XPathSelectElements("//test").Count();
+            summary.Succeeded = resultFileXml.XPathSelectElements("//test[@result = 'Pass']").Count();
             summary.Failed =
-                resultFileXml.XPathSelectElements("//test-case[@executed = 'True' and @success='False' and failure]").Count();
-            summary.Pending =
-                resultFileXml.XPathSelectElements("//test-case[@executed = 'True' and @success='False' and not(failure)]").Count
+                resultFileXml.XPathSelectElements("//test[@result = 'Fail']").Count();
+            summary.Ignored =
+                resultFileXml.XPathSelectElements("//test[@result = 'Skip']").Count
                     ();
-            summary.Ignored = resultFileXml.XPathSelectElements("//test-case[@executed = 'False']").Count();
 
             testExecutionResult.LastExecutionSummary = summary;
             testExecutionResult.ExecutionLog = File.ReadAllText(logFilePath);
@@ -55,6 +54,6 @@ namespace TechTalk.SpecFlow.Specs.Drivers
             Console.WriteLine(testExecutionResult.ExecutionLog);
 
             return summary;
-        }
+        }        
     }
 }

--- a/Tests/TechTalk.SpecFlow.Specs/Features/XUnit2Provider.feature
+++ b/Tests/TechTalk.SpecFlow.Specs/Features/XUnit2Provider.feature
@@ -86,3 +86,56 @@ Scenario: Should be able to specify xUnit provider in the configuration
 		| Total | 
 		| 1     | 
 	
+Scenario: Should be able to log custom messages
+Given there is a SpecFlow project
+And the project is configured to use the xUnit provider
+And a scenario 'Simple Scenario' as
+		"""
+		When I do something
+		"""	
+And the following step definition
+         """
+         [When(@"I do something")]
+		 public void WhenIDoSomething()
+		 {
+			ScenarioContext.Current.ScenarioContainer.Resolve<Xunit.Abstractions.ITestOutputHelper>().WriteLine("hello");
+		 }
+         """
+		 When I execute the tests with xUnit
+	Then the execution summary should contain
+		| Succeeded |
+		| 1         |
+
+
+
+Scenario: Should be able to log custom messages using context injection
+	Given there is a SpecFlow project
+	And the project is configured to use the xUnit provider
+	And the following binding class
+        """
+		[Binding]
+		public class StepsWithScenarioContext
+		{
+			private ScenarioContext _scenarioContext;
+			private Xunit.Abstractions.ITestOutputHelper _output;
+			public StepsWithScenarioContext(ScenarioContext scenarioContext)
+			{
+				_scenarioContext = scenarioContext;
+				_output = _scenarioContext.ScenarioContainer.Resolve<Xunit.Abstractions.ITestOutputHelper>();
+			}
+
+			[When(@"I do something")]
+			public void WhenIDoSomething()
+			{
+				_output.WriteLine("something");
+			}
+		}
+        """	
+	And a scenario 'Simple Scenario' as
+         """
+         When I do something         
+         """
+	When I execute the tests with xUnit
+	Then the execution summary should contain
+         | Succeeded |
+         | 1         |


### PR DESCRIPTION
Merged PR #788 and #689 to fix #575. Added unit tests to XUnit2TestGeneratorProviderTests.cs and scenarios to XUnit2Provider.feature as requested in comments in the earlier pull requests. 