### PR TITLE
@MsBuild [DeploymentItem] - added option to provide output directory

### DIFF
--- a/TechTalk.SpecFlow.Generator/UnitTestProvider/MsTest2010GeneratorProvider.cs
+++ b/TechTalk.SpecFlow.Generator/UnitTestProvider/MsTest2010GeneratorProvider.cs
@@ -85,7 +85,15 @@ namespace TechTalk.SpecFlow.Generator.UnitTestProvider
                 IEnumerable<string> deploymentItems = generationContext.CustomData[DEPLOYMENTITEM_TAG] as IEnumerable<string>;
                 foreach (string deploymentItem in deploymentItems)
                 {
-                    CodeDomHelper.AddAttribute(testMethod, DEPLOYMENTITEM_ATTR, deploymentItem);
+                    var outputDirProvided = deploymentItem.Split(':').Any();
+                    if (!outputDirProvided)
+                    {
+                        CodeDomHelper.AddAttribute(testMethod, DEPLOYMENTITEM_ATTR, deploymentItem);
+                    }
+                    else
+                    {
+                        CodeDomHelper.AddAttribute(testMethod, DEPLOYMENTITEM_ATTR, deploymentItem.Split(':'));
+                    }
                 }
             }
         }

--- a/TechTalk.SpecFlow.Generator/UnitTestProvider/MsTest2010GeneratorProvider.cs
+++ b/TechTalk.SpecFlow.Generator/UnitTestProvider/MsTest2010GeneratorProvider.cs
@@ -86,13 +86,13 @@ namespace TechTalk.SpecFlow.Generator.UnitTestProvider
                 foreach (string deploymentItem in deploymentItems)
                 {
                     var outputDirProvided = deploymentItem.Split(':').Any();
-                    if (!outputDirProvided)
+                    if (outputDirProvided)
                     {
-                        CodeDomHelper.AddAttribute(testMethod, DEPLOYMENTITEM_ATTR, deploymentItem);
+                        CodeDomHelper.AddAttribute(testMethod, DEPLOYMENTITEM_ATTR, deploymentItem.Split(':'));
                     }
                     else
                     {
-                        CodeDomHelper.AddAttribute(testMethod, DEPLOYMENTITEM_ATTR, deploymentItem.Split(':'));
+                        CodeDomHelper.AddAttribute(testMethod, DEPLOYMENTITEM_ATTR, deploymentItem);
                     }
                 }
             }

--- a/Tests/TechTalk.SpecFlow.Specs/Drivers/InputProjectDriver.cs
+++ b/Tests/TechTalk.SpecFlow.Specs/Drivers/InputProjectDriver.cs
@@ -147,11 +147,19 @@ namespace TechTalk.SpecFlow.Specs.Drivers
 
         public ContentFileInput AddContentFile(string fileName, string fileContent)
         {
+            var contentFileInput = GetContentFileInput(fileName, fileContent);
+            ContentFiles.Add(contentFileInput);
+            return contentFileInput;
+        }
+
+        private static ContentFileInput GetContentFileInput(string fileName, string fileContent)
+        {
             var file = Path.GetFileName(fileName);
             var directory = Path.GetDirectoryName(fileName);
 
-            var contentFileInput = string.IsNullOrEmpty(directory) || directory == "." ? new ContentFileInput(file, fileContent) : new ContentFileInput(file, fileContent, directory);
-            ContentFiles.Add(contentFileInput);
+            var isDirectoryProvided = !string.IsNullOrEmpty(directory) && directory != ".";
+
+            var contentFileInput = isDirectoryProvided ? new ContentFileInput(file, fileContent, directory) : new ContentFileInput(file, fileContent);
             return contentFileInput;
         }
 

--- a/Tests/TechTalk.SpecFlow.Specs/Drivers/InputProjectDriver.cs
+++ b/Tests/TechTalk.SpecFlow.Specs/Drivers/InputProjectDriver.cs
@@ -147,7 +147,10 @@ namespace TechTalk.SpecFlow.Specs.Drivers
 
         public ContentFileInput AddContentFile(string fileName, string fileContent)
         {
-            var contentFileInput = new ContentFileInput(fileName, fileContent);
+            var file = Path.GetFileName(fileName);
+            var directory = Path.GetDirectoryName(fileName);
+
+            var contentFileInput = string.IsNullOrEmpty(directory) || directory == "." ? new ContentFileInput(file, fileContent) : new ContentFileInput(file, fileContent, directory);
             ContentFiles.Add(contentFileInput);
             return contentFileInput;
         }

