### PR TITLE
Display full method name in error messages

### DIFF
--- a/TechTalk.SpecFlow/Bindings/Reflection/BindingType.cs
+++ b/TechTalk.SpecFlow/Bindings/Reflection/BindingType.cs
@@ -4,26 +4,25 @@ namespace TechTalk.SpecFlow.Bindings.Reflection
 {
     public class BindingType : IBindingType
     {
-        public string Name { get; private set; }
-        public string FullName { get; private set; }
+        public string Name { get; }
+        public string FullName { get; }
+        public string AssemblyName { get; }
 
-        public BindingType(string name, string fullName)
+        public BindingType(string name, string fullName, string assemblyName)
         {
-            if (name == null) throw new ArgumentNullException("name");
-            if (fullName == null) throw new ArgumentNullException("fullName");
-
-            Name = name;
-            FullName = fullName;
+            Name = name ?? throw new ArgumentNullException(nameof(name));
+            FullName = fullName ?? throw new ArgumentNullException(nameof(fullName));
+            AssemblyName = assemblyName ?? throw new ArgumentNullException(nameof(assemblyName));
         }
 
         public override string ToString()
         {
-            return "[" + FullName + "]";
+            return $"[{AssemblyName}:{FullName}]";
         }
 
         protected bool Equals(BindingType other)
         {
-            return string.Equals(Name, other.Name) && string.Equals(FullName, other.FullName);
+            return string.Equals(Name, other.Name) && string.Equals(FullName, other.FullName) && string.Equals(AssemblyName, other.AssemblyName);
         }
 
         public override bool Equals(object obj)
@@ -31,14 +30,14 @@ namespace TechTalk.SpecFlow.Bindings.Reflection
             if (ReferenceEquals(null, obj)) return false;
             if (ReferenceEquals(this, obj)) return true;
             if (obj.GetType() != this.GetType()) return false;
-            return Equals((BindingType) obj);
+            return Equals((BindingType)obj);
         }
 
         public override int GetHashCode()
         {
             unchecked
             {
-                return ((Name != null ? Name.GetHashCode() : 0)*397) ^ (FullName != null ? FullName.GetHashCode() : 0);
+                return ((Name != null ? Name.GetHashCode() : 0) * 397) ^ (FullName != null ? FullName.GetHashCode() : 0) ^ (AssemblyName != null ? AssemblyName.GetHashCode() : 0);
             }
         }
     }

--- a/TechTalk.SpecFlow/Bindings/Reflection/IBindingType.cs
+++ b/TechTalk.SpecFlow/Bindings/Reflection/IBindingType.cs
@@ -1,10 +1,10 @@
-﻿using System;
-
+﻿
 namespace TechTalk.SpecFlow.Bindings.Reflection
 {
     public interface IBindingType
     {
         string Name { get; }
         string FullName { get; }
+        string AssemblyName { get; }
     }
 }

