### PR TITLE
Allowed custom XSLT transforms to contain scripts.

### DIFF
--- a/TechTalk.SpecFlow.Reporting/XsltHelper.cs
+++ b/TechTalk.SpecFlow.Reporting/XsltHelper.cs
@@ -33,7 +33,8 @@ namespace TechTalk.SpecFlow.Reporting
             serializer.Serialize(xmlOutputWriter, report);
 
             XslCompiledTransform xslt = new XslCompiledTransform();
-            var xsltSettings = new XsltSettings(true, false);
+	    var allowXsltScripts = !string.IsNullOrEmpty(xsltFile);
+            var xsltSettings = new XsltSettings(true, allowXsltScripts);
             XmlResolver resourceResolver;
 
             var reportName = reportType.Name.Replace("Generator", "");

--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,7 @@
 New Features:
 + Access MSTest's TestContext property via ScenarioContext https://github.com/techtalk/SpecFlow/pull/882
 + @MsBuild [DeploymentItem] - added option to provide output directory https://github.com/techtalk/SpecFlow/pull/901
++ Allow custom XSLT files to include scripts https://github.com/techtalk/SpecFlow/pull/933
 
 Fixes:
 + unable to access readonly csproj file  https://github.com/techtalk/SpecFlow/pull/906


### PR DESCRIPTION
Added support for custom XSLT files to contain the <msxsl:script> tag for more complex processing. In my case I'm flattening debug images into base64 encoded images in the report for a single file download from the CD server.