### PR TITLE
Array & List support for strings and enums when instantiating class from Specflow table.

### DIFF
--- a/TechTalk.SpecFlow/Assist/Service.cs
+++ b/TechTalk.SpecFlow/Assist/Service.cs
@@ -102,6 +102,8 @@ namespace TechTalk.SpecFlow.Assist
             RegisterValueRetriever(new NullableLongValueRetriever());
             RegisterValueRetriever(new NullableTimeSpanValueRetriever());
             RegisterValueRetriever(new NullableDateTimeOffsetValueRetriever());
+
+            RegisterValueRetriever(new StringArrayValueRetriever());
         }
 
         public IValueRetriever GetValueRetrieverFor(TableRow row, Type targetType, Type propertyType)

--- a/TechTalk.SpecFlow/Assist/Service.cs
+++ b/TechTalk.SpecFlow/Assist/Service.cs
@@ -106,7 +106,7 @@ namespace TechTalk.SpecFlow.Assist
             RegisterValueRetriever(new StringArrayValueRetriever());
             RegisterValueRetriever(new StringListValueRetriever());
             RegisterValueRetriever(new EnumArrayValueRetriever());
-
+            RegisterValueRetriever(new EnumListValueRetriever());
         }
 
         public IValueRetriever GetValueRetrieverFor(TableRow row, Type targetType, Type propertyType)

--- a/TechTalk.SpecFlow/Assist/Service.cs
+++ b/TechTalk.SpecFlow/Assist/Service.cs
@@ -105,6 +105,8 @@ namespace TechTalk.SpecFlow.Assist
 
             RegisterValueRetriever(new StringArrayValueRetriever());
             RegisterValueRetriever(new StringListValueRetriever());
+            RegisterValueRetriever(new EnumArrayValueRetriever());
+
         }
 
         public IValueRetriever GetValueRetrieverFor(TableRow row, Type targetType, Type propertyType)

--- a/TechTalk.SpecFlow/Assist/Service.cs
+++ b/TechTalk.SpecFlow/Assist/Service.cs
@@ -104,6 +104,7 @@ namespace TechTalk.SpecFlow.Assist
             RegisterValueRetriever(new NullableDateTimeOffsetValueRetriever());
 
             RegisterValueRetriever(new StringArrayValueRetriever());
+            RegisterValueRetriever(new StringListValueRetriever());
         }
 
         public IValueRetriever GetValueRetrieverFor(TableRow row, Type targetType, Type propertyType)

--- a/TechTalk.SpecFlow/Assist/ValueRetrievers/EnumArrayValueRetriever.cs
+++ b/TechTalk.SpecFlow/Assist/ValueRetrievers/EnumArrayValueRetriever.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace TechTalk.SpecFlow.Assist.ValueRetrievers
+{
+    public class EnumArrayValueRetriever : IValueRetriever
+    {
+        public virtual object GetValue(string value, Type targetEnumType)
+        {
+            var enums = new StringArrayValueRetriever()
+                .GetValue(value)
+                .Select(item => Enum.Parse(targetEnumType, item))
+                .ToArray(); 
+
+            Array dest = Array.CreateInstance(targetEnumType, enums.Length);
+            Array.Copy(enums, dest, enums.Length);
+
+            return dest;
+
+        }
+
+        public object Retrieve(KeyValuePair<string, string> keyValuePair, Type targetType, Type propertyType)
+        {
+            return GetValue(keyValuePair.Value, propertyType.GetElementType());
+        }
+
+        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type targetType, Type propertyType)
+        {
+            return propertyType.IsArray && propertyType.GetElementType().IsEnum;
+        }
+
+        Array CastArray(Type target, string[] input)
+        {
+            Array dest = Array.CreateInstance(target, input.Length);
+
+            var enums = input.Select(value => Enum.Parse(target, value)).ToArray();
+
+            Array.Copy(enums, dest, enums.Length);
+
+            return dest;
+        }
+    }
+}

--- a/TechTalk.SpecFlow/Assist/ValueRetrievers/EnumArrayValueRetriever.cs
+++ b/TechTalk.SpecFlow/Assist/ValueRetrievers/EnumArrayValueRetriever.cs
@@ -10,7 +10,7 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
         {
             var enums = new StringArrayValueRetriever()
                 .GetValue(value)
-                .Select(item => Enum.Parse(targetEnumType, item))
+                .Select(item => new EnumValueRetriever().GetValue(item, targetEnumType))
                 .ToArray(); 
 
             Array dest = Array.CreateInstance(targetEnumType, enums.Length);

--- a/TechTalk.SpecFlow/Assist/ValueRetrievers/EnumArrayValueRetriever.cs
+++ b/TechTalk.SpecFlow/Assist/ValueRetrievers/EnumArrayValueRetriever.cs
@@ -30,15 +30,5 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
             return propertyType.IsArray && propertyType.GetElementType().IsEnum;
         }
 
-        Array CastArray(Type target, string[] input)
-        {
-            Array dest = Array.CreateInstance(target, input.Length);
-
-            var enums = input.Select(value => Enum.Parse(target, value)).ToArray();
-
-            Array.Copy(enums, dest, enums.Length);
-
-            return dest;
-        }
     }
 }