--- a/TechTalk.SpecFlow/Bindings/Reflection/RuntimeBindingType.cs
+++ b/TechTalk.SpecFlow/Bindings/Reflection/RuntimeBindingType.cs
@@ -6,15 +6,11 @@ namespace TechTalk.SpecFlow.Bindings.Reflection
     {
         public readonly Type Type;
 
-        public string Name
-        {
-            get { return Type.Name; }
-        }
+        public string Name => Type.Name;
 
-        public string FullName
-        {
-            get { return Type.FullName; }
-        }
+        public string FullName => Type.FullName;
+
+        public string AssemblyName => Type.Assembly.GetName().Name;
 
         public RuntimeBindingType(Type type)
         {

--- a/TechTalk.SpecFlow/ErrorHandling/ErrorProvider.cs
+++ b/TechTalk.SpecFlow/ErrorHandling/ErrorProvider.cs
@@ -41,7 +41,7 @@ namespace TechTalk.SpecFlow.ErrorHandling
 
         public string GetMethodText(IBindingMethod method)
         {
-            return string.Format("{0}.{1}({2})", method.Type.Name, method.Name,
+            return string.Format("{0}.{1}({2})", method.Type.FullName, method.Name,
                 string.Join(", ", method.Parameters.Select(p => p.Type.Name).ToArray()));
         }
 

--- a/TechTalk.SpecFlow/ErrorHandling/ErrorProvider.cs
+++ b/TechTalk.SpecFlow/ErrorHandling/ErrorProvider.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Reflection;
 using TechTalk.SpecFlow.Bindings;
 using TechTalk.SpecFlow.Bindings.Reflection;
 using TechTalk.SpecFlow.Configuration;
-using TechTalk.SpecFlow.Infrastructure;
 using TechTalk.SpecFlow.Tracing;
 using TechTalk.SpecFlow.UnitTestProvider;
 

--- a/TechTalk.SpecFlow/ErrorHandling/ErrorProvider.cs
+++ b/TechTalk.SpecFlow/ErrorHandling/ErrorProvider.cs
@@ -39,8 +39,8 @@ namespace TechTalk.SpecFlow.ErrorHandling
 
         public string GetMethodText(IBindingMethod method)
         {
-            return string.Format("{0}.{1}({2})", method.Type.FullName, method.Name,
-                string.Join(", ", method.Parameters.Select(p => p.Type.Name).ToArray()));
+            string parametersDisplayed = string.Join(", ", method.Parameters.Select(p => p.Type.Name).ToArray());
+            return $"{method.Type.AssemblyName}:{method.Type.FullName}.{method.Name}({parametersDisplayed})";
         }
 
         public Exception GetCallError(IBindingMethod method, Exception ex)

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/Bindings/StepDefinitionRegexCalculatorTests.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/Bindings/StepDefinitionRegexCalculatorTests.cs
@@ -33,7 +33,7 @@ namespace TechTalk.SpecFlow.RuntimeTests.Bindings
         {
             parameters = parameters ?? new string[0];
             return new BindingMethod(
-                new BindingType("SomeSteps", "SomeSteps"), 
+                new BindingType("SomeAssembly", "SomeSteps", "SomeSteps"),
                 name, 
                 parameters.Select(pn => new BindingParameter(new RuntimeBindingType(typeof(string)), pn)), 
                 new RuntimeBindingType(typeof(void)));

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/ErrorProviderTests.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/ErrorProviderTests.cs
@@ -1,0 +1,49 @@
+﻿using NUnit.Framework;
+using TechTalk.SpecFlow.ErrorHandling;
+using TechTalk.SpecFlow.Tracing;
+using TechTalk.SpecFlow.UnitTestProvider;
+using FluentAssertions;
+using Moq;
+using TechTalk.SpecFlow.Bindings.Reflection;
+
+namespace TechTalk.SpecFlow.RuntimeTests
+{
+    [TestFixture]
+    public class ErrorProviderTests
+    {
+        private static ErrorProvider CreateErrorProvider(IStepFormatter stepFormatter = null, SpecFlow.Configuration.SpecFlowConfiguration specFlowConfiguration = null, IUnitTestRuntimeProvider unitTestRuntimeProvider = null)
+        {
+            return new ErrorProvider(stepFormatter, specFlowConfiguration, unitTestRuntimeProvider);
+        }
+
+        [Test]
+        public void GetMethodText_should_return_string_containing_full_assembly_name__method_name_and_parameters_types()
+        {
+            var errorProvider = CreateErrorProvider();
+
+            var bindingMethodTypeStub = new Mock<IBindingType>();
+            bindingMethodTypeStub.Setup(t => t.FullName).Returns("StepsAssembly1.CalculatorSteps");
+
+            var bindingMethodStub = new Mock<IBindingMethod>();
+            bindingMethodStub.Setup(m => m.Type).Returns(bindingMethodTypeStub.Object);
+            bindingMethodStub.Setup(m => m.Name).Returns("WhenIAdd");
+
+            var bindingParameter1TypeStub = new Mock<IBindingType>();
+            bindingParameter1TypeStub.Setup(t => t.Name).Returns("Int32");
+            var bindingParameter1Stub = new Mock<IBindingParameter>();
+            bindingParameter1Stub.Setup(p => p.Type).Returns(bindingParameter1TypeStub.Object);
+
+            var bindingParameter2TypeStub = new Mock<IBindingType>();
+            bindingParameter2TypeStub.Setup(t => t.Name).Returns("String");
+            var bindingParameter2Stub = new Mock<IBindingParameter>();
+            bindingParameter2Stub.Setup(p => p.Type).Returns(bindingParameter2TypeStub.Object);
+
+
+            bindingMethodStub.Setup(m => m.Parameters).Returns(new[] { bindingParameter1Stub.Object, bindingParameter2Stub.Object });
+            
+            var result = errorProvider.GetMethodText(bindingMethodStub.Object);
+            result.Should().NotBeNull();
+            result.Should().Be("StepsAssembly1.CalculatorSteps.WhenIAdd(Int32, String)");
+        }
+    }
+}

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/ErrorProviderTests.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/ErrorProviderTests.cs
@@ -164,5 +164,15 @@ namespace TechTalk.SpecFlow.RuntimeTests
 
             result.Should().NotBeNull();
         }
+
+        [Test]
+        public void GetPendingStepDefinitionError_Throws_MissingStepDefinitionException()
+        {
+            var errorProvider = CreateErrorProvider();
+
+            var result = errorProvider.GetPendingStepDefinitionError();
+
+            result.Should().NotBeNull();
+        }
     }
 }

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/ErrorProviderTests.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/ErrorProviderTests.cs
@@ -6,6 +6,7 @@ using TechTalk.SpecFlow.Tracing;
 using TechTalk.SpecFlow.UnitTestProvider;
 using FluentAssertions;
 using Moq;
+using TechTalk.SpecFlow.Bindings;
 using TechTalk.SpecFlow.Bindings.Reflection;
 
 namespace TechTalk.SpecFlow.RuntimeTests
@@ -71,5 +72,34 @@ namespace TechTalk.SpecFlow.RuntimeTests
             result.Should().BeOfType<BindingException>();
             result.Message.Should().Be($"Error calling binding method '{methodBindingTypeFullName}.{methodName}({parameter1Type}, {parameter2Type})': {expectedExceptionMessage}");
         }
