### PR TITLE
Add SpecFlow.Tools.MsBuild.Generation package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ TechTalk.SpecFlow.Tools/plugincompability.config
 TechTalk.SpecFlow.sln.GhostDoc.xml
 Features.Generated/
 GitExtensions.settings.backup
+/Installer/NuGetPackages/SpecFlow.Tools.MsBuild.Generation/build/SpecFlow.Tools.MsBuild.Generation.targets

--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,4 @@ TechTalk.SpecFlow.sln.GhostDoc.xml
 Features.Generated/
 GitExtensions.settings.backup
 /Installer/NuGetPackages/SpecFlow.Tools.MsBuild.Generation/build/SpecFlow.Tools.MsBuild.Generation.targets
+/Installer/NuGetPackages/SpecFlow.Tools.MsBuild.Generation/build/SpecFlow.Tools.MsBuild.Generation.props

--- a/Installer/NuGetPackages/.build/build.targets
+++ b/Installer/NuGetPackages/.build/build.targets
@@ -19,11 +19,14 @@
     
     <Message Importance="High" Text="NugetVersion: $(NugetVersion)" />
     
+    <Copy SourceFiles="$(MSBuildThisFileDirectory)\..\..\..\TechTalk.SpecFlow.Tools\MsBuild\TechTalk.SpecFlow.targets" DestinationFiles="$(TargetDir)SpecFlow.Tools.MsBuild.Generation\build\SpecFlow.Tools.MsBuild.Generation.targets" OverwriteReadOnlyFiles="true"  />
+    
     <XmlPoke Condition="'$(SpecFlowPackageVersion)' != ''" XmlInputPath="$(TargetDir)SpecFlow.CustomPlugin\SpecFlow.CustomPlugin.nuspec" Namespaces="&lt;Namespace Prefix='ng' Uri='http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd' /&gt;" Query="//ng:dependency[@id='SpecFlow']/@version" Value="[$(SpecFlowPackageVersion)]" />
     <XmlPoke Condition="'$(SpecFlowPackageVersion)' != ''" XmlInputPath="$(TargetDir)SpecFlow.MsTest\SpecFlow.MsTest.nuspec" Namespaces="&lt;Namespace Prefix='ng' Uri='http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd' /&gt;" Query="//ng:dependency[@id='SpecFlow']/@version" Value="[$(SpecFlowPackageVersion)]" />
     <XmlPoke Condition="'$(SpecFlowPackageVersion)' != ''" XmlInputPath="$(TargetDir)SpecFlow.NUnit\SpecFlow.NUnit.nuspec" Namespaces="&lt;Namespace Prefix='ng' Uri='http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd' /&gt;" Query="//ng:dependency[@id='SpecFlow']/@version" Value="[$(SpecFlowPackageVersion)]" />
     <XmlPoke Condition="'$(SpecFlowPackageVersion)' != ''" XmlInputPath="$(TargetDir)SpecFlow.xUnit\SpecFlow.xUnit.nuspec" Namespaces="&lt;Namespace Prefix='ng' Uri='http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd' /&gt;" Query="//ng:dependency[@id='SpecFlow']/@version" Value="[$(SpecFlowPackageVersion)]" />
     <XmlPoke Condition="'$(SpecFlowPackageVersion)' != ''" XmlInputPath="$(TargetDir)SpecFlow.NUnit.Runners\SpecFlow.NUnit.Runners.nuspec" Namespaces="&lt;Namespace Prefix='ng' Uri='http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd' /&gt;" Query="//ng:dependency[@id='SpecFlow.NUnit']/@version" Value="[$(SpecFlowPackageVersion)]" />
+    <XmlPoke Condition="'$(SpecFlowPackageVersion)' != ''" XmlInputPath="$(TargetDir)SpecFlow.Tools.MsBuild.Generation\SpecFlow.Tools.MsBuild.Generation.nuspec" Namespaces="&lt;Namespace Prefix='ng' Uri='http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd' /&gt;" Query="//ng:dependency[@id='SpecFlow']/@version" Value="[$(SpecFlowPackageVersion)]" />
   </Target>
 
 </Project>

--- a/Installer/NuGetPackages/.build/build.targets
+++ b/Installer/NuGetPackages/.build/build.targets
@@ -20,7 +20,10 @@
     <Message Importance="High" Text="NugetVersion: $(NugetVersion)" />
     
     <Copy SourceFiles="$(MSBuildThisFileDirectory)\..\..\..\TechTalk.SpecFlow.Tools\MsBuild\TechTalk.SpecFlow.targets" DestinationFiles="$(TargetDir)SpecFlow.Tools.MsBuild.Generation\build\SpecFlow.Tools.MsBuild.Generation.targets" OverwriteReadOnlyFiles="true"  />
