### PR TITLE
Enable parallel execution support for MsTest V2 988

### DIFF
--- a/TechTalk.SpecFlow.Generator/TechTalk.SpecFlow.Generator.csproj
+++ b/TechTalk.SpecFlow.Generator/TechTalk.SpecFlow.Generator.csproj
@@ -118,6 +118,7 @@
     <Compile Include="TestGenerator.cs" />
     <Compile Include="TestGeneratorFactory.cs" />
     <Compile Include="UnitTestConverter\IFeatureGeneratorProvider.cs" />
+    <Compile Include="UnitTestProvider\MsTestV2GeneratorProvider.cs" />
     <Compile Include="UnitTestProvider\NUnit3TestGeneratorProvider.cs" />
     <Compile Include="UnitTestProvider\UnitTestGeneratorProviders.cs" />
     <Compile Include="UnitTestProvider\MbUnit3TestGeneratorProvider.cs" />

--- a/TechTalk.SpecFlow.Generator/UnitTestProvider/MsTestV2GeneratorProvider.cs
+++ b/TechTalk.SpecFlow.Generator/UnitTestProvider/MsTestV2GeneratorProvider.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.CodeDom;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using TechTalk.SpecFlow.Utils;
+
+namespace TechTalk.SpecFlow.Generator.UnitTestProvider
+{
+    public class MsTestV2GeneratorProvider : MsTest2010GeneratorProvider
+    {
+        public MsTestV2GeneratorProvider(CodeDomHelper codeDomHelper) : base(codeDomHelper)
+        {
+        }
+
+        public override UnitTestGeneratorTraits GetTraits()
+        {
+            return UnitTestGeneratorTraits.None | UnitTestGeneratorTraits.ParallelExecution;
+        }
+
+    }
+}

--- a/TechTalk.SpecFlow.Generator/UnitTestProvider/UnitTestGeneratorProviders.cs
+++ b/TechTalk.SpecFlow.Generator/UnitTestProvider/UnitTestGeneratorProviders.cs
@@ -20,6 +20,7 @@ namespace TechTalk.SpecFlow.Generator
             container.RegisterTypeAs<MsTestGeneratorProvider, IUnitTestGeneratorProvider>("mstest.2008");
             container.RegisterTypeAs<MsTest2010GeneratorProvider, IUnitTestGeneratorProvider>("mstest.2010");
             container.RegisterTypeAs<MsTest2010GeneratorProvider, IUnitTestGeneratorProvider>("mstest");
+            container.RegisterTypeAs<MsTestV2GeneratorProvider, IUnitTestGeneratorProvider>("mstest.v2");
         }
     }
 }


### PR DESCRIPTION
Enabling parallel execution to support mstest v2. by overriding 'GetTraits()' and extending 'MsTest2010GeneratorProvider' and adding a new UnitTestGeneratorProvider 'mstest.v2'