### PR TITLE
Add the ability to add aliases to target class properties

### DIFF
--- a/TechTalk.SpecFlow/Assist/Attributes/TableAliasesAttribute.cs
+++ b/TechTalk.SpecFlow/Assist/Attributes/TableAliasesAttribute.cs
@@ -1,0 +1,18 @@
+﻿using System;
+
+namespace TechTalk.SpecFlow.Assist.Attributes
+{
+    [AttributeUsage(
+        AttributeTargets.Property |
+        AttributeTargets.Field,
+        AllowMultiple = true)]
+    public class TableAliasesAttribute : Attribute
+    {
+        public TableAliasesAttribute(params string[] aliases)
+        {
+            Aliases = aliases;
+        }
+
+        public string[] Aliases { get; }
+    }
+}

--- a/TechTalk.SpecFlow/TechTalk.SpecFlow.csproj
+++ b/TechTalk.SpecFlow/TechTalk.SpecFlow.csproj
@@ -66,6 +66,7 @@
     <Compile Include="Assist\FormattingTableDiffExceptionBuilder.cs" />
     <Compile Include="Assist\SafetyTableDiffExceptionBuilder.cs" />
     <Compile Include="Assist\SetComparer.cs" />
+    <Compile Include="Assist\Attributes\TableAliasesAttribute.cs" />
     <Compile Include="Assist\TableDifferenceItem.cs" />
     <Compile Include="Assist\TableDifferenceResults.cs" />
     <Compile Include="Assist\TableDiffExceptionBuilder.cs" />
@@ -299,6 +300,7 @@
   <ItemGroup>
     <None Include="packages.config" />
   </ItemGroup>
+  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/CreateInstanceHelperMethodTests.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/CreateInstanceHelperMethodTests.cs
@@ -4,6 +4,7 @@ using System.Threading;
 using NUnit.Framework;
 using FluentAssertions;
 using TechTalk.SpecFlow.Assist;
+using TechTalk.SpecFlow.Assist.Attributes;
 using TechTalk.SpecFlow.RuntimeTests.AssistTests.ExampleEntities;
 
 namespace TechTalk.SpecFlow.RuntimeTests.AssistTests
@@ -368,6 +369,84 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests
             test.three.Should().Be(999);
         }
 
+        [Test]
+        public void Uses_property_aliases()
+        {
+            var table = new Table("AliasOne", "AliasTwo", "AliasThree");
+            table.AddRow("PropertyOne", "PropertyTwo", "PropertyThree");
+
+            var test = table.CreateInstance<AliasedClass>();
+            test.PropertyOne.Should().Be("PropertyOne");
+            test.PropertyTwo.Should().Be("PropertyTwo");
+            test.PropertyThree.Should().Be("PropertyThree");
+        }
+
+        [Test]
+        public void Uses_field_aliases()
+        {
+            var table = new Table("FieldAliasOne", "FieldAliasTwo", "FieldAliasThree");
+            table.AddRow("FieldOne", "FieldTwo", "FieldThree");
+
+            var test = table.CreateInstance<AliasedClass>();
+            test.FieldOne.Should().Be("FieldOne");
+            test.FieldTwo.Should().Be("FieldTwo");
+            test.FieldThree.Should().Be("FieldThree");
+        }
+
+        [Test]
+        public void Property_aliases_allow_multiple_property_population()
+        {
+            var table = new Table("AliasOne", "AliasTwo", "AliasThree");
+            table.AddRow("PropertyOne", "PropertyTwo", "PropertyThree");
+
+            var test = table.CreateInstance<AliasedClass>();
+            test.PropertyOne.Should().Be("PropertyOne");
+            test.AnotherPropertyWithSameAlias.Should().Be("PropertyOne");
+        }
+
+        [Test]
+        public void Property_aliases_do_not_allow_type_mismatch_property_population()
+        {
+            var table = new Table("AliasOne", "AliasTwo", "AliasThree");
+            table.AddRow("PropertyOne", "PropertyTwo", "PropertyThree");
+
+            var test = table.CreateInstance<AliasedClass>();
+            test.PropertyOne.Should().Be("PropertyOne");
+            test.AliasedButTypeMismatch.Should().Be(0);
+        }
+
+        [Test]
+        public void Property_aliases_work_for_vertical_format()
+        {
+            var table = new Table("Field", "Value");
+            table.AddRow("Alias One", "Hello");
+            table.AddRow("AliasTwo", "World");
+            table.AddRow("AliasThree", "From Rich");
+
+            var test = table.CreateInstance<AliasedClass>();
+            test.PropertyOne.Should().Be("Hello");
+            test.PropertyTwo.Should().Be("World");
+            test.PropertyThree.Should().Be("From Rich");
+        }
+
+        [Test]
+        [TestCase("FirstName", "MiddleName", "Surname")]
+        [TestCase("FirstName", "MiddleName", "Lastname")]
+        [TestCase("First Name", "Middle Name", "Last name")]
+        [TestCase("Known As", "Never Known As", "Dad's Last Name")]
+        public void Property_can_have_many_aliases_and_uses_regex_to_match_business_jargon(string firstNameAlias, string middleNameAlias, string lastNameAlias)
+        {
+            var table = new Table("Field", "Value");
+            table.AddRow(firstNameAlias, "Richard");
+            table.AddRow(middleNameAlias, "David");
+            table.AddRow(lastNameAlias, "Linnell");
+
+            var test = table.CreateInstance<AliasedClass>();
+            test.PropertyOne.Should().Be("Richard");
+            test.PropertyTwo.Should().Be("David");
+            test.PropertyThree.Should().Be("Linnell");
+        }
+
         private class Prop
         {
             public string Prop1 { get; set; }
@@ -380,5 +459,32 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests
             public string this_is_so_long { get; set; }
         }
 
+        private class AliasedClass
+        {
+            [TableAliases("Alias[ ]*One", "First[ ]?Name", "^Known As$")]
+            public string PropertyOne { get; set; }
+
+            [TableAliases("Alias[ ]*Two", "Middle[ ]?Name", "^Never Known As$")]
+            public string PropertyTwo { get; set; }
+
+            [TableAliases("AliasThree")]
+            [TableAliases("Surname")]
+            [TableAliases("Last[ ]?name")]
+            [TableAliases("Dad's Last Name")]
+            public string PropertyThree { get; set; }
+
+            [TableAliases("FieldAliasOne")]
+            public string FieldOne;
+            [TableAliases("FieldAliasTwo")]
+            public string FieldTwo;
+            [TableAliases("FieldAliasThree")]
+            public string FieldThree;
+
+            [TableAliases("AliasOne")]
+            public string AnotherPropertyWithSameAlias { get; set; }
+
+            [TableAliases("AliasOne")]
+            public long AliasedButTypeMismatch { get; set; }
+        }
     }
 }

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 2.3 - 2017-??-??
 New Features:
 + Expose the current status (result) of the scenario execution in ScenarioContext via ScenarioExecutionStatus property
++ Allow aliasing of properties or fields on objects mapped from tables via the CreateInstance or CreateSet extensionMethods by utilising the TableAliases attribute
 
 2.2.2 - 2017-??-??
 New Features:


### PR DESCRIPTION
Provides the ability to add an attribute to your target class indicating aliases that may be used for the properties or fields in specflow feature tables.

The aliases are Regex strings that are used by the `CreateInstance` and `CreateInstances` table extension methods to map table entries to the fields on the mapped to class.

For usage examples, see the `CreateInstanceHelperMethodTests` specifically the `AliasedClass` which demonstates how a class can be decorated.