-    
+    <Copy SourceFiles="$(MSBuildThisFileDirectory)\..\..\..\TechTalk.SpecFlow.Tools\MsBuild\TechTalk.SpecFlow.props" DestinationFiles="$(TargetDir)SpecFlow.Tools.MsBuild.Generation\build\SpecFlow.Tools.MsBuild.Generation.props" OverwriteReadOnlyFiles="true"  />
+    <XmlPoke XmlInputPath="$(TargetDir)SpecFlow.Tools.MsBuild.Generation\build\SpecFlow.Tools.MsBuild.Generation.targets" Namespaces="&lt;Namespace Prefix='ng' Uri='http://schemas.microsoft.com/developer/msbuild/2003' /&gt;" Query="//ng:Import/@Project" Value="SpecFlow.Tools.MsBuild.Generation.props" />
+
+
     <XmlPoke Condition="'$(SpecFlowPackageVersion)' != ''" XmlInputPath="$(TargetDir)SpecFlow.CustomPlugin\SpecFlow.CustomPlugin.nuspec" Namespaces="&lt;Namespace Prefix='ng' Uri='http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd' /&gt;" Query="//ng:dependency[@id='SpecFlow']/@version" Value="[$(SpecFlowPackageVersion)]" />
     <XmlPoke Condition="'$(SpecFlowPackageVersion)' != ''" XmlInputPath="$(TargetDir)SpecFlow.MsTest\SpecFlow.MsTest.nuspec" Namespaces="&lt;Namespace Prefix='ng' Uri='http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd' /&gt;" Query="//ng:dependency[@id='SpecFlow']/@version" Value="[$(SpecFlowPackageVersion)]" />
     <XmlPoke Condition="'$(SpecFlowPackageVersion)' != ''" XmlInputPath="$(TargetDir)SpecFlow.NUnit\SpecFlow.NUnit.nuspec" Namespaces="&lt;Namespace Prefix='ng' Uri='http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd' /&gt;" Query="//ng:dependency[@id='SpecFlow']/@version" Value="[$(SpecFlowPackageVersion)]" />

--- a/Installer/NuGetPackages/NuGetPackages.csproj
+++ b/Installer/NuGetPackages/NuGetPackages.csproj
@@ -48,6 +48,7 @@
     <None Include=".build\build.targets" />
     <None Include="Properties\build.props" />
     <None Include="SpecFlow.CustomPlugin\SpecFlow.CustomPlugin.nuspec.props" />
+    <None Include="SpecFlow.Tools.MsBuild.Generation\build\SpecFlow.Tools.MsBuild.Generation.props" />
     <None Include="SpecFlow.Tools.MsBuild.Generation\build\SpecFlow.Tools.MsBuild.Generation.targets" />
     <None Include="SpecFlow.Tools.MsBuild.Generation\SpecFlow.Tools.MsBuild.Generation.nuspec" />
     <None Include="SpecFlow.MsTest\SpecFlow.MsTest.nuspec.props" />

--- a/Installer/NuGetPackages/NuGetPackages.csproj
+++ b/Installer/NuGetPackages/NuGetPackages.csproj
@@ -48,6 +48,8 @@
     <None Include=".build\build.targets" />
     <None Include="Properties\build.props" />
     <None Include="SpecFlow.CustomPlugin\SpecFlow.CustomPlugin.nuspec.props" />
+    <None Include="SpecFlow.Tools.MsBuild.Generation\build\SpecFlow.Tools.MsBuild.Generation.targets" />
+    <None Include="SpecFlow.Tools.MsBuild.Generation\SpecFlow.Tools.MsBuild.Generation.nuspec" />
     <None Include="SpecFlow.MsTest\SpecFlow.MsTest.nuspec.props" />
     <None Include="SpecFlow.NUnit.Runners\SpecFlow.NUnit.Runners.nuspec.props" />
     <None Include="SpecFlow.NUnit\SpecFlow.NUnit.nuspec.props" />

--- a/Installer/NuGetPackages/NuGetPackages.csproj
+++ b/Installer/NuGetPackages/NuGetPackages.csproj
@@ -72,6 +72,7 @@
       <SubType>Designer</SubType>
     </None>
     <None Include="SpecFlow.xUnit\SpecFlow.xUnit.nuspec" />
+    <None Include="SpecFlow\build\SpecFlow.targets" />
     <None Include="SpecFlow\SpecFlow.nuspec" />
     <None Include="SpecFlow\SpecFlow.nuspec.props" />
     <None Include="SpecFlow.xUnit\App.config.transform" />