+
+        [Test]
+        public void GetParameterCountError_should_return_BindingException_containing_full_assembly_name__method_name_and_parameters_types_and_expected_parameter_count()
+        {
+            const string methodName = "WhenIMultiply";
+            const string methodBindingTypeName = "CalculatorSteps";
+            const string methodBindingTypeFullName = "StepsAssembly1.CalculatorSteps";
+            const string parameter1Type = "Int64";
+
+            const string expectedExceptionMessage = "Initialization failed";
+
+            var errorProvider = CreateErrorProvider();
+
+            var bindingMethod = CreateBindingMethod(methodName, methodBindingTypeName, methodBindingTypeFullName, parameter1Type);
+
+            var exceptionStub = new Mock<Exception>();
+            exceptionStub.Setup(e => e.Message).Returns(expectedExceptionMessage);
+
+            var stepDefinitionStub = new Mock<IStepDefinitionBinding>();
+            stepDefinitionStub.Setup(sd => sd.Method).Returns(bindingMethod);
+            var result = errorProvider.GetParameterCountError(new BindingMatch(stepDefinitionStub.Object, It.IsAny<int>(),null, null), 2);
+
+            result.Should().NotBeNull();
+            result.Should().BeOfType<BindingException>();
+            result.Message.Should().Be($"Parameter count mismatch! The binding method '{methodBindingTypeFullName}.{methodName}({parameter1Type})' should have 2 parameters");
+
+
+        }
+
     }
 }

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/ErrorProviderTests.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/ErrorProviderTests.cs
@@ -26,7 +26,7 @@ namespace TechTalk.SpecFlow.RuntimeTests
             return new BindingMethod(
                 new BindingType(methodBindingTypeName, methodBindingTypeFullName),
                 methodName,
-                parametersTypes.Select(pn => new BindingParameter(new BindingType(pn, pn),string.Empty)),
+                parametersTypes.Select(pn => new BindingParameter(new BindingType(pn, pn), string.Empty)),
                 null);
         }
 
