### PR TITLE
PoC for xUnit handling of @Ignore tag on a feature

### DIFF
--- a/TechTalk.SpecFlow.Generator/UnitTestProvider/XUnit2TestGeneratorProvider.cs
+++ b/TechTalk.SpecFlow.Generator/UnitTestProvider/XUnit2TestGeneratorProvider.cs
@@ -119,7 +119,7 @@ namespace TechTalk.SpecFlow.Generator.UnitTestProvider
 
         public override void FinalizeTestClass(TestClassGenerationContext generationContext)
         {
-            base.FinalizeTestClass(generationContext);
+            IgnoreFeature(generationContext);
 
             // testRunner.ScenarioContext.ScenarioContainer.RegisterInstanceAs<ITestOutputHelper>(_testOutputHelper);
             generationContext.ScenarioInitializeMethod.Statements.Add(
@@ -133,6 +133,11 @@ namespace TechTalk.SpecFlow.Generator.UnitTestProvider
                         "RegisterInstanceAs",
                         new CodeTypeReference(OUTPUT_INTERFACE)),
                     new CodeVariableReferenceExpression(OUTPUT_INTERFACE_FIELD_NAME)));
+        }
+
+        protected override bool IsTestMethodAlreadyIgnored(CodeMemberMethod testMethod)
+        {
+            return IsTestMethodAlreadyIgnored(testMethod, FACT_ATTRIBUTE, THEORY_ATTRIBUTE);
         }
     }
 }

--- a/TechTalk.SpecFlow.Generator/UnitTestProvider/XUnitTestGeneratorProvider.cs
+++ b/TechTalk.SpecFlow.Generator/UnitTestProvider/XUnitTestGeneratorProvider.cs
@@ -19,6 +19,7 @@ namespace TechTalk.SpecFlow.Generator.UnitTestProvider
         private const string TRAIT_ATTRIBUTE = "Xunit.TraitAttribute";
         private const string IUSEFIXTURE_INTERFACE = "Xunit.IUseFixture";
         private const string CATEGORY_PROPERTY_NAME = "Category";
+        private const string IGNORE_TAG = "@Ignore";
 
         private CodeTypeDeclaration _currentFixtureDataTypeDeclaration = null;
 
@@ -177,7 +178,9 @@ namespace TechTalk.SpecFlow.Generator.UnitTestProvider
 
         public void SetTestClassIgnore(TestClassGenerationContext generationContext)
         {
-            //TODO: how to do class level ignore?
+            // The individual tests have to get Skip argument in their attributes
+            // xUnit does not provide a way to Skip a set of tests - https://xunit.github.io/docs/comparisons.html#attributes
+            // This is handled in FinalizeTestClass
         }
 
         public virtual void SetTestMethodIgnore(TestClassGenerationContext generationContext, CodeMemberMethod testMethod)
@@ -242,7 +245,20 @@ namespace TechTalk.SpecFlow.Generator.UnitTestProvider
 
         public virtual void FinalizeTestClass(TestClassGenerationContext generationContext)
         {
-            // by default, doing nothing to the final generated code
+            var featureHasIgnoreTag = generationContext.Feature.Tags
+                .Any(x => string.Equals(x.Name, IGNORE_TAG, StringComparison.InvariantCultureIgnoreCase));
+
+            if(featureHasIgnoreTag)
+            {
+                foreach (CodeTypeMember member in generationContext.TestClass.Members)
+                {
+                    var method = member as CodeMemberMethod;
+                    if (method != null)
+                    {
+                        SetTestMethodIgnore(generationContext, method);
+                    }
+                }
+            }
         }
 
         public void SetTestMethodAsRow(TestClassGenerationContext generationContext, CodeMemberMethod testMethod, string scenarioTitle, string exampleSetName, string variantName, IEnumerable<KeyValuePair<string, string>> arguments)