--- a/TechTalk.SpecFlow/Assist/ValueRetrievers/EnumListValueRetriever.cs
+++ b/TechTalk.SpecFlow/Assist/ValueRetrievers/EnumListValueRetriever.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+namespace TechTalk.SpecFlow.Assist.ValueRetrievers
+{
+    public class EnumListValueRetriever : IValueRetriever
+    {
+        public virtual object GetValue(string value, Type targetEnumType)
+        {
+            var array = new EnumArrayValueRetriever().GetValue(value, targetEnumType);
+            return GenerateList(targetEnumType, array);
+        }
+
+        public object Retrieve(KeyValuePair<string, string> keyValuePair, Type targetType, Type propertyType)
+        {
+            return GetValue(keyValuePair.Value, propertyType.GetGenericArguments()[0]);
+        }
+
+        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type targetType, Type propertyType)
+        {
+            return propertyType.IsGenericType && (
+                       propertyType.GetGenericTypeDefinition() == typeof(IList<>) ||
+                       propertyType.GetGenericTypeDefinition() == typeof(List<>)) &&
+                   propertyType.GetGenericArguments()[0].IsEnum;
+        }
+
+        object GenerateList(Type targetType, object array)
+        {
+            var castMethod = typeof(Enumerable).GetMethod("Cast", BindingFlags.Static | BindingFlags.Public);
+            var genericCast = castMethod.MakeGenericMethod(targetType);
+
+            var toListMethod = typeof(Enumerable).GetMethod("ToList", BindingFlags.Static | BindingFlags.Public);
+            var genericToList = toListMethod.MakeGenericMethod(targetType);
+
+            var casted = genericCast.Invoke(null, new object[] { array });
+            var list = genericToList.Invoke(null, new[] { casted });
+
+            return list;
+        }
+    }
+}

--- a/TechTalk.SpecFlow/Assist/ValueRetrievers/StringArrayValueRetriever.cs
+++ b/TechTalk.SpecFlow/Assist/ValueRetrievers/StringArrayValueRetriever.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace TechTalk.SpecFlow.Assist.ValueRetrievers
+{
+    public class StringArrayValueRetriever : IValueRetriever
+    {
+        public virtual string[] GetValue(string value)
+        {
+            const char byCommaSeparator = ',';
+
+            var stringArray = value.Split(byCommaSeparator).Select(p => p.Trim()).ToArray();
+
+            return stringArray;
+        }
+
+        public object Retrieve(KeyValuePair<string, string> keyValuePair, Type targetType, Type propertyType)
+        {
+            return GetValue(keyValuePair.Value);
+        }
+
+        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type targetType, Type propertyType)
+        {
+            return propertyType == typeof(string[]);
+        }
+    }
+}

--- a/TechTalk.SpecFlow/Assist/ValueRetrievers/StringListValueRetriever.cs
+++ b/TechTalk.SpecFlow/Assist/ValueRetrievers/StringListValueRetriever.cs
@@ -18,7 +18,7 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
 
         public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type targetType, Type propertyType)
         {
-            return propertyType == typeof(List<string>);
+            return propertyType == typeof(List<string>) || propertyType == typeof(IList<string>);
         }
     }
 }

--- a/TechTalk.SpecFlow/Assist/ValueRetrievers/StringListValueRetriever.cs
+++ b/TechTalk.SpecFlow/Assist/ValueRetrievers/StringListValueRetriever.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace TechTalk.SpecFlow.Assist.ValueRetrievers
+{
+    public class StringListValueRetriever : IValueRetriever
+    {
+        public virtual List<string> GetValue(string value)
+        {
+            return new StringArrayValueRetriever().GetValue(value).ToList();
+        }
+
+        public object Retrieve(KeyValuePair<string, string> keyValuePair, Type targetType, Type propertyType)
+        {
+            return GetValue(keyValuePair.Value);
+        }
+
+        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type targetType, Type propertyType)
+        {
+            return propertyType == typeof(List<string>);
+        }
+    }
+}

--- a/TechTalk.SpecFlow/TechTalk.SpecFlow.csproj
+++ b/TechTalk.SpecFlow/TechTalk.SpecFlow.csproj
@@ -89,6 +89,7 @@
     <Compile Include="Assist\ValueRetrievers\ByteValueRetriever.cs" />
     <Compile Include="Assist\ValueRetrievers\CharValueRetriever.cs" />
     <Compile Include="Assist\ValueRetrievers\DateTimeOffsetValueRetriever.cs" />
+    <Compile Include="Assist\ValueRetrievers\EnumListValueRetriever.cs" />
     <Compile Include="Assist\ValueRetrievers\LongValueRetriever.cs" />
     <Compile Include="Assist\ValueRetrievers\NullableByteValueRetriever.cs" />
     <Compile Include="Assist\ValueRetrievers\NullableDateTimeOffsetValueRetriever.cs" />

--- a/TechTalk.SpecFlow/TechTalk.SpecFlow.csproj
+++ b/TechTalk.SpecFlow/TechTalk.SpecFlow.csproj
@@ -103,6 +103,7 @@
     <Compile Include="Assist\ValueRetrievers\FloatValueRetriever.cs" />
     <Compile Include="Assist\ValueRetrievers\NullableUIntValueRetriever.cs" />
     <Compile Include="Assist\ValueRetrievers\ShortValueRetriever.cs" />
+    <Compile Include="Assist\ValueRetrievers\StringArrayValueRetriever.cs" />
     <Compile Include="Assist\ValueRetrievers\UIntValueRetriever.cs" />
     <Compile Include="Assist\ValueRetrievers\EnumValueRetriever.cs" />
     <Compile Include="Assist\ValueRetrievers\GuidValueRetriever.cs" />