--- a/Installer/NuGetPackages/SpecFlow.Tools.MsBuild.Generation/SpecFlow.Tools.MsBuild.Generation.nuspec
+++ b/Installer/NuGetPackages/SpecFlow.Tools.MsBuild.Generation/SpecFlow.Tools.MsBuild.Generation.nuspec
@@ -1,0 +1,21 @@
+<?xml version="1.0"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+  <metadata>
+    <id>SpecFlow.Tools.MsBuild.Generation</id>
+    <version>1.0.0-alpha</version>
+    <title>SpecFlow.Tools.MsBuild.Generation</title>
+    <authors>TechTalk</authors>
+    <owners>TechTalk</owners>
+    <description>Package to enable the code-behind file generation during build time http://specflow.org/documentation/Generate-Tests-from-MsBuild/</description>
+    <summary>Package to enable the code-behind file generation during build time http://specflow.org/documentation/Generate-Tests-from-MsBuild/</summary>
+    <language>en-US</language>
+    <projectUrl>http://www.specflow.org</projectUrl>
+    <licenseUrl>http://go.specflow.org/license</licenseUrl>
+    <iconUrl>http://go.specflow.org/specflow-nuget-icon</iconUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <tags>specflow msbuild</tags>
+    <dependencies>
+      <dependency id="SpecFlow" version="[1.0.0-alpha]" />
+    </dependencies>
+  </metadata>
+</package>

--- a/Installer/NuGetPackages/SpecFlow/build/SpecFlow.targets
+++ b/Installer/NuGetPackages/SpecFlow/build/SpecFlow.targets
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-  <Import Project="..\tools\TechTalk.SpecFlow.tasks" />
+  <Import Project="$(MSBuildThisFileDirectory)\..\tools\TechTalk.SpecFlow.tasks" />
    
 </Project>

--- a/Installer/NuGetPackages/SpecFlow/build/SpecFlow.targets
+++ b/Installer/NuGetPackages/SpecFlow/build/SpecFlow.targets
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <Import Project="..\tools\TechTalk.SpecFlow.tasks" />
+   
+</Project>

--- a/TechTalk.SpecFlow.Tools/MsBuild/TechTalk.SpecFlow.props
+++ b/TechTalk.SpecFlow.Tools/MsBuild/TechTalk.SpecFlow.props
@@ -1,0 +1,12 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    
+    <ShowTrace Condition="'$(ShowTrace)'==''">false</ShowTrace>
+    <OverwriteReadOnlyFiles Condition="'$(OverwriteReadOnlyFiles)'==''">false</OverwriteReadOnlyFiles>
+    <ForceGeneration Condition="'$(ForceGeneration)'==''">false</ForceGeneration>
+    <VerboseOutput Condition="'$(VerboseOutput)'==''">false</VerboseOutput>
+
+    <_SpecFlowPropsImported Condition="'$(_SpecFlowPropsImported)'==''">true</_SpecFlowPropsImported>
+  </PropertyGroup>
+</Project>

--- a/TechTalk.SpecFlow.Tools/MsBuild/TechTalk.SpecFlow.targets
+++ b/TechTalk.SpecFlow.Tools/MsBuild/TechTalk.SpecFlow.targets
@@ -1,8 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-  <Import Project="TechTalk.SpecFlow.tasks"/>
-
   <!-- this setting is to workaround the bug in VS (does not detect changes during the pre-build event)
        see: https://connect.microsoft.com/VisualStudio/feedback/ViewFeedback.aspx?FeedbackID=423670&wa=wsignin1.0
   -->

--- a/TechTalk.SpecFlow.Tools/MsBuild/TechTalk.SpecFlow.targets
+++ b/TechTalk.SpecFlow.Tools/MsBuild/TechTalk.SpecFlow.targets
@@ -8,13 +8,7 @@
     <UseHostCompilerIfAvailable>false</UseHostCompilerIfAvailable>
   </PropertyGroup>
 
-  <PropertyGroup>
-    <ShowTrace Condition="'$(ShowTrace)'==''">false</ShowTrace>
-    
-    <OverwriteReadOnlyFiles Condition="'$(OverwriteReadOnlyFiles)'==''">false</OverwriteReadOnlyFiles>
-    <ForceGeneration Condition="'$(ForceGeneration)'==''">false</ForceGeneration>
-    <VerboseOutput Condition="'$(VerboseOutput)'==''">false</VerboseOutput>
-  </PropertyGroup>
+  <Import Project="TechTalk.SpecFlow.props" Condition="'$(_SpecFlowPropsImported)'==''"/>
 
   <PropertyGroup Condition="'$(BuildServerMode)' == ''">
     <BuildServerMode Condition="'$(BuildingInsideVisualStudio)'=='true'">false</BuildServerMode>