--- a/TechTalk.SpecFlow.Generator/UnitTestProvider/XUnitTestGeneratorProvider.cs
+++ b/TechTalk.SpecFlow.Generator/UnitTestProvider/XUnitTestGeneratorProvider.cs
@@ -245,20 +245,51 @@ namespace TechTalk.SpecFlow.Generator.UnitTestProvider
 
         public virtual void FinalizeTestClass(TestClassGenerationContext generationContext)
         {
-            var featureHasIgnoreTag = generationContext.Feature.Tags
-                .Any(x => string.Equals(x.Name, IGNORE_TAG, StringComparison.InvariantCultureIgnoreCase));
+            IgnoreFeature(generationContext);
+        }
 
-            if(featureHasIgnoreTag)
+        protected virtual void IgnoreFeature(TestClassGenerationContext generationContext)
+        {
+            var featureHasIgnoreTag = generationContext.Feature.Tags
+               .Any(x => string.Equals(x.Name, IGNORE_TAG, StringComparison.InvariantCultureIgnoreCase));
+
+            if (featureHasIgnoreTag)
             {
                 foreach (CodeTypeMember member in generationContext.TestClass.Members)
                 {
                     var method = member as CodeMemberMethod;
-                    if (method != null)
+                    if (method != null && !IsTestMethodAlreadyIgnored(method))
                     {
                         SetTestMethodIgnore(generationContext, method);
                     }
                 }
             }
+        }
+
+        protected virtual bool IsTestMethodAlreadyIgnored(CodeMemberMethod testMethod)
+        {
+            return IsTestMethodAlreadyIgnored(testMethod, FACT_ATTRIBUTE, THEORY_ATTRIBUTE);
+        }
+
+        protected static bool IsTestMethodAlreadyIgnored(CodeMemberMethod testMethod, string factAttributeName, string theoryAttributeName)
+        {
+            var factAttr = testMethod.CustomAttributes.OfType<CodeAttributeDeclaration>()
+                .FirstOrDefault(codeAttributeDeclaration => codeAttributeDeclaration.Name == factAttributeName);
+
+            var hasIgnoredFact = factAttr?.Arguments.OfType<CodeAttributeArgument>()
+                .Any(x =>
+                    string.Equals(x.Name, FACT_ATTRIBUTE_SKIP_PROPERTY_NAME, StringComparison.InvariantCultureIgnoreCase));
+
+            var theoryAttr = testMethod.CustomAttributes.OfType<CodeAttributeDeclaration>()
+               .FirstOrDefault(codeAttributeDeclaration => codeAttributeDeclaration.Name == theoryAttributeName);
+
+            var hasIgnoredTheory = theoryAttr?.Arguments.OfType<CodeAttributeArgument>()
+                .Any(x =>
+                    string.Equals(x.Name, THEORY_ATTRIBUTE_SKIP_PROPERTY_NAME, StringComparison.InvariantCultureIgnoreCase));
+
+            var result = hasIgnoredFact.GetValueOrDefault() || hasIgnoredTheory.GetValueOrDefault();
+
+            return result;
         }
 
         public void SetTestMethodAsRow(TestClassGenerationContext generationContext, CodeMemberMethod testMethod, string scenarioTitle, string exampleSetName, string variantName, IEnumerable<KeyValuePair<string, string>> arguments)

--- a/Tests/TechTalk.SpecFlow.Specs/Features/XUnit2Provider.feature
+++ b/Tests/TechTalk.SpecFlow.Specs/Features/XUnit2Provider.feature
@@ -40,6 +40,28 @@ Examples:
 		| Succeeded |
 		| 0         |
 
+Scenario: Should be able to ignore a scenario
+	Given there is a SpecFlow project
+	And the project is configured to use the xUnit provider
+	And there is a feature file in the project as
+		"""
+			Feature: Simple Feature
+			
+            Scenario: First
+                Given there is something
+                Then something should happen
+
+            @ignore
+            Scenario: Second
+                Given there is something
+                Then something should happen
+		"""
+	And all steps are bound and pass
+	When I execute the tests with xUnit
+	Then the execution summary should contain
+		| Succeeded | Ignored |
+		| 1         | 1       |
+
 Scenario: Should be able to ignore all Scenarios in a feature
 	Given there is a SpecFlow project
 	And the project is configured to use the xUnit provider