--- a/TechTalk.SpecFlow/TechTalk.SpecFlow.csproj
+++ b/TechTalk.SpecFlow/TechTalk.SpecFlow.csproj
@@ -103,6 +103,7 @@
     <Compile Include="Assist\ValueRetrievers\FloatValueRetriever.cs" />
     <Compile Include="Assist\ValueRetrievers\NullableUIntValueRetriever.cs" />
     <Compile Include="Assist\ValueRetrievers\ShortValueRetriever.cs" />
+    <Compile Include="Assist\ValueRetrievers\StringListValueRetriever.cs" />
     <Compile Include="Assist\ValueRetrievers\StringArrayValueRetriever.cs" />
     <Compile Include="Assist\ValueRetrievers\UIntValueRetriever.cs" />
     <Compile Include="Assist\ValueRetrievers\EnumValueRetriever.cs" />

--- a/TechTalk.SpecFlow/TechTalk.SpecFlow.csproj
+++ b/TechTalk.SpecFlow/TechTalk.SpecFlow.csproj
@@ -103,6 +103,7 @@
     <Compile Include="Assist\ValueRetrievers\FloatValueRetriever.cs" />
     <Compile Include="Assist\ValueRetrievers\NullableUIntValueRetriever.cs" />
     <Compile Include="Assist\ValueRetrievers\ShortValueRetriever.cs" />
+    <Compile Include="Assist\ValueRetrievers\EnumArrayValueRetriever.cs" />
     <Compile Include="Assist\ValueRetrievers\StringListValueRetriever.cs" />
     <Compile Include="Assist\ValueRetrievers\StringArrayValueRetriever.cs" />
     <Compile Include="Assist\ValueRetrievers\UIntValueRetriever.cs" />

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/ExampleEntities/Enums.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/ExampleEntities/Enums.cs
@@ -10,4 +10,8 @@
         Butch, Male, Soft, VeryCool, Sweet
     }
 
+    public enum Language
+    {
+        English, Finnish, Swedish
+    }
 }

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/ExampleEntities/Person.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/ExampleEntities/Person.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using NUnit.Framework;
 
 namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.ExampleEntities
 {
@@ -35,6 +37,8 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.ExampleEntities
 
         public string WithUmlauteäöü { get; set; }
 
-        public string[] StringArray { get; set; } 
+        public string[] StringArray { get; set; }
+        public List<string> StringList { get; set; }
+
     }
 }

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/ExampleEntities/Person.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/ExampleEntities/Person.cs
@@ -40,5 +40,7 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.ExampleEntities
         public string[] StringArray { get; set; }
         public List<string> StringList { get; set; }
         public Language[] Languages { get; set; }
+        public List<Language> LanguageList { get; set; }
+
     }
 }

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/ExampleEntities/Person.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/ExampleEntities/Person.cs
@@ -34,5 +34,7 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.ExampleEntities
         public string With_Underscore { get; set; }
 
         public string WithUmlauteäöü { get; set; }
+
+        public string[] StringArray { get; set; } 
     }
 }

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/ExampleEntities/Person.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/ExampleEntities/Person.cs
@@ -39,6 +39,6 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.ExampleEntities
 
         public string[] StringArray { get; set; }
         public List<string> StringList { get; set; }
-
+        public Language[] Languages { get; set; }
     }
 }

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/ExampleEntities/Person.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/ExampleEntities/Person.cs
@@ -40,7 +40,7 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.ExampleEntities
         public string[] StringArray { get; set; }
         public List<string> StringList { get; set; }
         public Language[] Languages { get; set; }
-        public List<Language> LanguageList { get; set; }
+        public IList<Language> LanguageList { get; set; }
 
     }
 }

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/ServiceTests.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/ServiceTests.cs
@@ -34,7 +34,7 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests
             var service = new Service();
 
             var results = service.ValueRetrievers;
-            Assert.AreEqual(38, results.Count());
+            Assert.AreEqual(39, results.Count());
 
             Assert.AreEqual(1, results.Where(x => x.GetType() == typeof(StringValueRetriever)).Count());
             Assert.AreEqual(1, results.Where(x => x.GetType() == typeof(ByteValueRetriever)).Count());
@@ -75,6 +75,7 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests
 
             Assert.AreEqual(1, results.Where(x => x.GetType() == typeof(StringArrayValueRetriever)).Count());
             Assert.AreEqual(1, results.Where(x => x.GetType() == typeof(StringListValueRetriever)).Count());
+            Assert.AreEqual(1, results.Where(x => x.GetType() == typeof(EnumArrayValueRetriever)).Count());
         }
 
         [Test]

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/ServiceTests.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/ServiceTests.cs
@@ -34,7 +34,7 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests
             var service = new Service();
 
             var results = service.ValueRetrievers;
-            Assert.AreEqual(37, results.Count());
+            Assert.AreEqual(38, results.Count());
 
             Assert.AreEqual(1, results.Where(x => x.GetType() == typeof(StringValueRetriever)).Count());
             Assert.AreEqual(1, results.Where(x => x.GetType() == typeof(ByteValueRetriever)).Count());
@@ -72,8 +72,9 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests
             Assert.AreEqual(1, results.Where(x => x.GetType() == typeof(NullableLongValueRetriever)).Count());
             Assert.AreEqual(1, results.Where(x => x.GetType() == typeof(NullableTimeSpanValueRetriever)).Count());
             Assert.AreEqual(1, results.Where(x => x.GetType() == typeof(NullableDateTimeOffsetValueRetriever)).Count());
