### PR TITLE
Fixing copy link in step definition report

### DIFF
--- a/TechTalk.SpecFlow.Reporting/Common/Common.xslt
+++ b/TechTalk.SpecFlow.Reporting/Common/Common.xslt
@@ -255,8 +255,9 @@
   </xsl:template>
   
   <xsl:template name="html-copy-step-to-clipboard-script">
-    <script>
+    <xsl:text disable-output-escaping="yes">
       <![CDATA[
+        <script>
           function getInnerText(elm)
           {
             if (elm.textContent)
@@ -316,8 +317,10 @@
             }
             return tableSource;
           }
-          ]]>
-    </script>
+
+        </script>
+      ]]>
+    </xsl:text>
   </xsl:template>
 
   <xsl:template name="html-body-header">


### PR DESCRIPTION
Fixes #915 

The issue is caused by the double encoding of the `<` signs in XSLT in the generated the for loops, e.g:
```
for (colIndex = 0; colIndex &lt; header.length; colIndex++)
	columnWidths[colIndex] = header[colIndex].innerHTML.length;
```

However I'm not sure that we need to keep this copy feature at all: see #957