@@ -42,11 +42,11 @@ namespace TechTalk.SpecFlow.RuntimeTests
             var errorProvider = CreateErrorProvider();
 
             var bindingMethod = CreateBindingMethod(methodName, methodBindingTypeName, methodBindingTypeFullName, parameter1Type, parameter2Type);
-            
+
             var result = errorProvider.GetMethodText(bindingMethod);
 
             result.Should().NotBeNull();
-            result.Should().Be($"{methodBindingTypeFullName}.{ methodName}({ parameter1Type}, { parameter2Type})");
+            result.Should().Be($"{methodBindingTypeFullName}.{methodName}({parameter1Type}, {parameter2Type})");
         }
 
         [Test]
@@ -88,38 +88,16 @@ namespace TechTalk.SpecFlow.RuntimeTests
 
             var stepDefinitionStub = new Mock<IStepDefinitionBinding>();
             stepDefinitionStub.Setup(sd => sd.Method).Returns(bindingMethod);
-            var result = errorProvider.GetParameterCountError(new BindingMatch(stepDefinitionStub.Object, It.IsAny<int>(),null, null), 2);
+            var result = errorProvider.GetParameterCountError(new BindingMatch(stepDefinitionStub.Object, It.IsAny<int>(), null, null), 2);
 
             result.Should().NotBeNull();
             result.Should().BeOfType<BindingException>();
             result.Message.Should().Be($"Parameter count mismatch! The binding method '{methodBindingTypeFullName}.{methodName}({parameter1Type})' should have 2 parameters");
         }
 
-        [Test]
-        public void GetAmbiguousMatchError_should_return_BindingException_containing_full_assembly_names_method_names_parameters_types_and_step_description()
-        {
-            const string prefixMessage = "Ambiguous step definitions found for step";
-            GetMatchErrorMethod_should_return_BindingException_containing_full_assembly_names_method_names_parameters_types_and_step_description(
-                (errorProvider,matches, stepInstance) => errorProvider.GetAmbiguousMatchError(matches, stepInstance), prefixMessage);
-        }
 
-        [Test]
-        public void GetAmbiguousBecauseParamCheckMatchError_should_return_BindingException_containing_full_assembly_names_method_names_parameters_types_and_step_description()
-        {
-            const string prefixMessage = "Multiple step definitions found, but none of them have matching parameter count and type for step";
-            GetMatchErrorMethod_should_return_BindingException_containing_full_assembly_names_method_names_parameters_types_and_step_description(
-                (errorProvider, matches, stepInstance) => errorProvider.GetAmbiguousBecauseParamCheckMatchError(matches, stepInstance), prefixMessage);
-        }
 
-        [Test]
-        public void GetNoMatchBecauseOfScopeFilterError_should_return_BindingException_containing_full_assembly_names_method_names_parameters_types_and_step_description()
-        {
-            const string prefixMessage = "Multiple step definitions found, but none of them have matching scope for step";
-            GetMatchErrorMethod_should_return_BindingException_containing_full_assembly_names_method_names_parameters_types_and_step_description(
-                (errorProvider, matches, stepInstance) => errorProvider.GetNoMatchBecauseOfScopeFilterError(matches, stepInstance), prefixMessage);
-        }
-
-        private void GetMatchErrorMethod_should_return_BindingException_containing_full_assembly_names_method_names_parameters_types_and_step_description(Func<ErrorProvider, List<BindingMatch>, StepInstance, Exception>GetMatchErrorFunc,string expectedPrefixMessage)
+        private void GetMatchErrorMethod_should_return_BindingException_containing_full_assembly_names_method_names_parameters_types_and_step_description(Func<ErrorProvider, List<BindingMatch>, StepInstance, Exception> GetMatchErrorFunc, string expectedPrefixMessage)
         {
             const string methodName = "WhenIMultiply";
             const string methodBindingTypeName = "CalculatorSteps";
@@ -145,12 +123,46 @@ namespace TechTalk.SpecFlow.RuntimeTests
                 new BindingMatch(stepDefinitionStub1.Object, It.IsAny<int>(), null, null),
                 new BindingMatch(stepDefinitionStub2.Object, It.IsAny<int>(), null, null)
             };