-            Assert.AreEqual(1, results.Where(x => x.GetType() == typeof(StringArrayValueRetriever)).Count());
 
+            Assert.AreEqual(1, results.Where(x => x.GetType() == typeof(StringArrayValueRetriever)).Count());
+            Assert.AreEqual(1, results.Where(x => x.GetType() == typeof(StringListValueRetriever)).Count());
         }
 
         [Test]

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/ServiceTests.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/ServiceTests.cs
@@ -34,7 +34,7 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests
             var service = new Service();
 
             var results = service.ValueRetrievers;
-            Assert.AreEqual(36, results.Count());
+            Assert.AreEqual(37, results.Count());
 
             Assert.AreEqual(1, results.Where(x => x.GetType() == typeof(StringValueRetriever)).Count());
             Assert.AreEqual(1, results.Where(x => x.GetType() == typeof(ByteValueRetriever)).Count());
@@ -72,6 +72,8 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests
             Assert.AreEqual(1, results.Where(x => x.GetType() == typeof(NullableLongValueRetriever)).Count());
             Assert.AreEqual(1, results.Where(x => x.GetType() == typeof(NullableTimeSpanValueRetriever)).Count());
             Assert.AreEqual(1, results.Where(x => x.GetType() == typeof(NullableDateTimeOffsetValueRetriever)).Count());
+            Assert.AreEqual(1, results.Where(x => x.GetType() == typeof(StringArrayValueRetriever)).Count());
+
         }
 
         [Test]

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/ServiceTests.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/ServiceTests.cs
@@ -34,7 +34,7 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests
             var service = new Service();
 
             var results = service.ValueRetrievers;
-            Assert.AreEqual(39, results.Count());
+            Assert.AreEqual(40, results.Count());
 
             Assert.AreEqual(1, results.Where(x => x.GetType() == typeof(StringValueRetriever)).Count());
             Assert.AreEqual(1, results.Where(x => x.GetType() == typeof(ByteValueRetriever)).Count());
@@ -76,6 +76,7 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests
             Assert.AreEqual(1, results.Where(x => x.GetType() == typeof(StringArrayValueRetriever)).Count());
             Assert.AreEqual(1, results.Where(x => x.GetType() == typeof(StringListValueRetriever)).Count());
             Assert.AreEqual(1, results.Where(x => x.GetType() == typeof(EnumArrayValueRetriever)).Count());
