### PR TITLE
Add support for commas and currency symbols in table columns 

### DIFF
--- a/TechTalk.SpecFlow/Assist/ValueRetrievers/ByteValueRetriever.cs
+++ b/TechTalk.SpecFlow/Assist/ValueRetrievers/ByteValueRetriever.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 
 namespace TechTalk.SpecFlow.Assist.ValueRetrievers
 {
@@ -7,9 +8,8 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
     {
         public virtual byte GetValue(string value)
         {
-            byte returnValue;
-            byte.TryParse(value, out returnValue);
-            return returnValue;
+            byte.TryParse(value, NumberStyles.Any, CultureInfo.CurrentCulture, out byte returnValue);
+			return returnValue;
         }
 
         public object Retrieve(KeyValuePair<string, string> keyValuePair, Type targetType, Type propertyType)

--- a/TechTalk.SpecFlow/Assist/ValueRetrievers/DateTimeOffsetValueRetriever.cs
+++ b/TechTalk.SpecFlow/Assist/ValueRetrievers/DateTimeOffsetValueRetriever.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 
 namespace TechTalk.SpecFlow.Assist.ValueRetrievers
 {
@@ -7,9 +8,8 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
     {
         public virtual DateTimeOffset GetValue(string value)
         {
-            var returnValue = DateTimeOffset.MinValue;
-            DateTimeOffset.TryParse(value, out returnValue);
-            return returnValue;
+            DateTimeOffset.TryParse(value, CultureInfo.CurrentCulture,DateTimeStyles.None, out DateTimeOffset returnValue);
+			return returnValue;
         }
 
         public object Retrieve(KeyValuePair<string, string> keyValuePair, Type targetType, Type propertyType)

--- a/TechTalk.SpecFlow/Assist/ValueRetrievers/DateTimeValueRetriever.cs
+++ b/TechTalk.SpecFlow/Assist/ValueRetrievers/DateTimeValueRetriever.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 
 namespace TechTalk.SpecFlow.Assist.ValueRetrievers
 {
@@ -7,9 +8,8 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
     {
         public virtual DateTime GetValue(string value)
         {
-            var returnValue = DateTime.MinValue;
-            DateTime.TryParse(value, out returnValue);
-            return returnValue;
+			DateTime.TryParse(value, CultureInfo.CurrentCulture, DateTimeStyles.None, out DateTime returnValue);
+			return returnValue;
         }
 
         public object Retrieve(KeyValuePair<string, string> keyValuePair, Type targetType, Type propertyType)

--- a/TechTalk.SpecFlow/Assist/ValueRetrievers/DecimalValueRetriever.cs
+++ b/TechTalk.SpecFlow/Assist/ValueRetrievers/DecimalValueRetriever.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 
 namespace TechTalk.SpecFlow.Assist.ValueRetrievers
 {
@@ -7,9 +8,8 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
     {
         public virtual decimal GetValue(string value)
         {
-            var returnValue = 0M;
-            Decimal.TryParse(value, out returnValue);
-            return returnValue;
+	        Decimal.TryParse(value, NumberStyles.Any, CultureInfo.CurrentCulture, out Decimal returnValue);
+			return returnValue;
         }
 
         public object Retrieve(KeyValuePair<string, string> keyValuePair, Type targetType, Type propertyType)

--- a/TechTalk.SpecFlow/Assist/ValueRetrievers/DoubleValueRetriever.cs
+++ b/TechTalk.SpecFlow/Assist/ValueRetrievers/DoubleValueRetriever.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 
 namespace TechTalk.SpecFlow.Assist.ValueRetrievers
 {
@@ -7,8 +8,7 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
     {
         public virtual double GetValue(string value)
         {
-            double returnValue = 0;
-            Double.TryParse(value, out returnValue);
+	        Double.TryParse(value, NumberStyles.Any, CultureInfo.CurrentCulture, out double returnValue);
             return returnValue;
         }
 

--- a/TechTalk.SpecFlow/Assist/ValueRetrievers/FloatValueRetriever.cs
+++ b/TechTalk.SpecFlow/Assist/ValueRetrievers/FloatValueRetriever.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 
 namespace TechTalk.SpecFlow.Assist.ValueRetrievers
 {
@@ -7,8 +8,7 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
     {
         public virtual float GetValue(string value)
         {
-            float returnValue = 0F;
-            float.TryParse(value, out returnValue);
+	        float.TryParse(value, NumberStyles.Any, CultureInfo.CurrentCulture, out float returnValue);
             return returnValue;
         }
 

--- a/TechTalk.SpecFlow/Assist/ValueRetrievers/IntValueRetriever.cs
+++ b/TechTalk.SpecFlow/Assist/ValueRetrievers/IntValueRetriever.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 
 namespace TechTalk.SpecFlow.Assist.ValueRetrievers
 {
@@ -7,9 +8,8 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
     {
         public virtual int GetValue(string value)
         {
-            int returnValue;
-            int.TryParse(value, out returnValue);
-            return returnValue;
+			int.TryParse(value, NumberStyles.Any, CultureInfo.CurrentCulture, out int returnValue);
+			return returnValue;
         }
 
         public object Retrieve(KeyValuePair<string, string> keyValuePair, Type targetType, Type propertyType)

--- a/TechTalk.SpecFlow/Assist/ValueRetrievers/LongValueRetriever.cs
+++ b/TechTalk.SpecFlow/Assist/ValueRetrievers/LongValueRetriever.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 
 namespace TechTalk.SpecFlow.Assist.ValueRetrievers
 {
@@ -7,9 +8,8 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
     {
         public virtual long GetValue(string value)
         {
-            long returnValue;
-            long.TryParse(value, out returnValue);
-            return returnValue;
+			long.TryParse(value, NumberStyles.Any, CultureInfo.CurrentCulture, out long returnValue);
+			return returnValue;
         }
             
         public object Retrieve(KeyValuePair<string, string> keyValuePair, Type targetType, Type propertyType)

--- a/TechTalk.SpecFlow/Assist/ValueRetrievers/SByteValueRetriever.cs
+++ b/TechTalk.SpecFlow/Assist/ValueRetrievers/SByteValueRetriever.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 
 namespace TechTalk.SpecFlow.Assist.ValueRetrievers
 {
@@ -7,9 +8,8 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
     {
         public virtual sbyte GetValue(string value)
         {
-            sbyte returnValue;
-            sbyte.TryParse(value, out returnValue);
-            return returnValue;
+	        sbyte.TryParse(value, NumberStyles.Any, CultureInfo.CurrentCulture, out sbyte returnValue);
+	        return returnValue;
         }
 
         public object Retrieve(KeyValuePair<string, string> keyValuePair, Type targetType, Type propertyType)

--- a/TechTalk.SpecFlow/Assist/ValueRetrievers/ShortValueRetriever.cs
+++ b/TechTalk.SpecFlow/Assist/ValueRetrievers/ShortValueRetriever.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 
 namespace TechTalk.SpecFlow.Assist.ValueRetrievers
 {
@@ -7,10 +8,9 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
     {
         public virtual short GetValue(string value)
         {
-            short returnValue;
-            short.TryParse(value, out returnValue);
-            return returnValue;
-        }
+			short.TryParse(value, NumberStyles.Any, CultureInfo.CurrentCulture, out short returnValue);
+	        return returnValue;
+		}
 
         public object Retrieve(KeyValuePair<string, string> keyValuePair, Type targetType, Type propertyType)
         {

--- a/TechTalk.SpecFlow/Assist/ValueRetrievers/TimeSpanValueRetriever.cs
+++ b/TechTalk.SpecFlow/Assist/ValueRetrievers/TimeSpanValueRetriever.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 
 namespace TechTalk.SpecFlow.Assist.ValueRetrievers
 {
@@ -7,7 +8,7 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
     {
         public virtual TimeSpan GetValue(string value)
         {
-            return TimeSpan.Parse(value);
+            return TimeSpan.Parse(value, CultureInfo.CurrentCulture);
         }
 
         public object Retrieve(KeyValuePair<string, string> keyValuePair, Type targetType, Type propertyType)

--- a/TechTalk.SpecFlow/Assist/ValueRetrievers/UIntValueRetriever.cs
+++ b/TechTalk.SpecFlow/Assist/ValueRetrievers/UIntValueRetriever.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 
 namespace TechTalk.SpecFlow.Assist.ValueRetrievers
 {
@@ -7,9 +8,8 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
     {
         public virtual uint GetValue(string value)
         {
-            uint returnValue;
-            uint.TryParse(value, out returnValue);
-            return returnValue;
+	        uint.TryParse(value, NumberStyles.Any, CultureInfo.CurrentCulture, out uint returnValue);
+			return returnValue;
         }
 
         public object Retrieve(KeyValuePair<string, string> keyValuePair, Type targetType, Type propertyType)

--- a/TechTalk.SpecFlow/Assist/ValueRetrievers/ULongValueRetriever.cs
+++ b/TechTalk.SpecFlow/Assist/ValueRetrievers/ULongValueRetriever.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 
 namespace TechTalk.SpecFlow.Assist.ValueRetrievers
 {
@@ -7,9 +8,8 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
     {
         public virtual ulong GetValue(string value)
         {
-            ulong returnValue;
-            ulong.TryParse(value, out returnValue);
-            return returnValue;
+	        ulong.TryParse(value, NumberStyles.Any, CultureInfo.CurrentCulture, out ulong returnValue);
+			return returnValue;
         }
 
         public object Retrieve(KeyValuePair<string, string> keyValuePair, Type targetType, Type propertyType)

--- a/TechTalk.SpecFlow/Assist/ValueRetrievers/UShortValueRetriever.cs
+++ b/TechTalk.SpecFlow/Assist/ValueRetrievers/UShortValueRetriever.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 
 namespace TechTalk.SpecFlow.Assist.ValueRetrievers
 {
@@ -7,9 +8,8 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
     {
         public virtual ushort GetValue(string value)
         {
-            ushort returnValue;
-            ushort.TryParse(value, out returnValue);
-            return returnValue;
+	        ushort.TryParse(value, NumberStyles.Any, CultureInfo.CurrentCulture, out ushort returnValue);
+			return returnValue;
         }
 
         public object Retrieve(KeyValuePair<string, string> keyValuePair, Type targetType, Type propertyType)

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/CreateInstanceHelperMethodTests.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/CreateInstanceHelperMethodTests.cs
@@ -169,7 +169,7 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests
             person.NullableDecimal.Should().Be(19.78M);
         }
 
-        [Test]
+		[Test]
         public void Sets_bool_values()
         {
             var table = new Table("Field", "Value");

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/ExampleEntities/Person.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/ExampleEntities/Person.cs
@@ -21,7 +21,13 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.ExampleEntities
         public decimal? NullableDecimal { get; set; }
         public int? NullableInt { get; set; }
 
-	    public long Long { get; set; }
+	    public short Short { get; set; }
+	    public short? NullableShort { get; set; }
+
+	    public ushort UShort { get; set; }
+	    public ushort? NullableUShort { get; set; }
+
+		public long Long { get; set; }
 	    public long? NullableLong { get; set; }
 
 	    public ulong ULong { get; set; }
@@ -37,6 +43,7 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.ExampleEntities
 	    public byte? NullableByte { get; set; }
 
 	    public sbyte SByte { get; set; }
+	    public sbyte? NullableSByte { get; set; }
 
 		public float Float { get; set; }
         public float? NullableFloat { get; set; }

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/ExampleEntities/Person.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/ExampleEntities/Person.cs
@@ -27,7 +27,10 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.ExampleEntities
         public Guid GuidId { get; set; }
         public Guid? NullableGuidId { get; set; }
 
-        public float Float { get; set; }
+	    public byte Byte { get; set; }
+	    public byte? NullableByte { get; set; }
+
+		public float Float { get; set; }
         public float? NullableFloat { get; set; }
         public uint UnsignedInt { get; set; }
         public uint? NullableUnsignedInt { get; set; }

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/ExampleEntities/Person.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/ExampleEntities/Person.cs
@@ -34,7 +34,6 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.ExampleEntities
 	    public byte? NullableByte { get; set; }
 
 	    public sbyte SByte { get; set; }
-	    public sbyte? NullableSByte { get; set; }
 
 		public float Float { get; set; }
         public float? NullableFloat { get; set; }

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/ExampleEntities/Person.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/ExampleEntities/Person.cs
@@ -21,7 +21,10 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.ExampleEntities
         public decimal? NullableDecimal { get; set; }
         public int? NullableInt { get; set; }
 
-        public double Double { get; set; }
+	    public long Long { get; set; }
+	    public long? NullableLong { get; set; }
+
+		public double Double { get; set; }
         public double? NullableDouble { get; set; }
 
         public Guid GuidId { get; set; }

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/ExampleEntities/Person.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/ExampleEntities/Person.cs
@@ -24,6 +24,9 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.ExampleEntities
 	    public long Long { get; set; }
 	    public long? NullableLong { get; set; }
 
+	    public ulong ULong { get; set; }
+	    public ulong? NullableULong { get; set; }
+
 		public double Double { get; set; }
         public double? NullableDouble { get; set; }
 

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/ExampleEntities/Person.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/ExampleEntities/Person.cs
@@ -33,6 +33,9 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.ExampleEntities
 	    public byte Byte { get; set; }
 	    public byte? NullableByte { get; set; }
 
+	    public sbyte SByte { get; set; }
+	    public sbyte? NullableSByte { get; set; }
+
 		public float Float { get; set; }
         public float? NullableFloat { get; set; }
         public uint UnsignedInt { get; set; }

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/TableHelperExtensionMethods/CreateSetHelperMethodTests.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/TableHelperExtensionMethods/CreateSetHelperMethodTests.cs
@@ -9,15 +9,9 @@ using TechTalk.SpecFlow.RuntimeTests.AssistTests.ExampleEntities;
 
 namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.TableHelperExtensionMethods
 {
-    [TestFixture]
+    [TestFixture, SetCulture("en-US")]
     public class CreateSetHelperMethodTests
     {
-        [SetUp]
-        public void SetUp()
-        {
-            Thread.CurrentThread.CurrentCulture = new CultureInfo("en-US");
-        }
-
         private static Table CreatePersonTableHeaders()
         {
             return new Table("FirstName", "LastName", "BirthDate", "NumberOfIdeas", "Salary", "IsRational");
@@ -178,7 +172,19 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.TableHelperExtensionMethods
             people.First().NullableDouble.Should().Be(7.28);
         }
 
-        [Test]
+	    [Test, SetCulture("fr-FR")]
+	    public void Sets_doubles_on_the_instance_when_type_is_double_and_culture_is_fr_FR()
+	    {
+		    var table = new Table("Double", "NullableDouble");
+		    table.AddRow("4,193", "7,28");
+
+		    var people = table.CreateSet<Person>();
+
+		    people.First().Double.Should().Be(4.193);
+		    people.First().NullableDouble.Should().Be(7.28);
+	    }
+
+		[Test]
         public void Sets_floats_on_the_instance_when_type_is_float()
         {
             var table = new Table("Float", "NullableFloat");

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/TableHelperExtensionMethods/CreateSetHelperMethodTests.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/TableHelperExtensionMethods/CreateSetHelperMethodTests.cs
@@ -104,11 +104,11 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.TableHelperExtensionMethods
         public void Sets_int_values_on_the_instance_when_type_is_int()
         {
             var table = CreatePersonTableHeaders();
-            table.AddRow("", "", "", "3", "", "");
+            table.AddRow("", "", "", "3,124", "", "");
 
             var people = table.CreateSet<Person>();
 
-            people.First().NumberOfIdeas.Should().Be(3);
+            people.First().NumberOfIdeas.Should().Be(3124);
         }
 
 

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/TableHelperExtensionMethods/CreateSetHelperMethodTests.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/TableHelperExtensionMethods/CreateSetHelperMethodTests.cs
@@ -135,10 +135,21 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.TableHelperExtensionMethods
             var people = table.CreateSet<Person>();
 
             people.First().BirthDate.Should().Be(new DateTime(2009, 4, 28));
-        }
+		}
 
-        
-        [Test]
+	    [Test, SetCulture("fr-FR")]
+	    public void Sets_datetime_on_the_instance_when_type_is_datetime_and_culture_is_fr_FR()
+	    {
+		    var table = CreatePersonTableHeaders();
+		    table.AddRow("", "", "28/4/2009", "3", "", "");
+
+		    var people = table.CreateSet<Person>();
+
+		    people.First().BirthDate.Should().Be(new DateTime(2009, 4, 28));
+	    }
+
+
+		[Test]
         public void Sets_decimal_on_the_instance_when_type_is_decimal()
         {
             var table = CreatePersonTableHeaders();

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/TableHelperExtensionMethods/CreateSetHelperMethodTests.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/TableHelperExtensionMethods/CreateSetHelperMethodTests.cs
@@ -253,6 +253,28 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.TableHelperExtensionMethods
 		    people.First().NullableByte.Should().Be(7);
 	    }
 
+	    [Test]
+	    public void Sets_sbytes_on_the_instance_when_type_is_sbyte()
+	    {
+		    var table = new Table("SByte");
+		    table.AddRow("4.0");
+
+		    var people = table.CreateSet<Person>();
+
+		    people.First().SByte.Should().Be(4);
+	    }
+
+	    [Test, SetCulture("fr-FR")]
+	    public void Sets_sbytes_on_the_instance_when_type_is_sbyte_and_culture_is_fr_FR()
+	    {
+		    var table = new Table("SByte");
+		    table.AddRow("4.0");
+
+			var people = table.CreateSet<Person>();
+
+		    people.First().SByte.Should().Be(4);
+	    }
+
 		[Test]
         public void Sets_floats_on_the_instance_when_type_is_float()
         {

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/TableHelperExtensionMethods/CreateSetHelperMethodTests.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/TableHelperExtensionMethods/CreateSetHelperMethodTests.cs
@@ -171,7 +171,31 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.TableHelperExtensionMethods
             people.First().IsRational.Should().BeTrue();
         }
 
-        [Test]
+	    [Test]
+	    public void Sets_decimals_on_the_instance_when_type_is_decimal()
+	    {
+			var table = new Table("Salary", "NullableDecimal");
+		    table.AddRow("4.193", "7.28");
+
+			var people = table.CreateSet<Person>();
+
+		    people.First().Salary.Should().Be(4.193M);
+		    people.First().NullableDecimal.Should().Be(7.28M);
+	    }
+
+	    [Test, SetCulture("fr-FR")]
+	    public void Sets_decimals_on_the_instance_when_type_is_decimal_and_culture_is_fr_FR()
+	    {
+			var table = new Table("Salary", "NullableDecimal");
+		    table.AddRow("4,193", "7,28");
+
+		    var people = table.CreateSet<Person>();
+
+		    people.First().Salary.Should().Be(4.193M);
+		    people.First().NullableDecimal.Should().Be(7.28M);
+		}
+
+		[Test]
         public void Sets_doubles_on_the_instance_when_type_is_double()
         {
             var table = new Table("Double", "NullableDouble");

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/TableHelperExtensionMethods/CreateSetHelperMethodTests.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/TableHelperExtensionMethods/CreateSetHelperMethodTests.cs
@@ -184,6 +184,30 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.TableHelperExtensionMethods
 		    people.First().NullableDouble.Should().Be(7.28);
 	    }
 
+	    [Test]
+	    public void Sets_bytes_on_the_instance_when_type_is_byte()
+	    {
+		    var table = new Table("Byte", "NullableByte");
+		    table.AddRow("4.0", "7.0");
+
+		    var people = table.CreateSet<Person>();
+
+		    people.First().Byte.Should().Be(4);
+		    people.First().NullableByte.Should().Be(7);
+	    }
+
+		[Test, SetCulture("fr-FR")]
+	    public void Sets_bytes_on_the_instance_when_type_is_byte_and_culture_is_fr_FR()
+	    {
+		    var table = new Table("Byte", "NullableByte");
+		    table.AddRow("4,000", "7,000");
+
+		    var people = table.CreateSet<Person>();
+
+		    people.First().Byte.Should().Be(4);
+		    people.First().NullableByte.Should().Be(7);
+	    }
+
 		[Test]
         public void Sets_floats_on_the_instance_when_type_is_float()
         {

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/TableHelperExtensionMethods/CreateSetHelperMethodTests.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/TableHelperExtensionMethods/CreateSetHelperMethodTests.cs
@@ -193,7 +193,7 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.TableHelperExtensionMethods
 		    people.First().NullableDecimal.Should().Be(7.28M);
 		}
 
-	    [Test]
+		[Test]
 	    public void Sets_longs_on_the_instance_when_type_is_long()
 	    {
 		    var table = new Table("Long", "NullableLong");
@@ -315,12 +315,12 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.TableHelperExtensionMethods
         public void Sets_uints_on_the_instance_when_the_type_is_uint()
         {
             var table = new Table("UnsignedInt", "NullableUnsignedInt");
-            table.AddRow("1", "2");
+            table.AddRow("1,234", "2452");
 
             var people = table.CreateSet<Person>();
 
-            people.First().UnsignedInt.Should().Be(1);
-            people.First().NullableUnsignedInt.Should().Be((uint?)2);
+            people.First().UnsignedInt.Should().Be(1234);
+            people.First().NullableUnsignedInt.Should().Be((uint?)2452);
         }
 
         [Test]

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/TableHelperExtensionMethods/CreateSetHelperMethodTests.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/TableHelperExtensionMethods/CreateSetHelperMethodTests.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+using System.Globalization;
 using System.Linq;
+using System.Threading;
 using NUnit.Framework;
 using FluentAssertions;
 using TechTalk.SpecFlow.Assist;
@@ -7,7 +9,7 @@ using TechTalk.SpecFlow.RuntimeTests.AssistTests.ExampleEntities;
 
 namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.TableHelperExtensionMethods
 {
-    [TestFixture, SetCulture("en-US")]
+    [TestFixture]
     public class CreateSetHelperMethodTests
     {
         private static Table CreatePersonTableHeaders()
@@ -15,7 +17,14 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.TableHelperExtensionMethods
             return new Table("FirstName", "LastName", "BirthDate", "NumberOfIdeas", "Salary", "IsRational");
         }
 
-        [Test]
+	    [SetUp]
+	    public void TestSetup()
+	    {
+		    // this is required, because the tests depend on parsing decimals with the en-US culture
+		    Thread.CurrentThread.CurrentCulture = new CultureInfo("en-US");
+	    }
+
+		[Test]
         public void Returns_empty_set_of_type_when_there_are_no_rows()
         {
             var table = new Table("FirstName");
@@ -135,10 +144,12 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.TableHelperExtensionMethods
             people.First().BirthDate.Should().Be(new DateTime(2009, 4, 28));
 		}
 
-	    [Test, SetCulture("fr-FR")]
+	    [Test]
 	    public void Sets_datetime_on_the_instance_when_type_is_datetime_and_culture_is_fr_FR()
 	    {
-		    var table = CreatePersonTableHeaders();
+		    Thread.CurrentThread.CurrentCulture = new CultureInfo("fr-FR");
+
+			var table = CreatePersonTableHeaders();
 		    table.AddRow("", "", "28/4/2009", "3", "", "");
 
 		    var people = table.CreateSet<Person>();
@@ -181,9 +192,11 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.TableHelperExtensionMethods
 		    people.First().NullableDecimal.Should().Be(7.28M);
 	    }
 
-	    [Test, SetCulture("fr-FR")]
+	    [Test]
 	    public void Sets_decimals_on_the_instance_when_type_is_decimal_and_culture_is_fr_FR()
-	    {
+		{
+			Thread.CurrentThread.CurrentCulture = new CultureInfo("fr-FR");
+
 			var table = new Table("Salary", "NullableDecimal");
 		    table.AddRow("4,193", "7,28");
 
@@ -253,10 +266,12 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.TableHelperExtensionMethods
             people.First().NullableDouble.Should().Be(7.28);
         }
 
-	    [Test, SetCulture("fr-FR")]
+	    [Test]
 	    public void Sets_doubles_on_the_instance_when_type_is_double_and_culture_is_fr_FR()
-	    {
-		    var table = new Table("Double", "NullableDouble");
+		{
+			Thread.CurrentThread.CurrentCulture = new CultureInfo("fr-FR");
+
+			var table = new Table("Double", "NullableDouble");
 		    table.AddRow("4,193", "7,28");
 
 		    var people = table.CreateSet<Person>();
@@ -277,10 +292,12 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.TableHelperExtensionMethods
 		    people.First().NullableByte.Should().Be(7);
 	    }
 
-		[Test, SetCulture("fr-FR")]
+		[Test]
 	    public void Sets_bytes_on_the_instance_when_type_is_byte_and_culture_is_fr_FR()
-	    {
-		    var table = new Table("Byte", "NullableByte");
+		{
+			Thread.CurrentThread.CurrentCulture = new CultureInfo("fr-FR");
+
+			var table = new Table("Byte", "NullableByte");
 		    table.AddRow("4,000", "7,000");
 
 		    var people = table.CreateSet<Person>();
@@ -301,10 +318,12 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.TableHelperExtensionMethods
 		    people.First().NullableSByte.Value.Should().Be(5);
 		}
 
-	    [Test, SetCulture("fr-FR")]
+	    [Test]
 	    public void Sets_sbytes_on_the_instance_when_type_is_sbyte_and_culture_is_fr_FR()
-	    {
-		    var table = new Table("SByte", "NullableSByte");
+		{
+			Thread.CurrentThread.CurrentCulture = new CultureInfo("fr-FR");
+
+			var table = new Table("SByte", "NullableSByte");
 		    table.AddRow("4,0", "5,0");
 
 			var people = table.CreateSet<Person>();
@@ -325,10 +344,12 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.TableHelperExtensionMethods
             people.First().NullableFloat.Should().Be(8.954F);
         }
 
-	    [Test, SetCulture("fr-FR")]
+	    [Test]
 	    public void Sets_floats_on_the_instance_when_type_is_float_and_culture_is_fr_FR()
-	    {
-		    var table = new Table("Float", "NullableFloat");
+		{
+			Thread.CurrentThread.CurrentCulture = new CultureInfo("fr-FR");
+
+			var table = new Table("Float", "NullableFloat");
 		    table.AddRow("2,698", "8,954");
 
 		    var people = table.CreateSet<Person>();

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/TableHelperExtensionMethods/CreateSetHelperMethodTests.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/TableHelperExtensionMethods/CreateSetHelperMethodTests.cs
@@ -1,7 +1,5 @@
 ﻿using System;
-using System.Globalization;
 using System.Linq;
-using System.Threading;
 using NUnit.Framework;
 using FluentAssertions;
 using TechTalk.SpecFlow.Assist;
@@ -255,7 +253,19 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.TableHelperExtensionMethods
             people.First().NullableFloat.Should().Be(8.954F);
         }
 
-        [Test]
+	    [Test, SetCulture("fr-FR")]
+	    public void Sets_floats_on_the_instance_when_type_is_float_and_culture_is_fr_FR()
+	    {
+		    var table = new Table("Float", "NullableFloat");
+		    table.AddRow("2,698", "8,954");
+
+		    var people = table.CreateSet<Person>();
+
+		    people.First().Float.Should().Be(2.698F);
+		    people.First().NullableFloat.Should().Be(8.954F);
+	    }
+
+		[Test]
         public void Sets_guids_on_the_instance_when_the_type_is_guid()
         {
             var table = new Table("GuidId", "NullableGuidId");

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/TableHelperExtensionMethods/CreateSetHelperMethodTests.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/TableHelperExtensionMethods/CreateSetHelperMethodTests.cs
@@ -193,6 +193,30 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.TableHelperExtensionMethods
 		    people.First().NullableDecimal.Should().Be(7.28M);
 		}
 
+	    [Test]
+	    public void Sets_short_on_the_instance_when_type_is_short()
+	    {
+		    var table = new Table("Short", "NullableShort");
+		    table.AddRow("1234", "1,234");
+
+		    var people = table.CreateSet<Person>();
+
+		    people.First().Short.Should().Be(1234);
+		    people.First().NullableShort.Should().Be(1234);
+	    }
+
+	    [Test]
+	    public void Sets_ushort_on_the_instance_when_type_is_ushort()
+	    {
+		    var table = new Table("UShort", "NullableUShort");
+		    table.AddRow("1234", "1,234");
+
+		    var people = table.CreateSet<Person>();
+
+		    people.First().UShort.Should().Be(1234);
+		    people.First().NullableUShort.Value.Should().Be(1234);
+	    }
+
 		[Test]
 	    public void Sets_longs_on_the_instance_when_type_is_long()
 	    {
@@ -268,24 +292,26 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.TableHelperExtensionMethods
 	    [Test]
 	    public void Sets_sbytes_on_the_instance_when_type_is_sbyte()
 	    {
-		    var table = new Table("SByte");
-		    table.AddRow("4.0");
+		    var table = new Table("SByte", "NullableSByte");
+		    table.AddRow("4.0", "5.0");
 
 		    var people = table.CreateSet<Person>();
 
 		    people.First().SByte.Should().Be(4);
-	    }
+		    people.First().NullableSByte.Value.Should().Be(5);
+		}
 
 	    [Test, SetCulture("fr-FR")]
 	    public void Sets_sbytes_on_the_instance_when_type_is_sbyte_and_culture_is_fr_FR()
 	    {
-		    var table = new Table("SByte");
-		    table.AddRow("4.0");
+		    var table = new Table("SByte", "NullableSByte");
+		    table.AddRow("4,0", "5,0");
 
 			var people = table.CreateSet<Person>();
 
 		    people.First().SByte.Should().Be(4);
-	    }
+		    people.First().NullableSByte.Value.Should().Be(5);
+		}
 
 		[Test]
         public void Sets_floats_on_the_instance_when_type_is_float()

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/TableHelperExtensionMethods/CreateSetHelperMethodTests.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/TableHelperExtensionMethods/CreateSetHelperMethodTests.cs
@@ -205,6 +205,18 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.TableHelperExtensionMethods
 		    people.First().NullableLong.Should().Be(1234567890123456789L);
 	    }
 
+	    [Test]
+	    public void Sets_ulongs_on_the_instance_when_type_is_ulong()
+	    {
+		    var table = new Table("ULong", "NullableULong");
+		    table.AddRow("1234567890123456789", "1,234,567,890,123,456,789");
+
+		    var people = table.CreateSet<Person>();
+
+		    people.First().ULong.Should().Be(1234567890123456789UL);
+		    people.First().NullableULong.Should().Be(1234567890123456789UL);
+	    }
+
 		[Test]
         public void Sets_doubles_on_the_instance_when_type_is_double()
         {

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/TableHelperExtensionMethods/CreateSetHelperMethodTests.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/TableHelperExtensionMethods/CreateSetHelperMethodTests.cs
@@ -193,6 +193,18 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.TableHelperExtensionMethods
 		    people.First().NullableDecimal.Should().Be(7.28M);
 		}
 
+	    [Test]
+	    public void Sets_longs_on_the_instance_when_type_is_long()
+	    {
+		    var table = new Table("Long", "NullableLong");
+		    table.AddRow("1234567890123456789", "1,234,567,890,123,456,789");
+
+		    var people = table.CreateSet<Person>();
+
+		    people.First().Long.Should().Be(1234567890123456789L);
+		    people.First().NullableLong.Should().Be(1234567890123456789L);
+	    }
+
 		[Test]
         public void Sets_doubles_on_the_instance_when_type_is_double()
         {

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/ValueComparerTests/DateTimeValueComparerTests.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/ValueComparerTests/DateTimeValueComparerTests.cs
@@ -1,14 +1,23 @@
 ﻿using System;
+using System.Globalization;
+using System.Threading;
 using NUnit.Framework;
 using FluentAssertions;
 using TechTalk.SpecFlow.Assist.ValueComparers;
 
 namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.ValueComparerTests
 {
-    [TestFixture, SetCulture("en-US")]
+    [TestFixture]
     public class DateTimeValueComparerTests
     {
-        [Test]
+	    [SetUp]
+	    public void TestSetup()
+	    {
+		    // this is required, because the tests depend on parsing decimals with the en-US culture
+		    Thread.CurrentThread.CurrentCulture = new CultureInfo("en-US");
+	    }
+
+		[Test]
         public void Can_compare_if_the_value_is_a_datetime()
         {
             new DateTimeValueComparer()

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/ValueComparerTests/DecimalValueComparerTests.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/ValueComparerTests/DecimalValueComparerTests.cs
@@ -1,13 +1,22 @@
-﻿using FluentAssertions;
+﻿using System.Globalization;
+using System.Threading;
+using FluentAssertions;
 using NUnit.Framework;
 using TechTalk.SpecFlow.Assist.ValueComparers;
 
 namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.ValueComparerTests
 {
-    [TestFixture, SetCulture("en-US")]
+    [TestFixture]
     public class DecimalValueComparerTests
-    {
-        [Test]
+	{
+		[SetUp]
+		public void TestSetup()
+		{
+			// this is required, because the tests depend on parsing decimals with the en-US culture
+			Thread.CurrentThread.CurrentCulture = new CultureInfo("en-US");
+		}
+
+		[Test]
         public void Can_compare_if_the_value_is_a_decimal()
         {
             var valueComparer = new DecimalValueComparer();

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/ValueComparerTests/DoubleValueComparerTests.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/ValueComparerTests/DoubleValueComparerTests.cs
@@ -1,13 +1,22 @@
-﻿using FluentAssertions;
+﻿using System.Globalization;
+using System.Threading;
+using FluentAssertions;
 using NUnit.Framework;
 using TechTalk.SpecFlow.Assist.ValueComparers;
 
 namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.ValueComparerTests
 {
-    [TestFixture, SetCulture("en-US")]
+    [TestFixture]
     public class DoubleValueComparerTests
-    {
-        [Test]
+	{
+		[SetUp]
+		public void TestSetup()
+		{
+			// this is required, because the tests depend on parsing decimals with the en-US culture
+			Thread.CurrentThread.CurrentCulture = new CultureInfo("en-US");
+		}
+
+		[Test]
         public void Can_compare_if_the_value_is_a_double()
         {
             var valueComparer = new DoubleValueComparer();

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/ValueComparerTests/FloatValueComparerTests.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/ValueComparerTests/FloatValueComparerTests.cs
@@ -1,13 +1,22 @@
-﻿using FluentAssertions;
+﻿using System.Globalization;
+using System.Threading;
+using FluentAssertions;
 using NUnit.Framework;
 using TechTalk.SpecFlow.Assist.ValueComparers;
 
 namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.ValueComparerTests
 {
-    [TestFixture, SetCulture("en-US")]
+    [TestFixture]
     public class FloatValueComparerTests
-    {
-        [Test]
+	{
+		[SetUp]
+		public void TestSetup()
+		{
+			// this is required, because the tests depend on parsing decimals with the en-US culture
+			Thread.CurrentThread.CurrentCulture = new CultureInfo("en-US");
+		}
+
+		[Test]
         public void Can_compare_if_the_value_is_a_single()
         {
             var valueComparer = new FloatValueComparer();

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/ValueRetrieverTests/ByteValueRetrieverTests.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/ValueRetrieverTests/ByteValueRetrieverTests.cs
@@ -1,4 +1,6 @@
-﻿using FluentAssertions;
+﻿using System.Globalization;
+using System.Threading;
+using FluentAssertions;
 using NUnit.Framework;
 using TechTalk.SpecFlow.Assist.ValueRetrievers;
 
@@ -16,10 +18,12 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.ValueRetrieverTests
             retriever.GetValue("30").Should().Be(30);
 		}
 
-	    [Test, SetCulture("fr-FR")]
+	    [Test]
 	    public void Returns_a_byte_when_passed_a_byte_value_if_culture_is_fr_Fr()
-	    {
-		    var retriever = new ByteValueRetriever();
+		{
+			Thread.CurrentThread.CurrentCulture = new CultureInfo("fr-FR");
+
+			var retriever = new ByteValueRetriever();
 		    retriever.GetValue("30,0").Should().Be(30);
 	    }
 

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/ValueRetrieverTests/ByteValueRetrieverTests.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/ValueRetrieverTests/ByteValueRetrieverTests.cs
@@ -14,9 +14,16 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.ValueRetrieverTests
             retriever.GetValue("1").Should().Be(1);
             retriever.GetValue("3").Should().Be(3);
             retriever.GetValue("30").Should().Be(30);
-        }
+		}
 
-        [Test]
+	    [Test, SetCulture("fr-FR")]
+	    public void Returns_a_byte_when_passed_a_byte_value_if_culture_is_fr_Fr()
+	    {
+		    var retriever = new ByteValueRetriever();
+		    retriever.GetValue("30,0").Should().Be(30);
+	    }
+
+		[Test]
         public void Returns_a_zero_when_passed_an_invalid_byte()
         {
             var retriever = new ByteValueRetriever();
@@ -26,5 +33,5 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.ValueRetrieverTests
             retriever.GetValue("500").Should().Be(0);
             retriever.GetValue("every good boy does fine").Should().Be(0);
         }
-    }
+	}
 }

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/ValueRetrieverTests/DateTimeOffsetValueRetrieverTests.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/ValueRetrieverTests/DateTimeOffsetValueRetrieverTests.cs
@@ -32,7 +32,7 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.ValueRetrieverTests
             retriever.GetValue("2013-12-05").Should().Be(new DateTimeOffset(2013, 12, 5, 0, 0, 0, TimeZone.CurrentTimeZone.GetUtcOffset(date2)));
         }
 
-        [Test]
+		[Test]
         public void Returns_the_date_and_time_when_value_represents_a_valid_datetime()
         {
             var retriever = new DateTimeOffsetValueRetriever();
@@ -40,9 +40,19 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.ValueRetrieverTests
             retriever.GetValue("2011-01-01 15:16:17").Should().Be(new DateTimeOffset(2011, 1, 1, 15, 16, 17, TimeZone.CurrentTimeZone.GetUtcOffset(date1)));
             var date2 = new DateTime(2011, 1, 1);
             retriever.GetValue("2011-01-01 5:6:7").Should().Be(new DateTimeOffset(2011, 1, 1, 5, 6, 7, TimeZone.CurrentTimeZone.GetUtcOffset(date2)));
-        }
+		}
 
-        [Test]
+	    [Test, SetCulture("fr-FR")]
+	    public void Returns_the_date_and_time_represents_a_valid_date_if_culture_is_fr_FR()
+	    {
+		    var retriever = new DateTimeOffsetValueRetriever();
+			var date1 = new DateTime(2011, 5, 1);
+		    retriever.GetValue("01/05/2011 15:16:17").Should().Be(new DateTimeOffset(2011, 5, 1, 15, 16, 17, TimeZone.CurrentTimeZone.GetUtcOffset(date1)));
+		    var date2 = new DateTime(2011, 5, 1);
+		    retriever.GetValue("01/05/2011 5:6:7").Should().Be(new DateTimeOffset(2011, 5, 1, 5, 6, 7, TimeZone.CurrentTimeZone.GetUtcOffset(date2)));
+		}
+
+		[Test]
         public void Returns_MinValue_when_the_value_is_not_a_valid_datetime()
         {
             var retriever = new DateTimeOffsetValueRetriever();

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/ValueRetrieverTests/DateTimeOffsetValueRetrieverTests.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/ValueRetrieverTests/DateTimeOffsetValueRetrieverTests.cs
@@ -1,14 +1,23 @@
 ﻿using System;
+using System.Globalization;
+using System.Threading;
 using NUnit.Framework;
 using FluentAssertions;
 using TechTalk.SpecFlow.Assist.ValueRetrievers;
 
 namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.ValueRetrieverTests
 {
-    [TestFixture, SetCulture("en-US")]
+    [TestFixture]
     public class DateTimeOffsetValueRetrieverTests
-    {
-        [Test]
+	{
+		[SetUp]
+		public void TestSetup()
+		{
+			// this is required, because the tests depend on parsing decimals with the en-US culture
+			Thread.CurrentThread.CurrentCulture = new CultureInfo("en-US");
+		}
+
+		[Test]
         public void Returns_MinValue_when_the_value_is_null()
         {
             var retriever = new DateTimeOffsetValueRetriever();
@@ -42,10 +51,12 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.ValueRetrieverTests
             retriever.GetValue("2011-01-01 5:6:7").Should().Be(new DateTimeOffset(2011, 1, 1, 5, 6, 7, TimeZone.CurrentTimeZone.GetUtcOffset(date2)));
 		}
 
-	    [Test, SetCulture("fr-FR")]
+	    [Test]
 	    public void Returns_the_date_and_time_represents_a_valid_date_if_culture_is_fr_FR()
-	    {
-		    var retriever = new DateTimeOffsetValueRetriever();
+		{
+			Thread.CurrentThread.CurrentCulture = new CultureInfo("fr-FR");
+
+			var retriever = new DateTimeOffsetValueRetriever();
 			var date1 = new DateTime(2011, 5, 1);
 		    retriever.GetValue("01/05/2011 15:16:17").Should().Be(new DateTimeOffset(2011, 5, 1, 15, 16, 17, TimeZone.CurrentTimeZone.GetUtcOffset(date1)));
 		    var date2 = new DateTime(2011, 5, 1);

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/ValueRetrieverTests/DateTimeValueRetrieverTests.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/ValueRetrieverTests/DateTimeValueRetrieverTests.cs
@@ -1,14 +1,23 @@
 ﻿using System;
+using System.Globalization;
+using System.Threading;
 using NUnit.Framework;
 using FluentAssertions;
 using TechTalk.SpecFlow.Assist.ValueRetrievers;
 
 namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.ValueRetrieverTests
 {
-    [TestFixture, SetCulture("en-US")]
+    [TestFixture]
     public class DateTimeValueRetrieverTests
-    {
-        [Test]
+	{
+		[SetUp]
+		public void TestSetup()
+		{
+			// this is required, because the tests depend on parsing decimals with the en-US culture
+			Thread.CurrentThread.CurrentCulture = new CultureInfo("en-US");
+		}
+
+		[Test]
         public void Returns_MinValue_when_the_value_is_null()
         {
             var retriever = new DateTimeValueRetriever();
@@ -38,10 +47,12 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.ValueRetrieverTests
             retriever.GetValue("1/1/2011 5:6:7").Should().Be(new DateTime(2011, 1, 1, 5, 6, 7));
         }
 
-	    [Test, SetCulture("fr-FR")]
+	    [Test]
 	    public void Returns_the_date_and_time_when_value_represents_a_valid_datetime_if_culture_is_fr_FR()
-	    {
-		    var retriever = new DateTimeValueRetriever();
+		{
+			Thread.CurrentThread.CurrentCulture = new CultureInfo("fr-FR");
+
+			var retriever = new DateTimeValueRetriever();
 		    retriever.GetValue("1/4/2011 15:16:17").Should().Be(new DateTime(2011, 4, 1, 15, 16, 17));
 		    retriever.GetValue("1/4/2011 5:6:7").Should().Be(new DateTime(2011, 4, 1, 5, 6, 7));
 	    }

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/ValueRetrieverTests/DateTimeValueRetrieverTests.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/ValueRetrieverTests/DateTimeValueRetrieverTests.cs
@@ -38,7 +38,15 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.ValueRetrieverTests
             retriever.GetValue("1/1/2011 5:6:7").Should().Be(new DateTime(2011, 1, 1, 5, 6, 7));
         }
 
-        [Test]
+	    [Test, SetCulture("fr-FR")]
+	    public void Returns_the_date_and_time_when_value_represents_a_valid_datetime_if_culture_is_fr_FR()
+	    {
+		    var retriever = new DateTimeValueRetriever();
+		    retriever.GetValue("1/4/2011 15:16:17").Should().Be(new DateTime(2011, 4, 1, 15, 16, 17));
+		    retriever.GetValue("1/4/2011 5:6:7").Should().Be(new DateTime(2011, 4, 1, 5, 6, 7));
+	    }
+
+		[Test]
         public void Returns_MinValue_when_the_value_is_not_a_valid_datetime()
         {
             var retriever = new DateTimeValueRetriever();

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/ValueRetrieverTests/DecimalValueRetreiverTests.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/ValueRetrieverTests/DecimalValueRetreiverTests.cs
@@ -16,9 +16,20 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.ValueRetrieverTests
             retriever.GetValue("2").Should().Be(2M);
             retriever.GetValue("2.23").Should().Be(2.23M);
             retriever.GetValue("384.234879").Should().Be(384.234879M);
-        }
+		}
 
-        [Test]
+	    [Test, SetCulture("fr-FR")]
+	    public void Returns_the_decimal_value_when_passed_a_decimal_string_if_culture_if_fr_FR()
+	    {
+		    var retriever = new DecimalValueRetriever();
+		    retriever.GetValue("0").Should().Be(0M);
+		    retriever.GetValue("1").Should().Be(1M);
+		    retriever.GetValue("2").Should().Be(2M);
+		    retriever.GetValue("2.23").Should().Be(2.23M);
+			retriever.GetValue("384,234879").Should().Be(384.234879M);
+	    }
+
+		[Test]
         public void Returns_a_negative_decimal_value_when_passed_one()
         {
             var retriever = new DecimalValueRetriever();

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/ValueRetrieverTests/DecimalValueRetreiverTests.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/ValueRetrieverTests/DecimalValueRetreiverTests.cs
@@ -25,7 +25,7 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.ValueRetrieverTests
 		    retriever.GetValue("0").Should().Be(0M);
 		    retriever.GetValue("1").Should().Be(1M);
 		    retriever.GetValue("2").Should().Be(2M);
-		    retriever.GetValue("2.23").Should().Be(2.23M);
+		    retriever.GetValue("2,23").Should().Be(2.23M);
 			retriever.GetValue("384,234879").Should().Be(384.234879M);
 	    }
 

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/ValueRetrieverTests/DecimalValueRetreiverTests.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/ValueRetrieverTests/DecimalValueRetreiverTests.cs
@@ -1,13 +1,22 @@
-﻿using FluentAssertions;
+﻿using System.Globalization;
+using System.Threading;
+using FluentAssertions;
 using NUnit.Framework;
 using TechTalk.SpecFlow.Assist.ValueRetrievers;
 
 namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.ValueRetrieverTests
 {
-    [TestFixture, SetCulture("en-US")]
+    [TestFixture]
     public class DecimalValueRetreiverTests
-    {
-        [Test]
+	{
+		[SetUp]
+		public void TestSetup()
+		{
+			// this is required, because the tests depend on parsing decimals with the en-US culture
+			Thread.CurrentThread.CurrentCulture = new CultureInfo("en-US");
+		}
+
+		[Test]
         public void Returns_the_decimal_value_when_passed_a_decimal_string()
         {
             var retriever = new DecimalValueRetriever();
@@ -18,10 +27,12 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.ValueRetrieverTests
             retriever.GetValue("384.234879").Should().Be(384.234879M);
 		}
 
-	    [Test, SetCulture("fr-FR")]
+	    [Test]
 	    public void Returns_the_decimal_value_when_passed_a_decimal_string_if_culture_if_fr_FR()
-	    {
-		    var retriever = new DecimalValueRetriever();
+		{
+			Thread.CurrentThread.CurrentCulture = new CultureInfo("fr-FR");
+
+			var retriever = new DecimalValueRetriever();
 		    retriever.GetValue("0").Should().Be(0M);
 		    retriever.GetValue("1").Should().Be(1M);
 		    retriever.GetValue("2").Should().Be(2M);

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/ValueRetrieverTests/DoubleValueRetreiverTests.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/ValueRetrieverTests/DoubleValueRetreiverTests.cs
@@ -1,13 +1,22 @@
-﻿using FluentAssertions;
+﻿using System.Globalization;
+using System.Threading;
+using FluentAssertions;
 using NUnit.Framework;
 using TechTalk.SpecFlow.Assist.ValueRetrievers;
 
 namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.ValueRetrieverTests
 {
-    [TestFixture, SetCulture("en-US")]
+    [TestFixture]
     public class DoubleValueRetreiverTests
-    {
-        [Test]
+	{
+		[SetUp]
+		public void TestSetup()
+		{
+			// this is required, because the tests depend on parsing decimals with the en-US culture
+			Thread.CurrentThread.CurrentCulture = new CultureInfo("en-US");
+		}
+
+		[Test]
         public void Returns_the_Double_value_when_passed_a_Double_string()
         {
             var retriever = new DoubleValueRetriever();
@@ -18,9 +27,11 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.ValueRetrieverTests
             retriever.GetValue("384.234879").Should().Be(384.234879);
         }
 
-		[Test, SetCulture("fr-FR")]
+		[Test]
 		public void Returns_the_Double_value_when_passed_a_Double_string_If_Culture_Is_fr_Fr()
 		{
+			Thread.CurrentThread.CurrentCulture = new CultureInfo("fr-FR");
+
 			var retriever = new DoubleValueRetriever();
 			retriever.GetValue("0").Should().Be(0);
 			retriever.GetValue("1").Should().Be(1);

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/ValueRetrieverTests/DoubleValueRetreiverTests.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/ValueRetrieverTests/DoubleValueRetreiverTests.cs
@@ -18,7 +18,18 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.ValueRetrieverTests
             retriever.GetValue("384.234879").Should().Be(384.234879);
         }
 
-        [Test]
+		[Test, SetCulture("fr-FR")]
+		public void Returns_the_Double_value_when_passed_a_Double_string_If_Culture_Is_fr_Fr()
+		{
+			var retriever = new DoubleValueRetriever();
+			retriever.GetValue("0").Should().Be(0);
+			retriever.GetValue("1").Should().Be(1);
+			retriever.GetValue("2").Should().Be(2);
+			retriever.GetValue("2,23").Should().Be(2.23);
+			retriever.GetValue("384,234879").Should().Be(384.234879);
+		}
+
+		[Test]
         public void Returns_a_negative_Double_value_when_passed_one()
         {
             var retriever = new DoubleValueRetriever();

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/ValueRetrieverTests/FloatValueRetrieverTests.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/ValueRetrieverTests/FloatValueRetrieverTests.cs
@@ -1,13 +1,22 @@
-﻿using FluentAssertions;
+﻿using System.Globalization;
+using System.Threading;
+using FluentAssertions;
 using NUnit.Framework;
 using TechTalk.SpecFlow.Assist.ValueRetrievers;
 
 namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.ValueRetrieverTests
 {
-    [TestFixture, SetCulture("en-US")]
+    [TestFixture]
     public class FloatValueRetrieverTests
-    {
-        [Test]
+	{
+		[SetUp]
+		public void TestSetup()
+		{
+			// this is required, because the tests depend on parsing decimals with the en-US culture
+			Thread.CurrentThread.CurrentCulture = new CultureInfo("en-US");
+		}
+
+		[Test]
         public void Returns_the_Float_value_when_passed_a_Float_string()
         {
             var retriever = new FloatValueRetriever();
@@ -18,9 +27,11 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.ValueRetrieverTests
             retriever.GetValue("384.234879").Should().Be(384.234879F);
 		}
 
-		[Test, SetCulture("fr-FR")]
+		[Test]
 		public void Returns_the_Float_value_when_passed_a_Float_string_if_culture_if_fr_FR()
 		{
+			Thread.CurrentThread.CurrentCulture = new CultureInfo("fr-FR");
+
 			var retriever = new FloatValueRetriever();
 			retriever.GetValue("0").Should().Be(0F);
 			retriever.GetValue("1").Should().Be(1F);

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/ValueRetrieverTests/FloatValueRetrieverTests.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/ValueRetrieverTests/FloatValueRetrieverTests.cs
@@ -16,9 +16,20 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.ValueRetrieverTests
             retriever.GetValue("2").Should().Be(2F);
             retriever.GetValue("2.23").Should().Be(2.23F);
             retriever.GetValue("384.234879").Should().Be(384.234879F);
-        }
+		}
 
-        [Test]
+		[Test, SetCulture("fr-FR")]
+		public void Returns_the_Float_value_when_passed_a_Float_string_if_culture_if_fr_FR()
+		{
+			var retriever = new FloatValueRetriever();
+			retriever.GetValue("0").Should().Be(0F);
+			retriever.GetValue("1").Should().Be(1F);
+			retriever.GetValue("2").Should().Be(2F);
+			retriever.GetValue("2,23").Should().Be(2.23F);
+			retriever.GetValue("384,234879").Should().Be(384.234879F);
+		}
+
+		[Test]
         public void Returns_a_negative_Float_value_when_passed_one()
         {
             var retriever = new FloatValueRetriever();

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/ValueRetrieverTests/IntValueRetrieverTests.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/ValueRetrieverTests/IntValueRetrieverTests.cs
@@ -4,7 +4,7 @@ using TechTalk.SpecFlow.Assist.ValueRetrievers;
 
 namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.ValueRetrieverTests
 {
-    [TestFixture]
+    [TestFixture, SetCulture("en-US")]
     public class IntValueRetrieverTests
     {
         [Test]
@@ -14,10 +14,20 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.ValueRetrieverTests
             retriever.GetValue("1").Should().Be(1);
             retriever.GetValue("3").Should().Be(3);
             retriever.GetValue("30").Should().Be(30);
-            retriever.GetValue("1234567890").Should().Be(1234567890);
+            retriever.GetValue("1,234,567,890").Should().Be(1234567890);
         }
 
-        [Test]
+	    [Test, SetCulture("fr-FR")]
+	    public void Returns_an_integer_when_passed_an_integer_value_if_culture_if_fr_FR()
+	    {
+		    var retriever = new IntValueRetriever();
+		    retriever.GetValue("1").Should().Be(1);
+		    retriever.GetValue("3").Should().Be(3);
+		    retriever.GetValue("30").Should().Be(30);
+		    retriever.GetValue("1234567890").Should().Be(1234567890);
+		}
+
+		[Test]
         public void Returns_negative_numbers_when_passed_a_negative_value()
         {
             var retriever = new IntValueRetriever();
@@ -32,6 +42,13 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.ValueRetrieverTests
             retriever.GetValue("x").Should().Be(0);
             retriever.GetValue("").Should().Be(0);
             retriever.GetValue("every good boy does fine").Should().Be(0);
-        }
-    }
+		}
+
+	    [Test, SetCulture("fr-FR")]
+	    public void Returns_a_zero_when_passed_an_invalid_int_if_culture_is_fr_FR()
+	    {
+		    var retriever = new IntValueRetriever();
+		    retriever.GetValue("1,234,567,890").Should().Be(0);
+		}
+	}
 }

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/ValueRetrieverTests/IntValueRetrieverTests.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/ValueRetrieverTests/IntValueRetrieverTests.cs
@@ -1,13 +1,22 @@
-﻿using FluentAssertions;
+﻿using System.Globalization;
+using System.Threading;
+using FluentAssertions;
 using NUnit.Framework;
 using TechTalk.SpecFlow.Assist.ValueRetrievers;
 
 namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.ValueRetrieverTests
 {
-    [TestFixture, SetCulture("en-US")]
+    [TestFixture]
     public class IntValueRetrieverTests
-    {
-        [Test]
+	{
+		[SetUp]
+		public void TestSetup()
+		{
+			// this is required, because the tests depend on parsing decimals with the en-US culture
+			Thread.CurrentThread.CurrentCulture = new CultureInfo("en-US");
+		}
+
+		[Test]
         public void Returns_an_integer_when_passed_an_integer_value()
         {
             var retriever = new IntValueRetriever();
@@ -18,10 +27,12 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.ValueRetrieverTests
 			retriever.GetValue("1,234,567,890").Should().Be(1234567890);
         }
 
-	    [Test, SetCulture("fr-FR")]
+	    [Test]
 	    public void Returns_an_integer_when_passed_an_integer_value_if_culture_if_fr_FR()
-	    {
-		    var retriever = new IntValueRetriever();
+		{
+			Thread.CurrentThread.CurrentCulture = new CultureInfo("fr-FR");
+
+			var retriever = new IntValueRetriever();
 		    retriever.GetValue("1").Should().Be(1);
 		    retriever.GetValue("3").Should().Be(3);
 		    retriever.GetValue("30").Should().Be(30);
@@ -45,10 +56,12 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.ValueRetrieverTests
             retriever.GetValue("every good boy does fine").Should().Be(0);
 		}
 
-	    [Test, SetCulture("fr-FR")]
+	    [Test]
 	    public void Returns_a_zero_when_passed_an_invalid_int_if_culture_is_fr_FR()
-	    {
-		    var retriever = new IntValueRetriever();
+		{
+			Thread.CurrentThread.CurrentCulture = new CultureInfo("fr-FR");
+
+			var retriever = new IntValueRetriever();
 		    retriever.GetValue("1,234,567,890").Should().Be(0);
 		}
 	}

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/ValueRetrieverTests/IntValueRetrieverTests.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/ValueRetrieverTests/IntValueRetrieverTests.cs
@@ -14,7 +14,8 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.ValueRetrieverTests
             retriever.GetValue("1").Should().Be(1);
             retriever.GetValue("3").Should().Be(3);
             retriever.GetValue("30").Should().Be(30);
-            retriever.GetValue("1,234,567,890").Should().Be(1234567890);
+	        retriever.GetValue("1234567890").Should().Be(1234567890);
+			retriever.GetValue("1,234,567,890").Should().Be(1234567890);
         }
 
 	    [Test, SetCulture("fr-FR")]

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/ValueRetrieverTests/LongValueRetrieverTests.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/ValueRetrieverTests/LongValueRetrieverTests.cs
@@ -7,17 +7,18 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.ValueRetrieverTests
     [TestFixture]
     public class LongValueRetrieverTests
     {
-        [Test]
+        [Test, SetCulture("en-US")]
         public void Returns_a_long_when_passed_a_long_value()
         {
             var retriever = new LongValueRetriever();
             retriever.GetValue("1").Should().Be(1);
             retriever.GetValue("3").Should().Be(3);
             retriever.GetValue("30").Should().Be(30);
-            retriever.GetValue("1234567890123456789").Should().Be(1234567890123456789L);
+	        retriever.GetValue("1234567890123456789").Should().Be(1234567890123456789L);
+			retriever.GetValue("1,234,567,890,123,456,789").Should().Be(1234567890123456789L);
         }
-
-        [Test]
+		
+		[Test]
         public void Returns_negative_numbers_when_passed_a_negative_value()
         {
             var retriever = new LongValueRetriever();
@@ -33,5 +34,12 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.ValueRetrieverTests
             retriever.GetValue("").Should().Be(0);
             retriever.GetValue("every good boy does fine").Should().Be(0);
         }
-    }
+
+	    [Test, SetCulture("fr-FR")]
+	    public void Returns_a_zero_when_passed_an_invalid_long_and_culture_is_fr_FR()
+	    {
+		    var retriever = new LongValueRetriever();
+		    retriever.GetValue("1,234,567,890,123,456,789").Should().Be(0);
+		}
+	}
 }

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/ValueRetrieverTests/LongValueRetrieverTests.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/ValueRetrieverTests/LongValueRetrieverTests.cs
@@ -1,4 +1,6 @@
-﻿using FluentAssertions;
+﻿using System.Globalization;
+using System.Threading;
+using FluentAssertions;
 using NUnit.Framework;
 using TechTalk.SpecFlow.Assist.ValueRetrievers;
 
@@ -7,10 +9,12 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.ValueRetrieverTests
     [TestFixture]
     public class LongValueRetrieverTests
     {
-        [Test, SetCulture("en-US")]
+        [Test]
         public void Returns_a_long_when_passed_a_long_value()
-        {
-            var retriever = new LongValueRetriever();
+		{
+			Thread.CurrentThread.CurrentCulture = new CultureInfo("en-US");
+
+			var retriever = new LongValueRetriever();
             retriever.GetValue("1").Should().Be(1);
             retriever.GetValue("3").Should().Be(3);
             retriever.GetValue("30").Should().Be(30);
@@ -35,10 +39,12 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.ValueRetrieverTests
             retriever.GetValue("every good boy does fine").Should().Be(0);
         }
 
-	    [Test, SetCulture("fr-FR")]
+	    [Test]
 	    public void Returns_a_zero_when_passed_an_invalid_long_and_culture_is_fr_FR()
-	    {
-		    var retriever = new LongValueRetriever();
+		{
+			Thread.CurrentThread.CurrentCulture = new CultureInfo("fr-FR");
+
+			var retriever = new LongValueRetriever();
 		    retriever.GetValue("1,234,567,890,123,456,789").Should().Be(0);
 		}
 	}

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/ValueRetrieverTests/NullableDateTimeOffsetValueRetriever.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/ValueRetrieverTests/NullableDateTimeOffsetValueRetriever.cs
@@ -1,14 +1,23 @@
 ﻿using System;
+using System.Globalization;
+using System.Threading;
 using NUnit.Framework;
 using FluentAssertions;
 using TechTalk.SpecFlow.Assist.ValueRetrievers;
 
 namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.ValueRetrieverTests
 {
-    [TestFixture, SetCulture("en-US")]
+    [TestFixture]
     public class NullableDateTimeOffsetValueRetrieverTests
-    {
-        [Test]
+	{
+		[SetUp]
+		public void TestSetup()
+		{
+			// this is required, because the tests depend on parsing decimals with the en-US culture
+			Thread.CurrentThread.CurrentCulture = new CultureInfo("en-US");
+		}
+
+		[Test]
         public void Returns_the_value_from_the_DateTimeOffsetValueRetriever()
         {
             Func<string, DateTimeOffset> func = v =>

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/ValueRetrieverTests/NullableDateTimeValueRetrieverTests.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/ValueRetrieverTests/NullableDateTimeValueRetrieverTests.cs
@@ -1,14 +1,23 @@
 ﻿using System;
+using System.Globalization;
+using System.Threading;
 using NUnit.Framework;
 using FluentAssertions;
 using TechTalk.SpecFlow.Assist.ValueRetrievers;
 
 namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.ValueRetrieverTests
 {
-    [TestFixture, SetCulture("en-US")]
+    [TestFixture]
     public class NullableDateTimeValueRetrieverTests
-    {
-        [Test]
+	{
+		[SetUp]
+		public void TestSetup()
+		{
+			// this is required, because the tests depend on parsing decimals with the en-US culture
+			Thread.CurrentThread.CurrentCulture = new CultureInfo("en-US");
+		}
+
+		[Test]
         public void Returns_the_value_from_the_DateTimeValueRetriever()
         {
             Func<string, DateTime> func = v =>

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/ValueRetrieverTests/NullableDecimalValueRetrieverTests.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/ValueRetrieverTests/NullableDecimalValueRetrieverTests.cs
@@ -1,14 +1,23 @@
 ﻿using System;
+using System.Globalization;
+using System.Threading;
 using NUnit.Framework;
 using FluentAssertions;
 using TechTalk.SpecFlow.Assist.ValueRetrievers;
 
 namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.ValueRetrieverTests
 {
-    [TestFixture, SetCulture("en-US")]
+    [TestFixture]
     public class NullableDecimalValueRetrieverTests
-    {
-        [Test]
+	{
+		[SetUp]
+		public void TestSetup()
+		{
+			// this is required, because the tests depend on parsing decimals with the en-US culture
+			Thread.CurrentThread.CurrentCulture = new CultureInfo("en-US");
+		}
+
+		[Test]
         public void Returns_null_when_passed_null()
         {
             var retriever = new NullableDecimalValueRetriever(v => 23M);

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/ValueRetrieverTests/NullableDoubleValueRetrieverTests.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/ValueRetrieverTests/NullableDoubleValueRetrieverTests.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Globalization;
+using System.Threading;
 using Moq;
 using NUnit.Framework;
 using FluentAssertions;
@@ -6,10 +8,17 @@ using TechTalk.SpecFlow.Assist.ValueRetrievers;
 
 namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.ValueRetrieverTests
 {
-    [TestFixture, SetCulture("en-US")]
+    [TestFixture]
     public class NullableDoubleValueRetrieverTests
-    {
-        [Test]
+	{
+		[SetUp]
+		public void TestSetup()
+		{
+			// this is required, because the tests depend on parsing decimals with the en-US culture
+			Thread.CurrentThread.CurrentCulture = new CultureInfo("en-US");
+		}
+
+		[Test]
         public void Returns_null_when_passed_null()
         {
             var retriever = new NullableDoubleValueRetriever(v => 3.01);

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/ValueRetrieverTests/NullableFloatValueRetrieverTests.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/ValueRetrieverTests/NullableFloatValueRetrieverTests.cs
@@ -1,14 +1,23 @@
 ﻿using System;
+using System.Globalization;
+using System.Threading;
 using NUnit.Framework;
 using FluentAssertions;
 using TechTalk.SpecFlow.Assist.ValueRetrievers;
 
 namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.ValueRetrieverTests
 {
-    [TestFixture, SetCulture("en-US")]
+    [TestFixture]
     public class NullableFloatValueRetrieverTests
-    {
-        [Test]
+	{
+		[SetUp]
+		public void TestSetup()
+		{
+			// this is required, because the tests depend on parsing decimals with the en-US culture
+			Thread.CurrentThread.CurrentCulture = new CultureInfo("en-US");
+		}
+
+		[Test]
         public void Returns_null_when_passed_null()
         {
             var retriever = new NullableFloatValueRetriever(v => 3.01F);

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/ValueRetrieverTests/SByteValueRetrieverTests.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/ValueRetrieverTests/SByteValueRetrieverTests.cs
@@ -1,4 +1,6 @@
-﻿using FluentAssertions;
+﻿using System.Globalization;
+using System.Threading;
+using FluentAssertions;
 using NUnit.Framework;
 using TechTalk.SpecFlow.Assist.ValueRetrievers;
 
@@ -16,10 +18,12 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.ValueRetrieverTests
             retriever.GetValue("30").Should().Be(30);
 		}
 
-	    [Test, SetCulture("fr-FR")]
+	    [Test]
 	    public void Returns_a_signed_byte_when_passed_a_signed_byte_value_if_culture_is_fr_Fr()
-	    {
-		    var retriever = new SByteValueRetriever();
+		{
+			Thread.CurrentThread.CurrentCulture = new CultureInfo("fr-FR");
+
+			var retriever = new SByteValueRetriever();
 		    retriever.GetValue("30,0").Should().Be(30);
 	    }
 

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/ValueRetrieverTests/SByteValueRetrieverTests.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/ValueRetrieverTests/SByteValueRetrieverTests.cs
@@ -14,9 +14,16 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.ValueRetrieverTests
             retriever.GetValue("1").Should().Be(1);
             retriever.GetValue("3").Should().Be(3);
             retriever.GetValue("30").Should().Be(30);
-        }
+		}
 
-        [Test]
+	    [Test, SetCulture("fr-FR")]
+	    public void Returns_a_signed_byte_when_passed_a_signed_byte_value_if_culture_is_fr_Fr()
+	    {
+		    var retriever = new SByteValueRetriever();
+		    retriever.GetValue("30,0").Should().Be(30);
+	    }
+
+		[Test]
         public void Returns_negative_numbers_when_passed_a_negative_value()
         {
             var retriever = new SByteValueRetriever();

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/ValueRetrieverTests/ShortValueRetrieverTests.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/ValueRetrieverTests/ShortValueRetrieverTests.cs
@@ -1,13 +1,22 @@
-﻿using FluentAssertions;
+﻿using System.Globalization;
+using System.Threading;
+using FluentAssertions;
 using NUnit.Framework;
 using TechTalk.SpecFlow.Assist.ValueRetrievers;
 
 namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.ValueRetrieverTests
 {
-    [TestFixture, SetCulture("en-US")]
+    [TestFixture]
     public class ShortValueRetrieverTests
-    {
-        [Test]
+	{
+		[SetUp]
+		public void TestSetup()
+		{
+			// this is required, because the tests depend on parsing decimals with the en-US culture
+			Thread.CurrentThread.CurrentCulture = new CultureInfo("en-US");
+		}
+
+		[Test]
         public void Returns_a_short_when_passed_a_short_value()
         {
             var retriever = new ShortValueRetriever();
@@ -17,10 +26,12 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.ValueRetrieverTests
             retriever.GetValue("12,345").Should().Be(12345);
 		}
 
-	    [Test, SetCulture("fr-FR")]
+	    [Test]
 	    public void Returns_a_short_when_passed_a_short_value_if_culture_is_fr_FR()
-	    {
-		    var retriever = new IntValueRetriever();
+		{
+			Thread.CurrentThread.CurrentCulture = new CultureInfo("fr-FR");
+
+			var retriever = new IntValueRetriever();
 		    retriever.GetValue("1").Should().Be(1);
 		    retriever.GetValue("3").Should().Be(3);
 		    retriever.GetValue("30").Should().Be(30);
@@ -45,10 +56,12 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.ValueRetrieverTests
             retriever.GetValue("every good boy does fine").Should().Be(0);
         }
 
-	    [Test, SetCulture("fr-FR")]
+	    [Test]
 	    public void Returns_a_zero_when_passed_an_invalid_short_if_culture_is_fr_FR()
-	    {
-		    var retriever = new IntValueRetriever();
+		{
+			Thread.CurrentThread.CurrentCulture = new CultureInfo("fr-FR");
+
+			var retriever = new IntValueRetriever();
 		    retriever.GetValue("12,345").Should().Be(0);
 		}
 	}

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/ValueRetrieverTests/ShortValueRetrieverTests.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/ValueRetrieverTests/ShortValueRetrieverTests.cs
@@ -4,7 +4,7 @@ using TechTalk.SpecFlow.Assist.ValueRetrievers;
 
 namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.ValueRetrieverTests
 {
-    [TestFixture]
+    [TestFixture, SetCulture("en-US")]
     public class ShortValueRetrieverTests
     {
         [Test]
@@ -14,10 +14,20 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.ValueRetrieverTests
             retriever.GetValue("1").Should().Be(1);
             retriever.GetValue("3").Should().Be(3);
             retriever.GetValue("30").Should().Be(30);
-            retriever.GetValue("12345").Should().Be(12345);
-        }
+            retriever.GetValue("12,345").Should().Be(12345);
+		}
 
-        [Test]
+	    [Test, SetCulture("fr-FR")]
+	    public void Returns_a_short_when_passed_a_short_value_if_culture_is_fr_FR()
+	    {
+		    var retriever = new IntValueRetriever();
+		    retriever.GetValue("1").Should().Be(1);
+		    retriever.GetValue("3").Should().Be(3);
+		    retriever.GetValue("30").Should().Be(30);
+		    retriever.GetValue("12345").Should().Be(12345);
+		}
+
+		[Test]
         public void Returns_negative_numbers_when_passed_a_negative_value()
         {
             var retriever = new ShortValueRetriever();
@@ -34,5 +44,12 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.ValueRetrieverTests
             retriever.GetValue("1234567890123456789").Should().Be(0);
             retriever.GetValue("every good boy does fine").Should().Be(0);
         }
-    }
+
+	    [Test, SetCulture("fr-FR")]
+	    public void Returns_a_zero_when_passed_an_invalid_short_if_culture_is_fr_FR()
+	    {
+		    var retriever = new IntValueRetriever();
+		    retriever.GetValue("12,345").Should().Be(0);
+		}
+	}
 }

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/ValueRetrieverTests/TimeSpanValueRetrieverTests.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/ValueRetrieverTests/TimeSpanValueRetrieverTests.cs
@@ -7,16 +7,24 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.ValueRetrieverTests
     [TestFixture]
     public class TimespanValueRetrieverTests
     {
-        [Test]
+        [Test, SetCulture("en-US")]
         public void Returns_a_timespan_when_passed_a_parsable_string_representation_of_a_timespan()
         {
             var retriever = new TimeSpanValueRetriever();
             retriever.GetValue("20:00:00").Should().Be(System.TimeSpan.Parse("20:00:00"));
             retriever.GetValue("20:00:01").Should().Be(System.TimeSpan.Parse("20:00:01"));
             retriever.GetValue("00:00:00").Should().Be(System.TimeSpan.Parse("00:00:00"));
-        }
+	        retriever.GetValue("6:12:14:45.3448").Should().Be(System.TimeSpan.Parse("6.12:14:45.3448000"));
+		}
 
-        [Test]
+	    [Test, SetCulture("fr-FR")]
+	    public void Returns_a_timespan_when_passed_a_parsable_string_representation_of_a_timespan_and_culture_is_fr_FR()
+	    {
+		    var retriever = new TimeSpanValueRetriever();
+		    retriever.GetValue("6:12:14:45,3448").Should().Be(System.TimeSpan.Parse("6.12:14:45.3448000"));
+	    }
+
+		[Test]
         public void It_handles_timespans()
         {
             var retriever = new TimeSpanValueRetriever();

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/ValueRetrieverTests/TimeSpanValueRetrieverTests.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/ValueRetrieverTests/TimeSpanValueRetrieverTests.cs
@@ -1,4 +1,6 @@
-﻿using FluentAssertions;
+﻿using System.Globalization;
+using System.Threading;
+using FluentAssertions;
 using NUnit.Framework;
 using TechTalk.SpecFlow.Assist.ValueRetrievers;
 
@@ -7,20 +9,24 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.ValueRetrieverTests
     [TestFixture]
     public class TimespanValueRetrieverTests
     {
-        [Test, SetCulture("en-US")]
+        [Test]
         public void Returns_a_timespan_when_passed_a_parsable_string_representation_of_a_timespan()
-        {
-            var retriever = new TimeSpanValueRetriever();
+		{
+			Thread.CurrentThread.CurrentCulture = new CultureInfo("en-US");
+
+			var retriever = new TimeSpanValueRetriever();
             retriever.GetValue("20:00:00").Should().Be(System.TimeSpan.Parse("20:00:00"));
             retriever.GetValue("20:00:01").Should().Be(System.TimeSpan.Parse("20:00:01"));
             retriever.GetValue("00:00:00").Should().Be(System.TimeSpan.Parse("00:00:00"));
 	        retriever.GetValue("6:12:14:45.3448").Should().Be(System.TimeSpan.Parse("6.12:14:45.3448000"));
 		}
 
-	    [Test, SetCulture("fr-FR")]
+	    [Test]
 	    public void Returns_a_timespan_when_passed_a_parsable_string_representation_of_a_timespan_and_culture_is_fr_FR()
-	    {
-		    var retriever = new TimeSpanValueRetriever();
+		{
+			Thread.CurrentThread.CurrentCulture = new CultureInfo("fr-FR");
+
+			var retriever = new TimeSpanValueRetriever();
 		    retriever.GetValue("6:12:14:45,3448").Should().Be(System.TimeSpan.Parse("6.12:14:45.3448000"));
 	    }
 

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/ValueRetrieverTests/UIntValueRetrieverTests.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/ValueRetrieverTests/UIntValueRetrieverTests.cs
@@ -4,7 +4,7 @@ using TechTalk.SpecFlow.Assist.ValueRetrievers;
 
 namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.ValueRetrieverTests
 {
-    [TestFixture]
+    [TestFixture, SetCulture("en-US")]
     public class UIntValueRetrieverTests
     {
         [Test]
@@ -15,9 +15,20 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.ValueRetrieverTests
             retriever.GetValue("3").Should().Be(3);
             retriever.GetValue("30").Should().Be(30);
             retriever.GetValue("1234567890").Should().Be(1234567890);
-        }
+	        retriever.GetValue("1,234,567,890").Should().Be(1234567890);
+		}
 
-        [Test]
+	    [Test, SetCulture("fr-FR")]
+	    public void Returns_an_unsigned_integer_when_passed_an_unsigned_integer_value_if_fr_FR()
+	    {
+		    var retriever = new UIntValueRetriever();
+		    retriever.GetValue("1").Should().Be(1);
+		    retriever.GetValue("3").Should().Be(3);
+		    retriever.GetValue("30").Should().Be(30);
+		    retriever.GetValue("1234567890").Should().Be(1234567890);
+	    }
+
+		[Test]
         public void Returns_a_zero_when_passed_an_invalid_unsigned_int()
         {
             var retriever = new UIntValueRetriever();

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/ValueRetrieverTests/UIntValueRetrieverTests.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/ValueRetrieverTests/UIntValueRetrieverTests.cs
@@ -1,13 +1,22 @@
+using System.Globalization;
+using System.Threading;
 using FluentAssertions;
 using NUnit.Framework;
 using TechTalk.SpecFlow.Assist.ValueRetrievers;
 
 namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.ValueRetrieverTests
 {
-    [TestFixture, SetCulture("en-US")]
+    [TestFixture]
     public class UIntValueRetrieverTests
-    {
-        [Test]
+	{
+		[SetUp]
+		public void TestSetup()
+		{
+			// this is required, because the tests depend on parsing decimals with the en-US culture
+			Thread.CurrentThread.CurrentCulture = new CultureInfo("en-US");
+		}
+
+		[Test]
         public void Returns_an_unsigned_integer_when_passed_an_unsigned_integer_value()
         {
             var retriever = new UIntValueRetriever();
@@ -18,10 +27,12 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.ValueRetrieverTests
 	        retriever.GetValue("1,234,567,890").Should().Be(1234567890);
 		}
 
-	    [Test, SetCulture("fr-FR")]
+	    [Test]
 	    public void Returns_an_unsigned_integer_when_passed_an_unsigned_integer_value_if_fr_FR()
-	    {
-		    var retriever = new UIntValueRetriever();
+		{
+			Thread.CurrentThread.CurrentCulture = new CultureInfo("fr-FR");
+
+			var retriever = new UIntValueRetriever();
 		    retriever.GetValue("1").Should().Be(1);
 		    retriever.GetValue("3").Should().Be(3);
 		    retriever.GetValue("30").Should().Be(30);

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/ValueRetrieverTests/ULongValueRetrieverTests.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/ValueRetrieverTests/ULongValueRetrieverTests.cs
@@ -1,4 +1,6 @@
-﻿using FluentAssertions;
+﻿using System.Globalization;
+using System.Threading;
+using FluentAssertions;
 using NUnit.Framework;
 using TechTalk.SpecFlow.Assist.ValueRetrievers;
 
@@ -7,10 +9,11 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.ValueRetrieverTests
     [TestFixture]
     public class ULongValueRetrieverTests
     {
-        [Test, SetCulture("en-US")]
+        [Test]
         public void Returns_an_unsigned_long_when_passed_an_unsigned_long_value()
-        {
-            var retriever = new ULongValueRetriever();
+		{
+			Thread.CurrentThread.CurrentCulture = new CultureInfo("en-US");
+			var retriever = new ULongValueRetriever();
             retriever.GetValue("1").Should().Be(1);
             retriever.GetValue("3").Should().Be(3);
             retriever.GetValue("30").Should().Be(30);

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/ValueRetrieverTests/ULongValueRetrieverTests.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/ValueRetrieverTests/ULongValueRetrieverTests.cs
@@ -7,7 +7,7 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.ValueRetrieverTests
     [TestFixture]
     public class ULongValueRetrieverTests
     {
-        [Test]
+        [Test, SetCulture("en-US")]
         public void Returns_an_unsigned_long_when_passed_an_unsigned_long_value()
         {
             var retriever = new ULongValueRetriever();
@@ -15,7 +15,8 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.ValueRetrieverTests
             retriever.GetValue("3").Should().Be(3);
             retriever.GetValue("30").Should().Be(30);
             retriever.GetValue("12345678901234567890").Should().Be(12345678901234567890);
-        }
+	        retriever.GetValue("12,345,678,901,234,567,890").Should().Be(12345678901234567890);
+		}
 
         [Test]
         public void Returns_a_zero_when_passed_an_invalid_unsigned_long()

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/ValueRetrieverTests/UShortValueRetrieverTests.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/ValueRetrieverTests/UShortValueRetrieverTests.cs
@@ -1,13 +1,22 @@
-﻿using FluentAssertions;
+﻿using System.Globalization;
+using System.Threading;
+using FluentAssertions;
 using NUnit.Framework;
 using TechTalk.SpecFlow.Assist.ValueRetrievers;
 
 namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.ValueRetrieverTests
 {
-    [TestFixture, SetCulture("en-US")]
+    [TestFixture]
     public class UShortValueRetrieverTests
-    {
-        [Test]
+	{
+		[SetUp]
+		public void TestSetup()
+		{
+			// this is required, because the tests depend on parsing decimals with the en-US culture
+			Thread.CurrentThread.CurrentCulture = new CultureInfo("en-US");
+		}
+
+		[Test]
         public void Returns_an_unsigned_short_when_passed_an_unsigned_short_value()
         {
             var retriever = new UShortValueRetriever();
@@ -18,10 +27,12 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.ValueRetrieverTests
 	        retriever.GetValue("12,345").Should().Be(12345);
 		}
 
-	    [Test, SetCulture("fr-FR")]
+	    [Test]
 	    public void Returns_an_unsigned_short_when_passed_an_unsigned_short_value_if_culture_is_fr_FR()
-	    {
-		    var retriever = new UShortValueRetriever();
+		{
+			Thread.CurrentThread.CurrentCulture = new CultureInfo("fr-FR");
+
+			var retriever = new UShortValueRetriever();
 		    retriever.GetValue("1").Should().Be(1);
 		    retriever.GetValue("3").Should().Be(3);
 		    retriever.GetValue("30").Should().Be(30);

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/ValueRetrieverTests/UShortValueRetrieverTests.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/ValueRetrieverTests/UShortValueRetrieverTests.cs
@@ -4,7 +4,7 @@ using TechTalk.SpecFlow.Assist.ValueRetrievers;
 
 namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.ValueRetrieverTests
 {
-    [TestFixture]
+    [TestFixture, SetCulture("en-US")]
     public class UShortValueRetrieverTests
     {
         [Test]
@@ -15,9 +15,20 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.ValueRetrieverTests
             retriever.GetValue("3").Should().Be(3);
             retriever.GetValue("30").Should().Be(30);
             retriever.GetValue("12345").Should().Be(12345);
-        }
+	        retriever.GetValue("12,345").Should().Be(12345);
+		}
 
-        [Test]
+	    [Test, SetCulture("fr-FR")]
+	    public void Returns_an_unsigned_short_when_passed_an_unsigned_short_value_if_culture_is_fr_FR()
+	    {
+		    var retriever = new UShortValueRetriever();
+		    retriever.GetValue("1").Should().Be(1);
+		    retriever.GetValue("3").Should().Be(3);
+		    retriever.GetValue("30").Should().Be(30);
+		    retriever.GetValue("12345").Should().Be(12345);
+	    }
+
+		[Test]
         public void Returns_a_zero_when_passed_an_invalid_unsigned_short()
         {
             var retriever = new UShortValueRetriever();


### PR DESCRIPTION
Fixes issue #898

- Updated implementations of IValueRetriever.GetValue to use the current culture when parsing the input value
In some cases (e.g. TimeSpan), the Parse method implicitely uses the current culture when no culture is specified. I specified the current culture anyway to make the implementations consistent.

- Written corresponding unit tests