--- a/Tests/TechTalk.SpecFlow.Specs/Features/XUnit2Provider.feature
+++ b/Tests/TechTalk.SpecFlow.Specs/Features/XUnit2Provider.feature
@@ -52,15 +52,20 @@ Scenario: Should be able to ignore all Scenarios in a feature
                 Given there is something
                 Then something should happen
 
+            @ignore
             Scenario: Second
                 Given there is something
                 Then something should happen
+
+            Scenario: Third
+                Given there is something else
+                Then something else should happen
 		"""
 	And all steps are bound and pass
 	When I execute the tests with xUnit
 	Then the execution summary should contain
 		| Succeeded | Ignored |
-		| 0         | 2       |
+		| 0         | 3       |
 
 Scenario: Should be able to ignore all Scenarios and Scenario Outlines in a feature
 	Given there is a SpecFlow project
@@ -83,6 +88,16 @@ Scenario: Should be able to ignore all Scenarios and Scenario Outlines in a feat
 				| something      |
 				| something else |
 
+            @ignore
+            Scenario Outline: Second Outline
+				Given there is something
+				When I do <what>
+				Then something should happen
+			Examples: 
+				| what           |
+				| something      |
+				| something else |
+
             Scenario: Last
                 Given there is something
                 Then something should happen
@@ -91,7 +106,7 @@ Scenario: Should be able to ignore all Scenarios and Scenario Outlines in a feat
 	When I execute the tests with xUnit
 	Then the execution summary should contain
 		| Succeeded | Ignored |
-		| 0         | 3       |
+		| 0         | 4       |
 
 Scenario Outline: Should handle scenario outlines
 	Given there is a SpecFlow project

--- a/Tests/TechTalk.SpecFlow.Specs/Features/XUnit2Provider.feature
+++ b/Tests/TechTalk.SpecFlow.Specs/Features/XUnit2Provider.feature
@@ -40,6 +40,59 @@ Examples:
 		| Succeeded |
 		| 0         |
 
+Scenario: Should be able to ignore all Scenarios in a feature
+	Given there is a SpecFlow project
+	And the project is configured to use the xUnit provider
+	And there is a feature file in the project as
+		"""
+            @ignore
+			Feature: Simple Feature
+			
+            Scenario: First
+                Given there is something
+                Then something should happen
+
+            Scenario: Second
+                Given there is something
+                Then something should happen
+		"""
+	And all steps are bound and pass
+	When I execute the tests with xUnit
+	Then the execution summary should contain
+		| Succeeded | Ignored |
+		| 0         | 2       |
+
+Scenario: Should be able to ignore all Scenarios and Scenario Outlines in a feature
+	Given there is a SpecFlow project
+	And the project is configured to use the xUnit provider
+	And there is a feature file in the project as
+		"""
+            @ignore
+			Feature: Simple Feature
+			
+            Scenario: First
+                Given there is something
+                Then something should happen
+
+            Scenario Outline: First Outline
+				Given there is something
+				When I do <what>
+				Then something should happen
+			Examples: 
+				| what           |
+				| something      |
+				| something else |
+
+            Scenario: Last
+                Given there is something
+                Then something should happen
+		"""
+	And all steps are bound and pass
+	When I execute the tests with xUnit
+	Then the execution summary should contain
+		| Succeeded | Ignored |
+		| 0         | 3       |
+
 Scenario Outline: Should handle scenario outlines
 	Given there is a SpecFlow project
 	And the project is configured to use the xUnit provider

--- a/Tests/TechTalk.SpecFlow.Specs/Features/XUnitProvider.feature
+++ b/Tests/TechTalk.SpecFlow.Specs/Features/XUnitProvider.feature
@@ -40,6 +40,59 @@ Examples:
 		| Succeeded |
 		| 0         |
 
+Scenario: Should be able to ignore all Scenarios in a feature
+	Given there is a SpecFlow project
+	And the project is configured to use the xUnit.1 provider
+	And there is a feature file in the project as
+		"""
+            @ignore
+			Feature: Simple Feature
+			
+            Scenario: First
+                Given there is something
+                Then something should happen
+
+            Scenario: Second
+                Given there is something
+                Then something should happen
+		"""
+	And all steps are bound and pass
+	When I execute the tests with xUnit
+	Then the execution summary should contain
+		| Succeeded | Ignored |
+		| 0         | 2       |
+
+Scenario: Should be able to ignore all Scenarios and Scenario Outlines in a feature
+	Given there is a SpecFlow project
+	And the project is configured to use the xUnit.1 provider
+	And there is a feature file in the project as
+		"""
+            @ignore
+			Feature: Simple Feature
+			
+            Scenario: First
+                Given there is something
+                Then something should happen
+
+            Scenario Outline: First Outline
+				Given there is something
+				When I do <what>
+				Then something should happen
+			Examples: 
+				| what           |
+				| something      |
+				| something else |
+
+            Scenario: Last
+                Given there is something
+                Then something should happen
+		"""
+	And all steps are bound and pass
+	When I execute the tests with xUnit
+	Then the execution summary should contain
+		| Succeeded | Ignored |
+		| 0         | 3       |
+
 Scenario Outline: Should handle scenario outlines
 	Given there is a SpecFlow project
 	And the project is configured to use the xUnit.1 provider

--- a/Tests/TechTalk.SpecFlow.Specs/Features/XUnitProvider.feature
+++ b/Tests/TechTalk.SpecFlow.Specs/Features/XUnitProvider.feature
@@ -52,15 +52,20 @@ Scenario: Should be able to ignore all Scenarios in a feature
                 Given there is something
                 Then something should happen
 
+            @ignore
             Scenario: Second
                 Given there is something
                 Then something should happen
+
+            Scenario: Third
+                Given there is something else
+                Then something else should happen
 		"""
 	And all steps are bound and pass
 	When I execute the tests with xUnit
 	Then the execution summary should contain
 		| Succeeded | Ignored |
