### PR TITLE
use FileStream constructor which grants ReadWrite to other processes.

### DIFF
--- a/TechTalk.SpecFlow.Generator/Project/MsBuildProjectReader.cs
+++ b/TechTalk.SpecFlow.Generator/Project/MsBuildProjectReader.cs
@@ -27,7 +27,7 @@ namespace TechTalk.SpecFlow.Generator.Project
         {
             var projectFolder = Path.GetDirectoryName(projectFilePath);
 
-            using (var filestream = new FileStream(projectFilePath, FileMode.Open))
+            using (var filestream = new FileStream(projectFilePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
             {
                 var xDocument = XDocument.Load(filestream);
 


### PR DESCRIPTION
~~use FileStream constructor which grants ReadWrite to other processes~~

Use another FileStream constructor, to be able to also read _readonly_ files.
See https://msdn.microsoft.com/en-us/library/47ek66wy(v=vs.110).aspx#Anchor_2

https://github.com/techtalk/SpecFlow/issues/904