-            var result = GetMatchErrorFunc(errorProvider,bindingMatch, null);
+
+            var result = GetMatchErrorFunc(errorProvider, bindingMatch, null);
 
             result.Should().NotBeNull();
             result.Should().BeOfType<BindingException>();
             result.Message.Should().Be($"{expectedPrefixMessage} '{stepInstanceDescription}': {method1BindingTypeFullName}.{methodName}({parameter1Type}), {method2BindingTypeFullName}.{methodName}({parameter1Type})");
         }
 
+        [Test]
+        public void GetAmbiguousMatchError_should_return_BindingException_containing_full_assembly_names_method_names_parameters_types_and_step_description()
+        {
+            const string prefixMessage = "Ambiguous step definitions found for step";
+            GetMatchErrorMethod_should_return_BindingException_containing_full_assembly_names_method_names_parameters_types_and_step_description(
+                (errorProvider, matches, stepInstance) => errorProvider.GetAmbiguousMatchError(matches, stepInstance), prefixMessage);
+        }
+
+        [Test]
+        public void GetAmbiguousBecauseParamCheckMatchError_should_return_BindingException_containing_full_assembly_names_method_names_parameters_types_and_step_description()
+        {
+            const string prefixMessage = "Multiple step definitions found, but none of them have matching parameter count and type for step";
+            GetMatchErrorMethod_should_return_BindingException_containing_full_assembly_names_method_names_parameters_types_and_step_description(
+                (errorProvider, matches, stepInstance) => errorProvider.GetAmbiguousBecauseParamCheckMatchError(matches, stepInstance), prefixMessage);
+        }
+
+        [Test]
+        public void GetNoMatchBecauseOfScopeFilterError_should_return_BindingException_containing_full_assembly_names_method_names_parameters_types_and_step_description()
+        {
+            const string prefixMessage = "Multiple step definitions found, but none of them have matching scope for step";
+            GetMatchErrorMethod_should_return_BindingException_containing_full_assembly_names_method_names_parameters_types_and_step_description(
+                (errorProvider, matches, stepInstance) => errorProvider.GetNoMatchBecauseOfScopeFilterError(matches, stepInstance), prefixMessage);
+        }
+
+        [Test]
+        public void GetMissingStepDefinitionError_Throws_MissingStepDefinitionException()
+        {
+            var errorProvider = CreateErrorProvider();
+
+            var result = errorProvider.GetMissingStepDefinitionError();
+
+            result.Should().NotBeNull();
+        }
     }
 }

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/ErrorProviderTests.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/ErrorProviderTests.cs
@@ -21,13 +21,13 @@ namespace TechTalk.SpecFlow.RuntimeTests
             return new ErrorProvider(stepFormatter, specFlowConfiguration, unitTestRuntimeProvider);
         }
 
-        private IBindingMethod CreateBindingMethod(string methodName, string methodBindingTypeName, string methodBindingTypeFullName, params string[] parametersTypes)
+        private IBindingMethod CreateBindingMethod(string methodName, string methodBindingTypeName, string methodBindingTypeFullName, string methodBindingAssemblyName, params string[] parametersTypes)
         {
             parametersTypes = parametersTypes ?? new string[0];
             return new BindingMethod(
-                new BindingType(methodBindingTypeName, methodBindingTypeFullName),
+                new BindingType(methodBindingTypeName, methodBindingTypeFullName, methodBindingAssemblyName),
                 methodName,
-                parametersTypes.Select(pn => new BindingParameter(new BindingType(pn, pn), string.Empty)),
+                parametersTypes.Select(pn => new BindingParameter(new BindingType(pn, pn, string.Empty), string.Empty)),
                 null);
         }
 
