### PR TITLE
Parsing exception on missing examples

### DIFF
--- a/TechTalk.SpecFlow.Parser/SpecFlowGherkinParser.cs
+++ b/TechTalk.SpecFlow.Parser/SpecFlowGherkinParser.cs
@@ -158,6 +158,8 @@ namespace TechTalk.SpecFlow.Parser
 
             CheckForDuplicateExamples(specFlowDocument.SpecFlowFeature, errors);
 
+            CheckForMissingExamples(specFlowDocument.SpecFlowFeature, errors);
+
             // collect
             if (errors.Count == 1)
                 throw errors[0];
@@ -192,6 +194,23 @@ namespace TechTalk.SpecFlow.Parser
                     {
                         var message = string.Format("Scenario Outline '{0}' already contains an example with name '{1}'", scenarioOutline.Name, duplicateExample.Key);
                         var semanticParserException = new SemanticParserException(message, duplicateExample.ElementAt(1).Location);
+                        errors.Add(semanticParserException);
+                    }
+                }
+            }
+        }
+
+        private void CheckForMissingExamples(SpecFlowFeature feature, List<ParserException> errors)
+        {
+            foreach (var scenarioDefinition in feature.ScenarioDefinitions)
+            {
+                var scenarioOutline = scenarioDefinition as ScenarioOutline;
+                if (scenarioOutline != null)
+                {
+                    if(!scenarioOutline.Examples.Any())
+                    {
+                        var message = string.Format("Scenario Outline '{0}' has no examples defined", scenarioOutline.Name);
+                        var semanticParserException = new SemanticParserException(message, scenarioDefinition.Location);
                         errors.Add(semanticParserException);
                     }
                 }

--- a/TechTalk.SpecFlow.Parser/SpecFlowGherkinParser.cs
+++ b/TechTalk.SpecFlow.Parser/SpecFlowGherkinParser.cs
@@ -207,7 +207,7 @@ namespace TechTalk.SpecFlow.Parser
                 var scenarioOutline = scenarioDefinition as ScenarioOutline;
                 if (scenarioOutline != null)
                 {
-                    if(!scenarioOutline.Examples.Any())
+                    if (DoesntHavePopulatedExamples(scenarioOutline))
                     {
                         var message = string.Format("Scenario Outline '{0}' has no examples defined", scenarioOutline.Name);
                         var semanticParserException = new SemanticParserException(message, scenarioDefinition.Location);
@@ -215,6 +215,11 @@ namespace TechTalk.SpecFlow.Parser
                     }
                 }
             }
+        }
+
+        private static bool DoesntHavePopulatedExamples(ScenarioOutline scenarioOutline)
+        {
+            return !scenarioOutline.Examples.Any() || scenarioOutline.Examples.Any(x => x.TableBody == null || !x.TableBody.Any());
         }
     }
 }

--- a/Tests/TechTalk.SpecFlow.GeneratorTests/GeneratorTests.csproj
+++ b/Tests/TechTalk.SpecFlow.GeneratorTests/GeneratorTests.csproj
@@ -78,6 +78,7 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Compile Include="MSBuildRelativePathParserTests.cs" />
+    <Compile Include="ScenarioOutlineParserTests.cs" />
     <Compile Include="TestGeneratorTest.cs" />
     <Compile Include="CodeDomExtensions.cs" />
     <Compile Include="CustomTestGeneratorProviderTest.cs" />

--- a/Tests/TechTalk.SpecFlow.GeneratorTests/ScenarioOutlineParserTests.cs
+++ b/Tests/TechTalk.SpecFlow.GeneratorTests/ScenarioOutlineParserTests.cs
@@ -28,6 +28,42 @@ namespace TechTalk.SpecFlow.GeneratorTests
         }
 
         [Test]