--- a/TechTalk.SpecFlow.Tools/TechTalk.SpecFlow.Tools.csproj
+++ b/TechTalk.SpecFlow.Tools/TechTalk.SpecFlow.Tools.csproj
@@ -104,6 +104,10 @@
     <None Include="app.config">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+    <None Include="MsBuild\TechTalk.SpecFlow.props">
+      <SubType>Designer</SubType>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Include="plugincompability.config">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>

--- a/Tests/TechTalk.SpecFlow.IntegrationTests/TechTalk.SpecFlow.IntegrationTests.csproj
+++ b/Tests/TechTalk.SpecFlow.IntegrationTests/TechTalk.SpecFlow.IntegrationTests.csproj
@@ -209,6 +209,7 @@
   <PropertyGroup>
     <SpecFlowTasksPath>..\..\TechTalk.SpecFlow.Tools\$(OutDir)\specflow.exe</SpecFlowTasksPath>
   </PropertyGroup>
+  <Import Project="..\..\TechTalk.SpecFlow.Tools\MsBuild\TechTalk.SpecFlow.tasks" />
   <Import Project="..\..\TechTalk.SpecFlow.Tools\MsBuild\TechTalk.SpecFlow.targets" />
   <PropertyGroup>
     <PostBuildEvent>$(SolutionDir)\Tests\PostBuild.bat "$(TargetDir)" "$(SolutionDir)"</PostBuildEvent>

--- a/Tests/TechTalk.SpecFlow.Specs/Drivers/Templates/TestProjectFile.csproj
+++ b/Tests/TechTalk.SpecFlow.Specs/Drivers/Templates/TestProjectFile.csproj
@@ -70,6 +70,7 @@
   <PropertyGroup>
     <VerboseOutput>true</VerboseOutput>
   </PropertyGroup>
+  <Import Project="{SpecFlowRoot}\Tools\TechTalk.SpecFlow.tasks" />
   <Import Project="{SpecFlowRoot}\Tools\TechTalk.SpecFlow.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/Tests/TechTalk.SpecFlow.Specs/Drivers/Templates/TestProjectFile.fsproj
+++ b/Tests/TechTalk.SpecFlow.Specs/Drivers/Templates/TestProjectFile.fsproj
@@ -52,6 +52,7 @@
   <PropertyGroup>
     <VerboseOutput>true</VerboseOutput>
   </PropertyGroup>
+  <Import Project="{SpecFlowRoot}\Tools\TechTalk.SpecFlow.tasks" />
   <Import Project="{SpecFlowRoot}\Tools\TechTalk.SpecFlow.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/Tests/TechTalk.SpecFlow.Specs/Drivers/Templates/TestProjectFile.vbproj
+++ b/Tests/TechTalk.SpecFlow.Specs/Drivers/Templates/TestProjectFile.vbproj
@@ -67,5 +67,6 @@
     <Import Include="System.Threading.Tasks" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.VisualBasic.targets" />
+  <Import Project="{SpecFlowRoot}\Tools\TechTalk.SpecFlow.tasks" />
   <Import Project="{SpecFlowRoot}\Tools\TechTalk.SpecFlow.targets" />
 </Project>

--- a/Tests/TechTalk.SpecFlow.Specs/TechTalk.SpecFlow.Specs.csproj
+++ b/Tests/TechTalk.SpecFlow.Specs/TechTalk.SpecFlow.Specs.csproj
@@ -196,7 +196,9 @@
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <ItemGroup>
-    <EmbeddedResource Include="Drivers\Templates\TestProjectFile.vbproj" />
+    <EmbeddedResource Include="Drivers\Templates\TestProjectFile.vbproj">
+      <SubType>Designer</SubType>
+    </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Drivers\Templates\BindingClass.vb" />
@@ -206,6 +208,7 @@
   <PropertyGroup>
     <SpecFlowTasksPath>..\..\TechTalk.SpecFlow.Tools\$(OutDir)\specflow.exe</SpecFlowTasksPath>
   </PropertyGroup>
+  <Import Project="..\..\TechTalk.SpecFlow.Tools\MsBuild\TechTalk.SpecFlow.tasks" />
   <Import Project="..\..\TechTalk.SpecFlow.Tools\MsBuild\TechTalk.SpecFlow.targets" />
   <PropertyGroup>
     <PostBuildEvent>$(SolutionDir)\Tests\PostBuild.bat "$(TargetDir)" "$(SolutionDir)"</PostBuildEvent>


### PR DESCRIPTION
This PR adds the NuGet package SpecFlow.Tools.MsBuild.Generation and resolves #934 

Additionally it changes the SpecFlow package, so that this imports the MSBuild tasks always.
This helps this package and other packages, that depend on the MSBuild tasks, because you don't need anymore a version number in the import.