@@ -36,18 +36,19 @@ namespace TechTalk.SpecFlow.RuntimeTests
         {
             const string methodName = "WhenIAdd";
             const string methodBindingTypeName = "CalculatorSteps";
-            const string methodBindingTypeFullName = "StepsAssembly1.CalculatorSteps";
+            const string methodBindingAssemblyName = "StepsAssembly1";
+            const string methodBindingTypeFullName = "StepsNamespace.CalculatorSteps";
             const string parameter1Type = "Int32";
             const string parameter2Type = "String";
 
             var errorProvider = CreateErrorProvider();
 
-            var bindingMethod = CreateBindingMethod(methodName, methodBindingTypeName, methodBindingTypeFullName, parameter1Type, parameter2Type);
+            var bindingMethod = CreateBindingMethod(methodName, methodBindingTypeName, methodBindingTypeFullName, methodBindingAssemblyName, parameter1Type, parameter2Type);
 
             var result = errorProvider.GetMethodText(bindingMethod);
 
             result.Should().NotBeNull();
-            result.Should().Be($"{methodBindingTypeFullName}.{methodName}({parameter1Type}, {parameter2Type})");
+            result.Should().Be($"{methodBindingAssemblyName}:{methodBindingTypeFullName}.{methodName}({parameter1Type}, {parameter2Type})");
         }
 
         [Test]
@@ -55,7 +56,8 @@ namespace TechTalk.SpecFlow.RuntimeTests
         {
             const string methodName = "WhenIMultiply";
             const string methodBindingTypeName = "CalculatorSteps";
-            const string methodBindingTypeFullName = "StepsAssembly1.CalculatorSteps";
+            const string methodBindingAssemblyName = "StepsAssembly1";
+            const string methodBindingTypeFullName = "StepsNamespace.CalculatorSteps";
             const string parameter1Type = "String";
             const string parameter2Type = "Int64";
 
@@ -63,7 +65,7 @@ namespace TechTalk.SpecFlow.RuntimeTests
 
             var errorProvider = CreateErrorProvider();
 
-            var bindingMethod = CreateBindingMethod(methodName, methodBindingTypeName, methodBindingTypeFullName, parameter1Type, parameter2Type);
+            var bindingMethod = CreateBindingMethod(methodName, methodBindingTypeName, methodBindingTypeFullName, methodBindingAssemblyName, parameter1Type, parameter2Type);
 
             var exceptionStub = new Mock<Exception>();
             exceptionStub.Setup(e => e.Message).Returns(expectedExceptionMessage);
@@ -72,7 +74,7 @@ namespace TechTalk.SpecFlow.RuntimeTests
 
             result.Should().NotBeNull();
             result.Should().BeOfType<BindingException>();
-            result.Message.Should().Be($"Error calling binding method '{methodBindingTypeFullName}.{methodName}({parameter1Type}, {parameter2Type})': {expectedExceptionMessage}");
+            result.Message.Should().Be($"Error calling binding method '{methodBindingAssemblyName}:{methodBindingTypeFullName}.{methodName}({parameter1Type}, {parameter2Type})': {expectedExceptionMessage}");
         }
 
         [Test]