-		| 0         | 2       |
+		| 0         | 3       |
 
 Scenario: Should be able to ignore all Scenarios and Scenario Outlines in a feature
 	Given there is a SpecFlow project
@@ -83,6 +88,16 @@ Scenario: Should be able to ignore all Scenarios and Scenario Outlines in a feat
 				| something      |
 				| something else |
 
+            @ignore
+            Scenario Outline: Second Outline
+				Given there is something
+				When I do <what>
+				Then something should happen
+			Examples: 
+				| what           |
+				| something      |
+				| something else |
+
             Scenario: Last
                 Given there is something
                 Then something should happen
@@ -91,7 +106,7 @@ Scenario: Should be able to ignore all Scenarios and Scenario Outlines in a feat
 	When I execute the tests with xUnit
 	Then the execution summary should contain
 		| Succeeded | Ignored |
-		| 0         | 3       |
+		| 0         | 4       |
 
 Scenario Outline: Should handle scenario outlines
 	Given there is a SpecFlow project

--- a/Tests/TechTalk.SpecFlow.Specs/Features/XUnitProvider.feature
+++ b/Tests/TechTalk.SpecFlow.Specs/Features/XUnitProvider.feature
@@ -40,6 +40,28 @@ Examples:
 		| Succeeded |
 		| 0         |
 
+Scenario: Should be able to ignore a scenario
+	Given there is a SpecFlow project
+	And the project is configured to use the xUnit.1 provider
+	And there is a feature file in the project as
+		"""
+			Feature: Simple Feature
+			
+            Scenario: First
+                Given there is something
+                Then something should happen
+
+            @ignore
+            Scenario: Second
+                Given there is something
+                Then something should happen
+		"""
+	And all steps are bound and pass
+	When I execute the tests with xUnit
+	Then the execution summary should contain
+		| Succeeded | Ignored |
+		| 1         | 1       |
+
 Scenario: Should be able to ignore all Scenarios in a feature
 	Given there is a SpecFlow project
 	And the project is configured to use the xUnit.1 provider


### PR DESCRIPTION
Related to  #956. Using FinalizeTestClass method of XUnitTestGeneratorProvider to mark all Scenarios and Outlines as ignored when a Feature is tagged with @Ignore.
Not sure it this is the best/only way.