+        public void Parser_throws_meaningful_exception_when_Examples_are_empty_in_Scenario_Outline()
+        {
+            var feature = @"Feature: Missing
+                            Scenario Outline: No Examples
+                            Given something
+                            
+                            Examples:";
+
+            var parser = new SpecFlowGherkinParser(CultureInfo.GetCultureInfo("en"));
+
+            Action act = () => parser.Parse(new StringReader(feature), null);
+
+            act.ShouldThrow<SemanticParserException>().WithMessage("(2:29): Scenario Outline 'No Examples' has no examples defined")
+                .And.Location.Line.Should().Be(2);
+        }
+
+        [Test]
+        public void Parser_throws_meaningful_exception_when_Examples_have_header_but_are_empty_in_Scenario_Outline()
+        {
+            var feature = @"Feature: Missing
+                            Scenario Outline: No Examples
+                            Given something
+                            
+                            Examples:
+                            | Column |
+                            ";
+
+            var parser = new SpecFlowGherkinParser(CultureInfo.GetCultureInfo("en"));
+
+            Action act = () => parser.Parse(new StringReader(feature), null);
+
+            act.ShouldThrow<SemanticParserException>().WithMessage("(2:29): Scenario Outline 'No Examples' has no examples defined")
+                .And.Location.Line.Should().Be(2);
+        }
+
+        [Test]
         public void Parser_throws_meaningful_exception_when_Examples_are_missing_in_multiple_Scenario_Outlines()
         {
             var feature = @"Feature: Missing

--- a/Tests/TechTalk.SpecFlow.GeneratorTests/ScenarioOutlineParserTests.cs
+++ b/Tests/TechTalk.SpecFlow.GeneratorTests/ScenarioOutlineParserTests.cs
@@ -1,0 +1,64 @@
+﻿using FluentAssertions;
+using Gherkin;
+using Gherkin.Ast;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using TechTalk.SpecFlow.Parser;
+
+namespace TechTalk.SpecFlow.GeneratorTests
+{
+    [TestFixture]
+    public class ScenarioOutlineParserTests
+    {
+        [Test]
+        public void Parser_throws_meaningful_exception_when_Examples_are_missing_in_Scenario_Outline()
+        {
+            var feature = @"Feature: Missing
+                            Scenario Outline: No Examples";
+
+            var parser = new SpecFlowGherkinParser(CultureInfo.GetCultureInfo("en"));
+
+            Action act = () => parser.Parse(new StringReader(feature), null);
+
+            act.ShouldThrow<SemanticParserException>().WithMessage("(2:29): Scenario Outline 'No Examples' has no examples defined")
+                .And.Location.Line.Should().Be(2);
+        }
+
+        [Test]
+        public void Parser_throws_meaningful_exception_when_Examples_are_missing_in_multiple_Scenario_Outlines()
+        {
+            var feature = @"Feature: Missing
+                            Scenario Outline: No Examples
+                            Scenario Outline: Still no Examples";
+
+            var parser = new SpecFlowGherkinParser(CultureInfo.GetCultureInfo("en"));
+
+            Action act = () => parser.Parse(new StringReader(feature), null);
+
+            var expectedErrors = new List<SemanticParserException> { new SemanticParserException("Scenario Outline 'No Examples' has no examples defined", new Location(2, 29)),
+                new SemanticParserException("Scenario Outline 'Still no Examples' has no examples defined", new Location(3, 29))};
+
+            act.ShouldThrow<CompositeParserException>().And.Errors.ShouldBeEquivalentTo(expectedErrors);
+        }
+
+        [Test]
+        public void Parser_doesnt_throw_exception_when_Examples_are_provided_for_Scenario_Outline()
+        {
+            var feature = @"Feature: Missing
+                    Scenario Outline: No Examples
+                    Given I do <thing>
+                    Examples:
+                    | thing |
+                    | test  |";
+
+            var parser = new SpecFlowGherkinParser(CultureInfo.GetCultureInfo("en"));
+
+            Action act = () => parser.Parse(new StringReader(feature), null);
+
+            act.ShouldNotThrow();
+        }
+    }
+}

--- a/Tests/TechTalk.SpecFlow.Specs/Features/Parser/ParsingErrors.feature
+++ b/Tests/TechTalk.SpecFlow.Specs/Features/Parser/ParsingErrors.feature
@@ -75,18 +75,42 @@ Scenario: Scenario outline without examples
         | line | error                                                                        |
         | 3    | Scenario Outline 'Scenario outline without examples' has no examples defined |
 
-Scenario: Empty example set
+Scenario: Scenario outline with empty Examples
 	Given there is a Gherkin file as
 	"""
-		Feature: Empty example set
+		Feature: Delayed semantic error
 
-		Scenario Outline: Scenario outline without examples
-			Given <something>
+		Scenario Outline: Scenario outline with empty examples
+			Given something
+        
+        Examples: 
 
-		Examples: 
+		Scenario: proper scenario
+			Given something
 	"""
 	When the file is parsed
-	Then no parsing error is reported
+	Then the following errors are provided
+        | line | error                                                                           |
+        | 3    | Scenario Outline 'Scenario outline with empty examples' has no examples defined |
+
+Scenario: Scenario outline with empty Examples with a header
+	Given there is a Gherkin file as
+	"""
+		Feature: Delayed semantic error
+
+		Scenario Outline: Scenario outline with empty defined examples
+			Given something
+        
+        Examples: 
+            | Column |
+
+		Scenario: proper scenario
+			Given something
+	"""
+	When the file is parsed
+	Then the following errors are provided
+        | line | error                                                                                   |
+        | 3    | Scenario Outline 'Scenario outline with empty defined examples' has no examples defined |
 
 Scenario: Language not supported
 	Given there is a Gherkin file as

--- a/Tests/TechTalk.SpecFlow.Specs/Features/Parser/ParsingErrors.feature
+++ b/Tests/TechTalk.SpecFlow.Specs/Features/Parser/ParsingErrors.feature
@@ -71,7 +71,9 @@ Scenario: Scenario outline without examples
 			Given something
 	"""
 	When the file is parsed
-	Then no parsing error is reported
+	Then the following errors are provided
+        | line | error                                                                        |
+        | 3    | Scenario Outline 'Scenario outline without examples' has no examples defined |
 
 Scenario: Empty example set
 	Given there is a Gherkin file as

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,10 +1,9 @@
-2.3.1 - 2017-??-??
-Fixes:
-+ Meaningful exception is thrown when there are no Examples or Examples are empty in Scenario Outline
-
 2.3 - 2017-??-??
 New Features:
 + Expose the current status (result) of the scenario execution in ScenarioContext via ScenarioExecutionStatus property
+
+Fixes:
++ Meaningful exception is thrown when there are no Examples or Examples are empty in Scenario Outline https://github.com/techtalk/SpecFlow/pull/967
 
 2.2.2 - 2017-??-??
 New Features:

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,7 @@
+2.3.1 - 2017-??-??
+Fixes:
++ Meaningful exception is thrown when there are no Examples or Examples are empty in Scenario Outline
+
 2.3 - 2017-??-??
 New Features:
 + Expose the current status (result) of the scenario execution in ScenarioContext via ScenarioExecutionStatus property


### PR DESCRIPTION
This is related to #792 (Better error message for Scenario Outlines without arguments)
Now a SemanticParserException will be thrown when Examples are missing from a Scenario Outline. The exception will point to the Outline with missing examples. Multiple Outlines without Examples are also handled.