--- a/Tests/TechTalk.SpecFlow.Specs/Drivers/MsBuild/ProjectGenerator.cs
+++ b/Tests/TechTalk.SpecFlow.Specs/Drivers/MsBuild/ProjectGenerator.cs
@@ -64,7 +64,7 @@ namespace TechTalk.SpecFlow.Specs.Drivers.MsBuild
             foreach (var contentFileInput in inputProjectDriver.ContentFiles)
             {
                 string outputPath = Path.Combine(inputProjectDriver.CompilationFolder, contentFileInput.ProjectRelativePath);
-                new FileInfo(outputPath).Directory?.Create();
+                Directory.CreateDirectory(Path.GetDirectoryName(outputPath));
                 File.WriteAllText(outputPath, contentFileInput.Content, Encoding.UTF8);
                 project.AddItem("Content", contentFileInput.ProjectRelativePath, new[]
                                                                                   {

--- a/Tests/TechTalk.SpecFlow.Specs/Drivers/MsBuild/ProjectGenerator.cs
+++ b/Tests/TechTalk.SpecFlow.Specs/Drivers/MsBuild/ProjectGenerator.cs
@@ -64,6 +64,7 @@ namespace TechTalk.SpecFlow.Specs.Drivers.MsBuild
             foreach (var contentFileInput in inputProjectDriver.ContentFiles)
             {
                 string outputPath = Path.Combine(inputProjectDriver.CompilationFolder, contentFileInput.ProjectRelativePath);
+                new FileInfo(outputPath).Directory?.Create();
                 File.WriteAllText(outputPath, contentFileInput.Content, Encoding.UTF8);
                 project.AddItem("Content", contentFileInput.ProjectRelativePath, new[]
                                                                                   {

--- a/Tests/TechTalk.SpecFlow.Specs/Features/MsTestProvider.feature
+++ b/Tests/TechTalk.SpecFlow.Specs/Features/MsTestProvider.feature
@@ -109,3 +109,54 @@ Scenario: Should be able to deploy files
 	Then the execution summary should contain
          | Succeeded |
          | 1         |
+
+@config
+Scenario: Should be able to deploy files to specific folder
+    Given there is a SpecFlow project
+	And the following binding class
+        """
+		using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+		[Binding]
+		public class DeploymentItemSteps
+		{
+			[Then(@"the file '(.*)' exists")]
+			public void ThenTheFileExists(string fileName)
+			{
+			    Assert.IsTrue(File.Exists(fileName));
+			}
+		}
+        """
+	And there is a feature file in the project as
+         """
+		 @MsTest:DeploymentItem:TestXmls\:TestXmls
+		 Feature: Deployment Item Feature
+	
+		 Scenario: Deployment Item Scenario
+			Then the file 'TestXmls\DeploymentItemTestFile.txt' exists
+         """
+	And there is a content file 'TestXmls\DeploymentItemTestFile.txt' in the project as
+		"""
+		This is a deployment item file
+		"""
+	And the specflow configuration is
+		"""
+		<specFlow>
+			<unitTestProvider name="MsTest"/>
+		</specFlow>
+		"""
+	And there is a test settings file 'Local.testsettings'
+		"""
+		<?xml version="1.0" encoding="UTF-8"?>
+		<TestSettings
+		  id="b8f2810b-cd53-4519-8b18-d0e599219d54"
+		  name="Local"
+		  enableDefaultDataCollectors="false"
+		  xmlns="http://microsoft.com/schemas/VisualStudio/TeamTest/2010">
+		  <Deployment enabled="true" />
+		</TestSettings>
+		"""
+	When I execute the tests with MsTest
+	Then the execution summary should contain
+         | Succeeded |
+         | 1         |

--- a/Tests/TechTalk.SpecFlow.Specs/Features/MsTestProvider.feature
+++ b/Tests/TechTalk.SpecFlow.Specs/Features/MsTestProvider.feature
@@ -129,13 +129,13 @@ Scenario: Should be able to deploy files to specific folder
         """
 	And there is a feature file in the project as
          """
-		 @MsTest:DeploymentItem:TestXmls\:TestXmls
+		 @MsTest:DeploymentItem:Resources\DeploymentItemTestFile.txt:Data
 		 Feature: Deployment Item Feature
 	
 		 Scenario: Deployment Item Scenario
-			Then the file 'TestXmls\DeploymentItemTestFile.txt' exists
+			Then the file 'Data\DeploymentItemTestFile.txt' exists
          """
-	And there is a content file 'TestXmls\DeploymentItemTestFile.txt' in the project as
+	And there is a content file 'Resources\DeploymentItemTestFile.txt' in the project as
 		"""
 		This is a deployment item file
 		"""


### PR DESCRIPTION
[DeploymentItem] has an option to provide output directory, so either file or a complete source dir will be copied to new output dir:

[DeploymentItem("test1.xml")] //file available in root
[DeploymentItem("test2.xml", "Data")] //file available in Data dir (Data\test2.xml)
[DeploymentItem("Resources\\test3.xml")] //file available in  root
[DeploymentItem("Resources\\test4.xml", "Data")] //file available in Data dir (Data\test4.xml)
[DeploymentItem("Resources\\", "Data")] //all files available in Data dir (Data\*)

Current solution will preserve the current functionallity, output directory is an optional parameter. Changes needed to support this feature:
- MsTest2010GeneratorProvider.cs - understand @msbuild:deploymentitem:FileToDeploy:OutputDir syntax
- InputProjectDriver.cs - files can be created in unit tests under specific folder
- ProjectGenerator.cs - create structure of content files with directories.
- MsTestProvider.feature - test of how it should work