@@ -80,12 +82,13 @@ namespace TechTalk.SpecFlow.RuntimeTests
         {
             const string methodName = "WhenIMultiply";
             const string methodBindingTypeName = "CalculatorSteps";
-            const string methodBindingTypeFullName = "StepsAssembly1.CalculatorSteps";
+            const string methodBindingAssemblyName = "StepsAssembly1";
+            const string methodBindingTypeFullName = "StepsNamespace.CalculatorSteps";
             const string parameter1Type = "Int64";
 
             var errorProvider = CreateErrorProvider();
 
-            var bindingMethod = CreateBindingMethod(methodName, methodBindingTypeName, methodBindingTypeFullName, parameter1Type);
+            var bindingMethod = CreateBindingMethod(methodName, methodBindingTypeName, methodBindingTypeFullName, methodBindingAssemblyName, parameter1Type);
 
             var stepDefinitionStub = new Mock<IStepDefinitionBinding>();
             stepDefinitionStub.Setup(sd => sd.Method).Returns(bindingMethod);
@@ -93,7 +96,7 @@ namespace TechTalk.SpecFlow.RuntimeTests
 
             result.Should().NotBeNull();
             result.Should().BeOfType<BindingException>();
-            result.Message.Should().Be($"Parameter count mismatch! The binding method '{methodBindingTypeFullName}.{methodName}({parameter1Type})' should have 2 parameters");
+            result.Message.Should().Be($"Parameter count mismatch! The binding method '{methodBindingAssemblyName}:{methodBindingTypeFullName}.{methodName}({parameter1Type})' should have 2 parameters");
         }
 
 
@@ -102,8 +105,9 @@ namespace TechTalk.SpecFlow.RuntimeTests
         {
             const string methodName = "WhenIMultiply";
             const string methodBindingTypeName = "CalculatorSteps";
-            const string method1BindingTypeFullName = "StepsAssembly1.CalculatorSteps";
-            const string method2BindingTypeFullName = "StepsAssembly1.CalculatorSteps";
+            const string methodBindingAssemblyName = "StepsAssembly1";
+            const string method1BindingTypeFullName = "StepsNamespace.CalculatorSteps";
+            const string method2BindingTypeFullName = "StepsNamespace.CalculatorSteps";
             const string parameter1Type = "Int64";
 
             const string stepInstanceDescription = "'Given I multiply 10 and 5'";
@@ -112,8 +116,8 @@ namespace TechTalk.SpecFlow.RuntimeTests
             stepFormatterStub.Setup(f => f.GetStepDescription(It.IsAny<StepInstance>())).Returns(stepInstanceDescription);
             var errorProvider = CreateErrorProvider(stepFormatterStub.Object);
 
-            var bindingMethod1 = CreateBindingMethod(methodName, methodBindingTypeName, method1BindingTypeFullName, parameter1Type);
-            var bindingMethod2 = CreateBindingMethod(methodName, methodBindingTypeName, method2BindingTypeFullName, parameter1Type);
+            var bindingMethod1 = CreateBindingMethod(methodName, methodBindingTypeName, method1BindingTypeFullName, methodBindingAssemblyName, parameter1Type);
+            var bindingMethod2 = CreateBindingMethod(methodName, methodBindingTypeName, method2BindingTypeFullName, methodBindingAssemblyName, parameter1Type);
 
             var stepDefinitionStub1 = new Mock<IStepDefinitionBinding>();
             stepDefinitionStub1.Setup(sd => sd.Method).Returns(bindingMethod1);
@@ -129,7 +133,7 @@ namespace TechTalk.SpecFlow.RuntimeTests
 
             result.Should().NotBeNull();
             result.Should().BeOfType<BindingException>();
-            result.Message.Should().Be($"{expectedPrefixMessage} '{stepInstanceDescription}': {method1BindingTypeFullName}.{methodName}({parameter1Type}), {method2BindingTypeFullName}.{methodName}({parameter1Type})");
+            result.Message.Should().Be($"{expectedPrefixMessage} '{stepInstanceDescription}': {methodBindingAssemblyName}:{method1BindingTypeFullName}.{methodName}({parameter1Type}), {methodBindingAssemblyName}:{method2BindingTypeFullName}.{methodName}({parameter1Type})");
         }
 
         [Test]