+            Assert.AreEqual(1, results.Where(x => x.GetType() == typeof(EnumListValueRetriever)).Count());
         }
 
         [Test]

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/TableHelperExtensionMethods/CreateInstanceHelperMethodTests_WithArrayOfEnums.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/TableHelperExtensionMethods/CreateInstanceHelperMethodTests_WithArrayOfEnums.cs
@@ -5,13 +5,8 @@ using TechTalk.SpecFlow.RuntimeTests.AssistTests.ExampleEntities;
 
 namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.TableHelperExtensionMethods
 {
-    class CreateInstanceHelperMethodTests_WithArrayOfEnums : CreateInstanceHelperMethodTestBase
+    class CreateInstanceHelperMethodTests_WithArrayOfEnums
     {
-        public CreateInstanceHelperMethodTests_WithArrayOfEnums()
-            : base(t => t.CreateInstance<Person>())
-        {
-        }
-
         [Test]
         public void Can_create_an_instance_with_enum_array_from_comma_separated_list_of_strings()
         {

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/TableHelperExtensionMethods/CreateInstanceHelperMethodTests_WithArrayOfEnums.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/TableHelperExtensionMethods/CreateInstanceHelperMethodTests_WithArrayOfEnums.cs
@@ -1,0 +1,28 @@
+﻿using FluentAssertions;
+using NUnit.Framework;
+using TechTalk.SpecFlow.Assist;
+using TechTalk.SpecFlow.RuntimeTests.AssistTests.ExampleEntities;
+
+namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.TableHelperExtensionMethods
+{
+    class CreateInstanceHelperMethodTests_WithArrayOfEnums : CreateInstanceHelperMethodTestBase
+    {
+        public CreateInstanceHelperMethodTests_WithArrayOfEnums()
+            : base(t => t.CreateInstance<Person>())
+        {
+        }
+
+        [Test]
+        public void Can_create_an_instance_with_enum_array_from_comma_separated_list_of_strings()
+        {
+            var table = new Table("Field", "Value");
+            table.AddRow("Languages", $"Finnish, English, Swedish");
+ 
+            var @class = table.CreateInstance<Person>();
+
+            @class.Languages[0].Should().Be(Language.Finnish);
+            @class.Languages[1].Should().Be(Language.English);
+            @class.Languages[2].Should().Be(Language.Swedish);
+        }
+    }
+}

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/TableHelperExtensionMethods/CreateInstanceHelperMethodTests_WithArrayOfValues.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/TableHelperExtensionMethods/CreateInstanceHelperMethodTests_WithArrayOfValues.cs
@@ -1,0 +1,30 @@
+﻿using FluentAssertions;
+using NUnit.Framework;
+using TechTalk.SpecFlow.Assist;
+using TechTalk.SpecFlow.RuntimeTests.AssistTests.ExampleEntities;
+
+namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.TableHelperExtensionMethods
+{
+    class CreateInstanceHelperMethodTests_WithArrayOfValues : CreateInstanceHelperMethodTestBase
+    {
+        public CreateInstanceHelperMethodTests_WithArrayOfValues()
+            : base(t => t.CreateInstance<Person>())
+        {
+        }
+
+        [Test]
+        public void Can_create_an_instance_with_string_array_from_comma_separated_list_of_strings()
+        {
+            const string first = "First string";
+            const string second = "Second string";
+
+            var table = new Table("Field", "Value");
+            table.AddRow("StringArray", $"{first}, {second}");
+ 
+            var @class = table.CreateInstance<Person>();
+
+            @class.StringArray[0].Should().Be(first);
+            @class.StringArray[1].Should().Be(second);
+        }
+    }
+}

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/TableHelperExtensionMethods/CreateInstanceHelperMethodTests_WithArrayOfValues.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/TableHelperExtensionMethods/CreateInstanceHelperMethodTests_WithArrayOfValues.cs
@@ -5,12 +5,8 @@ using TechTalk.SpecFlow.RuntimeTests.AssistTests.ExampleEntities;
 
 namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.TableHelperExtensionMethods
 {
-    class CreateInstanceHelperMethodTests_WithArrayOfValues : CreateInstanceHelperMethodTestBase
+    class CreateInstanceHelperMethodTests_WithArrayOfValues
     {
-        public CreateInstanceHelperMethodTests_WithArrayOfValues()
-            : base(t => t.CreateInstance<Person>())
-        {
-        }
 
         [Test]
         public void Can_create_an_instance_with_string_array_from_comma_separated_list_of_strings()

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/TableHelperExtensionMethods/CreateInstanceHelperMethodTests_WithListOfEnums.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/TableHelperExtensionMethods/CreateInstanceHelperMethodTests_WithListOfEnums.cs
@@ -1,0 +1,23 @@
+﻿using FluentAssertions;
+using NUnit.Framework;
+using TechTalk.SpecFlow.Assist;
+using TechTalk.SpecFlow.RuntimeTests.AssistTests.ExampleEntities;
+
+namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.TableHelperExtensionMethods
+{
+    class CreateInstanceHelperMethodTests_WithListOfEnums
+    {
+        [Test]
+        public void Can_create_an_instance_with_enum_list_from_comma_separated_list_of_strings()
+        {
+            var table = new Table("Field", "Value");
+            table.AddRow("LanguageList", $"Finnish, English, Swedish");
+ 
+            var @class = table.CreateInstance<Person>();
+
+            @class.LanguageList[0].Should().Be(Language.Finnish);
+            @class.LanguageList[1].Should().Be(Language.English);
+            @class.LanguageList[2].Should().Be(Language.Swedish);
+        }
+    }
+}

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/TableHelperExtensionMethods/CreateInstanceHelperMethodTests_WithListOfValues.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/TableHelperExtensionMethods/CreateInstanceHelperMethodTests_WithListOfValues.cs
@@ -5,13 +5,8 @@ using TechTalk.SpecFlow.RuntimeTests.AssistTests.ExampleEntities;
 
 namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.TableHelperExtensionMethods
 {
-    class CreateInstanceHelperMethodTests_WithListOfValues : CreateInstanceHelperMethodTestBase
+    class CreateInstanceHelperMethodTests_WithListOfValues
     {
-        public CreateInstanceHelperMethodTests_WithListOfValues()
-            : base(t => t.CreateInstance<Person>())
-        {
-        }
-
         [Test]
         public void Can_create_an_instance_with_list_of_strings_from_comma_separated_list_of_strings()
         {

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/TableHelperExtensionMethods/CreateInstanceHelperMethodTests_WithListOfValues.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/TableHelperExtensionMethods/CreateInstanceHelperMethodTests_WithListOfValues.cs
@@ -1,0 +1,30 @@
+﻿using FluentAssertions;
+using NUnit.Framework;
+using TechTalk.SpecFlow.Assist;
+using TechTalk.SpecFlow.RuntimeTests.AssistTests.ExampleEntities;
+
+namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.TableHelperExtensionMethods
+{
+    class CreateInstanceHelperMethodTests_WithListOfValues : CreateInstanceHelperMethodTestBase
+    {
+        public CreateInstanceHelperMethodTests_WithListOfValues()
+            : base(t => t.CreateInstance<Person>())
+        {
+        }
+
+        [Test]
+        public void Can_create_an_instance_with_list_of_strings_from_comma_separated_list_of_strings()
+        {
+            const string first = "First string";
+            const string second = "Second string";
+
+            var table = new Table("Field", "Value");
+            table.AddRow("StringList", $"{first}, {second}");
+ 
+            var @class = table.CreateInstance<Person>();
+
+            @class.StringList[0].Should().Be(first);
+            @class.StringList[1].Should().Be(second);
+        }
+    }
+}

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/ValueRetrieverTests/EnumArrayValueRetrieverTests.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/ValueRetrieverTests/EnumArrayValueRetrieverTests.cs
@@ -1,0 +1,52 @@
+﻿using System.Collections.Generic;
+using FluentAssertions;
+using NUnit.Framework;
+using TechTalk.SpecFlow.Assist.ValueRetrievers;
+
+namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.ValueRetrieverTests
+{
+    [TestFixture]
+    public class EnumArrayValueRetrieverTests
+    {
+
+        [Test]
+        public void Can_retrieve_when_property_is_array_of_enums()
+        {
+            var retriever = new EnumArrayValueRetriever();
+
+            var result = retriever.CanRetrieve(new KeyValuePair<string, string>(), typeof(TestEnum[]), typeof(TestEnum[]));
+
+            result.Should().BeTrue();
+        }
+
+        [Test]
+        public void Cannot_retrieve_when_property_is_array_of_ints()
+        {
+            var retriever = new EnumArrayValueRetriever();
+
+            var result = retriever.CanRetrieve(new KeyValuePair<string, string>(), typeof(int[]), typeof(int[]));
+
+            result.Should().BeFalse();
+
+        }
+
+        [Test]
+        public void Returns_array_of_enums_from_comma_separated_list()
+        {
+            var retriever = new EnumArrayValueRetriever();
+            var dictionary = new KeyValuePair<string, string>("key", "Bar, Foo, FooBar");
+           
+            var result = retriever.Retrieve(dictionary, typeof(TestEnum[]), typeof(TestEnum[])) as TestEnum[];
+
+            result[0].Should().Be(TestEnum.Bar);
+            result[1].Should().Be(TestEnum.Foo);
+            result[2].Should().Be(TestEnum.FooBar);
+        }
+
+    }
+
+    public enum TestEnum
+    {
+        Foo, Bar, FooBar
+    }
+}

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/ValueRetrieverTests/EnumListValueRetrieverTests.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/ValueRetrieverTests/EnumListValueRetrieverTests.cs
@@ -1,0 +1,67 @@
+﻿using System.Collections.Generic;
+using FluentAssertions;
+using NUnit.Framework;
+using TechTalk.SpecFlow.Assist.ValueRetrievers;
+
+namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.ValueRetrieverTests
+{
+    [TestFixture]
+    public class EnumListValueRetrieverTests
+    {
+
+        [Test]
+        public void Can_retrieve_when_property_is_list_of_enums()
+        {
+            var retriever = new EnumListValueRetriever();
+
+            var result = retriever.CanRetrieve(new KeyValuePair<string, string>(), typeof(List<TestEnum>), typeof(List<TestEnum>));
+
+            result.Should().BeTrue();
+        }
+
+        [Test]
+        public void Can_retrieve_when_property_is_ilist_of_enums()
+        {
+            var retriever = new EnumListValueRetriever();
+
+            var result = retriever.CanRetrieve(new KeyValuePair<string, string>(), typeof(IList<TestEnum>), typeof(IList<TestEnum>));
+
+            result.Should().BeTrue();
+        }
+
+        [Test]
+        public void Cannot_retrieve_when_property_is_List_of_ints()
+        {
+            var retriever = new EnumListValueRetriever();
+
+            var result = retriever.CanRetrieve(new KeyValuePair<string, string>(), typeof(List<int>), typeof(List<int>));
+
+            result.Should().BeFalse();
+        }
+
+        [Test]
+        public void Cannot_retrieve_when_property_is_List_of_strings()
+        {
+            var retriever = new EnumListValueRetriever();
+
+            var result = retriever.CanRetrieve(new KeyValuePair<string, string>(), typeof(List<string>), typeof(List<string>));
+
+            result.Should().BeFalse();
+        }
+
+        [Test]
+        public void Returns_list_of_enums_from_comma_separated_list()
+        {
+            var retriever = new EnumListValueRetriever();
+            var dictionary = new KeyValuePair<string, string>("key", "Bar, Foo, FooBar");
+           
+            var result = retriever.Retrieve(dictionary, typeof(List<TestEnum>), typeof(List<TestEnum>)) as List<TestEnum>;
+
+            result[0].Should().Be(TestEnum.Bar);
+            result[1].Should().Be(TestEnum.Foo);
+            result[2].Should().Be(TestEnum.FooBar);
+        }
+
+    }
+
+}

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/ValueRetrieverTests/StringArrayValueRetrieverTests.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/ValueRetrieverTests/StringArrayValueRetrieverTests.cs
@@ -1,4 +1,5 @@
-﻿using FluentAssertions;
+﻿using System.Collections.Generic;
+using FluentAssertions;
 using NUnit.Framework;
 using TechTalk.SpecFlow.Assist.ValueRetrievers;
 
@@ -7,6 +8,24 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.ValueRetrieverTests
     [TestFixture]
     public class StringArrayValueRetrieverTests
     {
+        [Test]
+        public void Can_retrieve_string_array_properties()
+        {
+            var retriever = new StringArrayValueRetriever();
+
+            retriever.CanRetrieve(new KeyValuePair<string, string>(), null, typeof(string[])).Should().BeTrue();
+        }
+
+        [Test]
+        public void Cannot_retrieve_other_properties()
+        {
+            var retriever = new StringArrayValueRetriever();
+
+            retriever.CanRetrieve(new KeyValuePair<string, string>(), null, typeof(int[])).Should().BeFalse();
+            retriever.CanRetrieve(new KeyValuePair<string, string>(), null, typeof(List<string>)).Should().BeFalse();
+            retriever.CanRetrieve(new KeyValuePair<string, string>(), null, typeof(string)).Should().BeFalse();
+        }
+
         [Test]
         public void Returns_array_from_comma_separated_list()
         {

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/ValueRetrieverTests/StringArrayValueRetrieverTests.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/ValueRetrieverTests/StringArrayValueRetrieverTests.cs
@@ -1,0 +1,34 @@
+﻿using FluentAssertions;
+using NUnit.Framework;
+using TechTalk.SpecFlow.Assist.ValueRetrievers;
+
+namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.ValueRetrieverTests
+{
+    [TestFixture]
+    public class StringArrayValueRetrieverTests
+    {
+        [Test]
+        public void Returns_array_from_comma_separated_list()
+        {
+            var retriever = new StringArrayValueRetriever();
+
+            var result = retriever.GetValue("A,B,C");
+
+            result[0].Should().Be("A");
+            result[1].Should().Be("B");
+            result[2].Should().Be("C");
+        }
+
+        [Test]
+        public void Trims_the_individual_values()
+        {
+            var retriever = new StringArrayValueRetriever();
+
+            var result = retriever.GetValue("A , B, C ");
+
+            result[0].Should().Be("A");
+            result[1].Should().Be("B");
+            result[2].Should().Be("C");
+        }
+    }
+}

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/ValueRetrieverTests/StringListValueRetrieverTests.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/ValueRetrieverTests/StringListValueRetrieverTests.cs
@@ -1,4 +1,5 @@
-﻿using FluentAssertions;
+﻿using System.Collections.Generic;
+using FluentAssertions;
 using NUnit.Framework;
 using TechTalk.SpecFlow.Assist.ValueRetrievers;
 
@@ -7,6 +8,32 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.ValueRetrieverTests
     [TestFixture]
     public class StringListValueRetrieverTests
     {
+        [Test]
+        public void Can_retrieve_string_list_properties()
+        {
+            var retriever = new StringListValueRetriever();
+            
+            retriever.CanRetrieve(new KeyValuePair<string, string>(), null, typeof(List<string>)).Should().BeTrue();
+        }
+
+        [Test]
+        public void Can_retrieve_string_ilist_properties()
+        {
+            var retriever = new StringListValueRetriever();
+
+            retriever.CanRetrieve(new KeyValuePair<string, string>(), null, typeof(IList<string>)).Should().BeTrue();
+        }
+
+        [Test]
+        public void Cannot_retrieve_other_properties()
+        {
+            var retriever = new StringListValueRetriever();
+
+            retriever.CanRetrieve(new KeyValuePair<string, string>(), null, typeof(string[])).Should().BeFalse();
+            retriever.CanRetrieve(new KeyValuePair<string, string>(), null, typeof(List<int>)).Should().BeFalse();
+            retriever.CanRetrieve(new KeyValuePair<string, string>(), null, typeof(string)).Should().BeFalse();
+        }
+
         [Test]
         public void Returns_lsit_from_comma_separated_list()
         {

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/ValueRetrieverTests/StringListValueRetrieverTests.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/ValueRetrieverTests/StringListValueRetrieverTests.cs
@@ -1,0 +1,34 @@
+﻿using FluentAssertions;
+using NUnit.Framework;
+using TechTalk.SpecFlow.Assist.ValueRetrievers;
+
+namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.ValueRetrieverTests
+{
+    [TestFixture]
+    public class StringListValueRetrieverTests
+    {
+        [Test]
+        public void Returns_lsit_from_comma_separated_list()
+        {
+            var retriever = new StringListValueRetriever();
+
+            var result = retriever.GetValue("A,B,C");
+
+            result[0].Should().Be("A");
+            result[1].Should().Be("B");
+            result[2].Should().Be("C");
+        }
+
+        [Test]
+        public void Trims_the_individual_values()
+        {
+            var retriever = new StringArrayValueRetriever();
+
+            var result = retriever.GetValue("A , B, C ");
+
+            result[0].Should().Be("A");
+            result[1].Should().Be("B");
+            result[2].Should().Be("C");
+        }
+    }
+}

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/RuntimeTests.csproj
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/RuntimeTests.csproj
@@ -95,6 +95,7 @@
     <Compile Include="AssistTests\SituationalTests\NullableEnumTests.cs" />
     <Compile Include="AssistTests\TableDiffExceptionBuilderTests.cs" />
     <Compile Include="AssistTests\TableHelperExtensionMethods\CreateInstanceHelperMethodTestBase.cs" />
+    <Compile Include="AssistTests\TableHelperExtensionMethods\CreateInstanceHelperMethodTests_WithListOfValues.cs" />
     <Compile Include="AssistTests\TableHelperExtensionMethods\CreateInstanceHelperMethodTests_WithArrayOfValues.cs" />
     <Compile Include="AssistTests\TableHelperExtensionMethods\CreateInstanceHelperMethodTests_WithFunc.cs" />
     <Compile Include="AssistTests\TableHelperExtensionMethods\CreateInstanceHelperStandardTypesTests.cs" />
@@ -141,6 +142,7 @@
     <Compile Include="AssistTests\ValueRetrieverTests\NullableUShortValueRetrieverTests.cs" />
     <Compile Include="AssistTests\ValueRetrieverTests\SByteValueRetrieverTests.cs" />
     <Compile Include="AssistTests\ValueRetrieverTests\ShortValueRetrieverTests.cs" />
+    <Compile Include="AssistTests\ValueRetrieverTests\StringListValueRetrieverTests.cs" />
     <Compile Include="AssistTests\ValueRetrieverTests\StringArrayValueRetrieverTests.cs" />
     <Compile Include="AssistTests\ValueRetrieverTests\UIntValueRetrieverTests.cs" />
     <Compile Include="AssistTests\ValueRetrieverTests\EnumValueRetrieverTests.cs" />

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/RuntimeTests.csproj
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/RuntimeTests.csproj
@@ -95,6 +95,7 @@
     <Compile Include="AssistTests\SituationalTests\NullableEnumTests.cs" />
     <Compile Include="AssistTests\TableDiffExceptionBuilderTests.cs" />
     <Compile Include="AssistTests\TableHelperExtensionMethods\CreateInstanceHelperMethodTestBase.cs" />
+    <Compile Include="AssistTests\TableHelperExtensionMethods\CreateInstanceHelperMethodTests_WithListOfEnums.cs" />
     <Compile Include="AssistTests\TableHelperExtensionMethods\CreateInstanceHelperMethodTests_WithArrayOfEnums.cs" />
     <Compile Include="AssistTests\TableHelperExtensionMethods\CreateInstanceHelperMethodTests_WithListOfValues.cs" />
     <Compile Include="AssistTests\TableHelperExtensionMethods\CreateInstanceHelperMethodTests_WithArrayOfValues.cs" />
@@ -129,6 +130,7 @@
     <Compile Include="AssistTests\ValueRetrieverTests\ByteValueRetrieverTests.cs" />
     <Compile Include="AssistTests\ValueRetrieverTests\CharValueRetrieverTests.cs" />
     <Compile Include="AssistTests\ValueRetrieverTests\DateTimeOffsetValueRetrieverTests.cs" />
+    <Compile Include="AssistTests\ValueRetrieverTests\EnumListValueRetrieverTests.cs" />
     <Compile Include="AssistTests\ValueRetrieverTests\GuidValueRetriever_IsAValidGuidTests.cs" />
     <Compile Include="AssistTests\ValueRetrieverTests\LongValueRetrieverTests.cs" />
     <Compile Include="AssistTests\ValueRetrieverTests\NullableByteValueRetrieverTests.cs" />

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/RuntimeTests.csproj
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/RuntimeTests.csproj
@@ -95,6 +95,7 @@
     <Compile Include="AssistTests\SituationalTests\NullableEnumTests.cs" />
     <Compile Include="AssistTests\TableDiffExceptionBuilderTests.cs" />
     <Compile Include="AssistTests\TableHelperExtensionMethods\CreateInstanceHelperMethodTestBase.cs" />
+    <Compile Include="AssistTests\TableHelperExtensionMethods\CreateInstanceHelperMethodTests_WithArrayOfEnums.cs" />
     <Compile Include="AssistTests\TableHelperExtensionMethods\CreateInstanceHelperMethodTests_WithListOfValues.cs" />
     <Compile Include="AssistTests\TableHelperExtensionMethods\CreateInstanceHelperMethodTests_WithArrayOfValues.cs" />
     <Compile Include="AssistTests\TableHelperExtensionMethods\CreateInstanceHelperMethodTests_WithFunc.cs" />
@@ -142,6 +143,7 @@
     <Compile Include="AssistTests\ValueRetrieverTests\NullableUShortValueRetrieverTests.cs" />
     <Compile Include="AssistTests\ValueRetrieverTests\SByteValueRetrieverTests.cs" />
     <Compile Include="AssistTests\ValueRetrieverTests\ShortValueRetrieverTests.cs" />
+    <Compile Include="AssistTests\ValueRetrieverTests\EnumArrayValueRetrieverTests.cs" />
     <Compile Include="AssistTests\ValueRetrieverTests\StringListValueRetrieverTests.cs" />
     <Compile Include="AssistTests\ValueRetrieverTests\StringArrayValueRetrieverTests.cs" />
     <Compile Include="AssistTests\ValueRetrieverTests\UIntValueRetrieverTests.cs" />

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/RuntimeTests.csproj
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/RuntimeTests.csproj
@@ -95,6 +95,7 @@
     <Compile Include="AssistTests\SituationalTests\NullableEnumTests.cs" />
     <Compile Include="AssistTests\TableDiffExceptionBuilderTests.cs" />
     <Compile Include="AssistTests\TableHelperExtensionMethods\CreateInstanceHelperMethodTestBase.cs" />
+    <Compile Include="AssistTests\TableHelperExtensionMethods\CreateInstanceHelperMethodTests_WithArrayOfValues.cs" />
     <Compile Include="AssistTests\TableHelperExtensionMethods\CreateInstanceHelperMethodTests_WithFunc.cs" />
     <Compile Include="AssistTests\TableHelperExtensionMethods\CreateInstanceHelperStandardTypesTests.cs" />
     <Compile Include="AssistTests\TableHelperExtensionMethods\CreateSetHelperMethodTests_WithFunc.cs" />
@@ -140,6 +141,7 @@
     <Compile Include="AssistTests\ValueRetrieverTests\NullableUShortValueRetrieverTests.cs" />
     <Compile Include="AssistTests\ValueRetrieverTests\SByteValueRetrieverTests.cs" />
     <Compile Include="AssistTests\ValueRetrieverTests\ShortValueRetrieverTests.cs" />
+    <Compile Include="AssistTests\ValueRetrieverTests\StringArrayValueRetrieverTests.cs" />
     <Compile Include="AssistTests\ValueRetrieverTests\UIntValueRetrieverTests.cs" />
     <Compile Include="AssistTests\ValueRetrieverTests\EnumValueRetrieverTests.cs" />
     <Compile Include="AssistTests\ValueRetrieverTests\GuidValueRetriever_GetValueTests.cs" />


### PR DESCRIPTION
Idea behind this PR:

```
Given the following specflow table definition: 
	| Field   | Value            |
	| MyArray | Val1, Val2, Val3 |
  And class MyClass containing string[] MyArray property  
 When I use the CreateInstance<MyClass> extension for the specflow table
 Then I should have instance of MyClass having MyArray property having following items:
	| index | item |
	| 0     | Val1 |
	| 1     | Val2 |
	| 2     | Val3 |
```
And same would apply to `List<string>`, `IList<string>` and enum arrays & lists.