### PR TITLE
Fix generation from visual studio

### DIFF
--- a/TechTalk.SpecFlow.Generator/Interfaces/FeatureFileInput.cs
+++ b/TechTalk.SpecFlow.Generator/Interfaces/FeatureFileInput.cs
@@ -3,6 +3,12 @@ using System.IO;
 
 namespace TechTalk.SpecFlow.Generator.Interfaces
 {
+    /// IMPORTANT
+    /// This class is used for interop with the Visual Studio Extension
+    /// DO NOT REMOVE OR RENAME FIELDS!
+    /// This breaks binary serialization accross appdomains
+    /// 
+    /// 
     /// <summary>
     /// Represents the information related to a feature file as an input of the generation
     /// </summary>

--- a/TechTalk.SpecFlow.Generator/Interfaces/GenerationSettings.cs
+++ b/TechTalk.SpecFlow.Generator/Interfaces/GenerationSettings.cs
@@ -1,10 +1,16 @@
 ﻿using System;
 
 namespace TechTalk.SpecFlow.Generator.Interfaces
-{
-    /// <summary>
-    /// Settings for test generation
-    /// </summary>
+{  
+    /// IMPORTANT
+    /// This class is used for interop with the Visual Studio Extension
+    /// DO NOT REMOVE OR RENAME FIELDS!
+    /// This breaks binary serialization accross appdomains
+    /// 
+    /// 
+   /// <summary>
+   /// Settings for test generation
+   /// </summary>
     [Serializable]
     public class GenerationSettings
     {

--- a/TechTalk.SpecFlow.Generator/Interfaces/ITestGenerator.cs
+++ b/TechTalk.SpecFlow.Generator/Interfaces/ITestGenerator.cs
@@ -3,6 +3,10 @@ using System.IO;
 
 namespace TechTalk.SpecFlow.Generator.Interfaces
 {
+    /// IMPORTANT
+    /// This class is used for interop with the Visual Studio Extension
+    /// DO NOT REMOVE OR RENAME FIELDS!
+    /// This breaks binary serialization accross appdomains
     public interface ITestGenerator : IDisposable
     {
         TestGeneratorResult GenerateTestFile(FeatureFileInput featureFileInput, GenerationSettings settings);

--- a/TechTalk.SpecFlow.Generator/Interfaces/ITestGeneratorFactory.cs
+++ b/TechTalk.SpecFlow.Generator/Interfaces/ITestGeneratorFactory.cs
@@ -2,6 +2,10 @@
 
 namespace TechTalk.SpecFlow.Generator.Interfaces
 {
+    /// IMPORTANT
+    /// This class is used for interop with the Visual Studio Extension
+    /// DO NOT REMOVE OR RENAME FIELDS!
+    /// This breaks binary serialization accross appdomains
     public interface ITestGeneratorFactory
     {
         Version GetGeneratorVersion();

--- a/TechTalk.SpecFlow.Generator/Interfaces/ProjectPlatformSettings.cs
+++ b/TechTalk.SpecFlow.Generator/Interfaces/ProjectPlatformSettings.cs
@@ -2,6 +2,10 @@
 
 namespace TechTalk.SpecFlow.Generator.Interfaces
 {
+    /// IMPORTANT
+    /// This class is used for interop with the Visual Studio Extension
+    /// DO NOT REMOVE OR RENAME FIELDS!
+    /// This breaks binary serialization accross appdomains
     [Serializable]
     public class ProjectPlatformSettings
     {

--- a/TechTalk.SpecFlow.Generator/Interfaces/ProjectSettings.cs
+++ b/TechTalk.SpecFlow.Generator/Interfaces/ProjectSettings.cs
@@ -3,6 +3,10 @@ using TechTalk.SpecFlow.Configuration;
 
 namespace TechTalk.SpecFlow.Generator.Interfaces
 {
+    /// IMPORTANT
+    /// This class is used for interop with the Visual Studio Extension
+    /// DO NOT REMOVE OR RENAME FIELDS!
+    /// This breaks binary serialization accross appdomains
     [Serializable]
     public class ProjectSettings
     {

--- a/TechTalk.SpecFlow.Generator/Interfaces/SpecFlowConfigurationHolder.cs
+++ b/TechTalk.SpecFlow.Generator/Interfaces/SpecFlowConfigurationHolder.cs
@@ -4,6 +4,10 @@ using TechTalk.SpecFlow.Configuration;
 
 namespace TechTalk.SpecFlow.Generator.Interfaces
 {
+    /// IMPORTANT
+    /// This class is used for interop with the Visual Studio Extension
+    /// DO NOT REMOVE OR RENAME FIELDS!
+    /// This breaks binary serialization accross appdomains
     [Serializable]
     public class SpecFlowConfigurationHolder : ISpecFlowConfigurationHolder
     {

--- a/TechTalk.SpecFlow.Generator/Interfaces/SpecFlowConfigurationHolder.cs
+++ b/TechTalk.SpecFlow.Generator/Interfaces/SpecFlowConfigurationHolder.cs
@@ -7,28 +7,28 @@ namespace TechTalk.SpecFlow.Generator.Interfaces
     [Serializable]
     public class SpecFlowConfigurationHolder : ISpecFlowConfigurationHolder
     {
-        private readonly string _content;
+        private readonly string xmlString;
 
         public ConfigSource ConfigSource { get; private set; }
 
-        public string Content => _content;
+        public string Content => xmlString;
 
-        public bool HasConfiguration => !string.IsNullOrEmpty(_content);
+        public bool HasConfiguration => !string.IsNullOrEmpty(xmlString);
 
         public SpecFlowConfigurationHolder()
         {
-            _content = null;
+            xmlString = null;
         }
 
         public SpecFlowConfigurationHolder(ConfigSource configSource, string content)
         {
             ConfigSource = configSource;
-            _content = content;
+            xmlString = content;
         }
 
         public SpecFlowConfigurationHolder(XmlNode configXmlNode)
         {
-            _content = configXmlNode?.OuterXml;
+            xmlString = configXmlNode?.OuterXml;
             ConfigSource = ConfigSource.AppConfig;
         }
     }

--- a/TechTalk.SpecFlow.Generator/Interfaces/TestGenerationError.cs
+++ b/TechTalk.SpecFlow.Generator/Interfaces/TestGenerationError.cs
@@ -2,6 +2,10 @@
 
 namespace TechTalk.SpecFlow.Generator.Interfaces
 {
+    /// IMPORTANT
+    /// This class is used for interop with the Visual Studio Extension
+    /// DO NOT REMOVE OR RENAME FIELDS!
+    /// This breaks binary serialization accross appdomains
     [Serializable]
     public class TestGenerationError
     {

--- a/TechTalk.SpecFlow.Generator/Interfaces/TestGeneratorFactoryAttribute.cs
+++ b/TechTalk.SpecFlow.Generator/Interfaces/TestGeneratorFactoryAttribute.cs
@@ -2,6 +2,10 @@
 
 namespace TechTalk.SpecFlow.Generator.Interfaces
 {
+    /// IMPORTANT
+    /// This class is used for interop with the Visual Studio Extension
+    /// DO NOT REMOVE OR RENAME FIELDS!
+    /// This breaks binary serialization accross appdomains
     [AttributeUsage(AttributeTargets.Assembly)]
     public class TestGeneratorFactoryAttribute : Attribute
     {

--- a/TechTalk.SpecFlow.Generator/Interfaces/TestGeneratorResult.cs
+++ b/TechTalk.SpecFlow.Generator/Interfaces/TestGeneratorResult.cs
@@ -4,6 +4,10 @@ using System.Linq;
 
 namespace TechTalk.SpecFlow.Generator.Interfaces
 {
+    /// IMPORTANT
+    /// This class is used for interop with the Visual Studio Extension
+    /// DO NOT REMOVE OR RENAME FIELDS!
+    /// This breaks binary serialization accross appdomains
     [Serializable]
     public class TestGeneratorResult
     {

--- a/TechTalk.SpecFlow/Configuration/SpecFlowConfiguration.cs
+++ b/TechTalk.SpecFlow/Configuration/SpecFlowConfiguration.cs
@@ -12,9 +12,9 @@ namespace TechTalk.SpecFlow.Configuration
 {
     public enum ConfigSource
     {
-        Default,
         AppConfig,
-        Json
+        Json,
+        Default
     }
 
     public class SpecFlowConfiguration

--- a/Tests/TechTalk.SpecFlow.GeneratorTests/FeatureGeneratorRegistryTests.cs
+++ b/Tests/TechTalk.SpecFlow.GeneratorTests/FeatureGeneratorRegistryTests.cs
@@ -20,7 +20,7 @@ namespace TechTalk.SpecFlow.GeneratorTests
         [SetUp]
         public void Setup()
         {
-            container = GeneratorContainerBuilder.CreateContainer(new SpecFlowConfigurationHolder(), new ProjectSettings());
+            container = GeneratorContainerBuilder.CreateContainer(new SpecFlowConfigurationHolder(ConfigSource.Default, null), new ProjectSettings());
         }
 
         private FeatureGeneratorRegistry CreateFeatureGeneratorRegistry()
@@ -103,7 +103,7 @@ namespace TechTalk.SpecFlow.GeneratorTests
         [Test]
         public void Should_FeatureGeneratorRegistry_be_registered_as_IFeatureGeneratorRegistry_by_default()
         {
-            var testContainer = GeneratorContainerBuilder.CreateContainer(new SpecFlowConfigurationHolder(), new ProjectSettings());
+            var testContainer = GeneratorContainerBuilder.CreateContainer(new SpecFlowConfigurationHolder(ConfigSource.Default, null), new ProjectSettings());
 
             var registry = testContainer.Resolve<IFeatureGeneratorRegistry>();
 

--- a/Tests/TechTalk.SpecFlow.GeneratorTests/GeneratorContainerBuilderTests.cs
+++ b/Tests/TechTalk.SpecFlow.GeneratorTests/GeneratorContainerBuilderTests.cs
@@ -15,14 +15,14 @@ namespace TechTalk.SpecFlow.GeneratorTests
         [Test]
         public void Should_create_a_container()
         {
-            var container = GeneratorContainerBuilder.CreateContainer(new SpecFlowConfigurationHolder(), new ProjectSettings());
+            var container = GeneratorContainerBuilder.CreateContainer(new SpecFlowConfigurationHolder(ConfigSource.Default, null), new ProjectSettings());
             container.Should().NotBeNull();
         }
 
         [Test]
         public void Should_register_generator_configuration_with_default_config()
         {
-            var container = GeneratorContainerBuilder.CreateContainer(new SpecFlowConfigurationHolder(), new ProjectSettings());
+            var container = GeneratorContainerBuilder.CreateContainer(new SpecFlowConfigurationHolder(ConfigSource.Default, null), new ProjectSettings());
             container.Resolve<Configuration.SpecFlowConfiguration>().Should().NotBeNull();
         }
 

--- a/Tests/TechTalk.SpecFlow.GeneratorTests/IgnoredTestGeneratorTests.cs
+++ b/Tests/TechTalk.SpecFlow.GeneratorTests/IgnoredTestGeneratorTests.cs
@@ -25,7 +25,7 @@ namespace TechTalk.SpecFlow.GeneratorTests
         [SetUp]
         public void Setup()
         {
-            container = GeneratorContainerBuilder.CreateContainer(new SpecFlowConfigurationHolder(), new ProjectSettings());
+            container = GeneratorContainerBuilder.CreateContainer(new SpecFlowConfigurationHolder(ConfigSource.Default, null), new ProjectSettings());
             unitTestGeneratorProviderMock = new Mock<IUnitTestGeneratorProvider>();
             container.RegisterInstanceAs(unitTestGeneratorProviderMock.Object);
         }

--- a/Tests/TechTalk.SpecFlow.GeneratorTests/NUnit3GeneratorProviderTests.cs
+++ b/Tests/TechTalk.SpecFlow.GeneratorTests/NUnit3GeneratorProviderTests.cs
@@ -82,7 +82,7 @@ namespace TechTalk.SpecFlow.GeneratorTests
 
         private static IFeatureGenerator CreateFeatureGenerator(bool parallelCode,string[] ignoreParallelTags)
         {
-            var container = GeneratorContainerBuilder.CreateContainer(new SpecFlowConfigurationHolder(), new ProjectSettings());
+            var container = GeneratorContainerBuilder.CreateContainer(new SpecFlowConfigurationHolder(ConfigSource.Default, null), new ProjectSettings());
             var specFlowConfiguration = container.Resolve<SpecFlowConfiguration>();
             specFlowConfiguration.MarkFeaturesParallelizable = parallelCode;
             specFlowConfiguration.SkipParallelizableMarkerForTags = ignoreParallelTags ??

--- a/Tests/TechTalk.SpecFlow.GeneratorTests/TestGeneratorFactoryTests.cs
+++ b/Tests/TechTalk.SpecFlow.GeneratorTests/TestGeneratorFactoryTests.cs
@@ -29,6 +29,7 @@ namespace TechTalk.SpecFlow.GeneratorTests
         [Test]
         public void Should_be_able_to_create_generator_with_default_config()
         {
+            net35CSProjectSettings.ConfigurationHolder = new SpecFlowConfigurationHolder(ConfigSource.Default, null);
             factory.CreateGenerator(net35CSProjectSettings).Should().NotBeNull();
         }
 

--- a/Tests/TechTalk.SpecFlow.GeneratorTests/UnitTestFeatureGeneratorTests.cs
+++ b/Tests/TechTalk.SpecFlow.GeneratorTests/UnitTestFeatureGeneratorTests.cs
@@ -29,7 +29,7 @@ namespace TechTalk.SpecFlow.GeneratorTests
 
         protected virtual void SetupInternal()
         {
-            container = GeneratorContainerBuilder.CreateContainer(new SpecFlowConfigurationHolder(), new ProjectSettings());
+            container = GeneratorContainerBuilder.CreateContainer(new SpecFlowConfigurationHolder(ConfigSource.Default, null), new ProjectSettings());
             unitTestGeneratorProviderMock = new Mock<IUnitTestGeneratorProvider>();
             container.RegisterInstanceAs(unitTestGeneratorProviderMock.Object);
         }


### PR DESCRIPTION
During the work on PR https://github.com/techtalk/SpecFlow/pull/690 a refactoring changed https://github.com/techtalk/SpecFlow/blob/master/TechTalk.SpecFlow.Generator/Interfaces/SpecFlowConfigurationHolder.cs.
But this class is used in the Visual Studio Extension as parameter when the code generation is triggered (https://github.com/techtalk/SpecFlow.VisualStudio/blob/master/IdeIntegration/Generator/RemoteAppDomainTestGeneratorFactory.cs#L186).
As the two classes were different, the serialization could not deserialize the _content field.

This PR fixes that, with renaming the field back to _xmlString and adjusting the ConfigSource enum to have AppConfig as default value.