@@ -195,7 +199,7 @@ namespace TechTalk.SpecFlow.RuntimeTests
             var missingOrPendingStepsOutcome = MissingOrPendingStepsOutcome.Pending;
 
             var testRuntimeProviderMock = ThrowPendingError(missingOrPendingStepsOutcome, expectedMessage);
-            
+
             testRuntimeProviderMock.Verify(p => p.TestPending(expectedMessage));
         }
 

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/Infrastructure/StepDefinitionMatchServiceTest.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/Infrastructure/StepDefinitionMatchServiceTest.cs
@@ -38,12 +38,12 @@ namespace TechTalk.SpecFlow.RuntimeTests.Infrastructure
 
         private static BindingMethod CreateBindingMethod(string name = "dummy")
         {
-            return new BindingMethod(new BindingType("dummy", "dummy"), name, new IBindingParameter[0], null);
+            return new BindingMethod(new BindingType("dummy", "dummy", "dummy"), name, new IBindingParameter[0], null);
         }
 
         private static BindingMethod CreateBindingMethodWithStrignParam(string name = "dummy")
         {
-            return new BindingMethod(new BindingType("dummy", "dummy"), name, new IBindingParameter[] { new BindingParameter(new RuntimeBindingType(typeof(string)), "param1") }, null);
+            return new BindingMethod(new BindingType("dummy", "dummy", "dummy"), name, new IBindingParameter[] { new BindingParameter(new RuntimeBindingType(typeof(string)), "param1") }, null);
         }
 
         private StepInstance CreateSimpleWhen(string text = "I do something")

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/Infrastructure/TestExecutionEngineTests.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/Infrastructure/TestExecutionEngineTests.cs
@@ -175,7 +175,7 @@ namespace TechTalk.SpecFlow.RuntimeTests.Infrastructure
         private Mock<IHookBinding> CreateParametrizedHookMock(List<IHookBinding> hookList, params Type[] paramTypes)
         {
             var hookMock = CreateHookMock(hookList);
-            var bindingMethod = new BindingMethod(new BindingType("BT", "Test.BT"), "X", 
+            var bindingMethod = new BindingMethod(new BindingType("AssemblyBT", "BT", "Test.BT"), "X",
                 paramTypes.Select((paramType, i) => new BindingParameter(new RuntimeBindingType(paramType), "p" + i)), 
                 RuntimeBindingType.Void);
             hookMock.Setup(h => h.Method).Returns(bindingMethod);

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/RuntimeTests.csproj
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/RuntimeTests.csproj
@@ -162,6 +162,7 @@
     <Compile Include="Bindings\BindingRegistryTests.cs" />
     <Compile Include="Configuration\JsonConfigTests.cs" />
     <Compile Include="Bindings\StepDefinitionRegexCalculatorTests.cs" />
+    <Compile Include="ErrorProviderTests.cs" />
     <Compile Include="Infrastructure\TestThreadContextTests.cs" />
     <Compile Include="Infrastructure\StepDefinitionMatchServiceTest.cs" />
     <Compile Include="RuntimeBindingRegistryBuilderTests.cs" />

--- a/changelog.txt
+++ b/changelog.txt
@@ -9,6 +9,7 @@ Fixes:
 + Meaningful exception is thrown when there are no Examples or Examples are empty in Scenario Outline https://github.com/techtalk/SpecFlow/pull/967
 + "copy" feature in the step definition report is not working in modern browsers https://github.com/techtalk/SpecFlow/issues/958 https://github.com/techtalk/SpecFlow/issues/915
 + Xunit support @ignore on a feature level https://github.com/techtalk/SpecFlow/pull/968
++ Format error message to facilate identification of ambiguous steps https://github.com/techtalk/SpecFlow/issues/994
 
 API Changes:
 + GetValue of ValueRetrievers are virtual https://github.com/techtalk/SpecFlow/pull/981


### PR DESCRIPTION
Closes https://github.com/techtalk/SpecFlow/issues/994

- Updated ErrorProvider.GetMethodText
- Added unit tests for ErrorProvider