### PR TITLE
Adjust Plugin Folder Search Order

### DIFF
--- a/TechTalk.SpecFlow.Generator/Plugins/GeneratorPluginLocator.cs
+++ b/TechTalk.SpecFlow.Generator/Plugins/GeneratorPluginLocator.cs
@@ -79,7 +79,14 @@ namespace TechTalk.SpecFlow.Generator.Plugins
         {
             var pluginGeneratorFolders = (new[] { @"" })
                 .Concat(GetSpecFlowVersionSpecifiers().Select(v => @"tools\SpecFlowPlugin" + v))
-                .Concat(new[] { @"tools", @"lib\net45", @"lib\net40", @"lib\net35", @"lib" });
+                .Concat(new[]
+                {
+                    @"lib\net45",
+                    @"lib\net40",
+                    @"lib\net35",
+                    @"lib",
+                    @"tools",
+                });
 
             return GetPluginFolders(pluginDescriptor).SelectMany(pluginFolder => pluginGeneratorFolders, Path.Combine);
         }
@@ -89,7 +96,7 @@ namespace TechTalk.SpecFlow.Generator.Plugins
             if (pluginDescriptor.Path != null)
             {
                 var path = Environment.ExpandEnvironmentVariables(pluginDescriptor.Path);
-                
+
                 yield return Path.IsPathRooted(path)
                     ? path
                     : Path.Combine(projectSettings.ProjectFolder, path);

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 2.3.2
 Fixes:
 + Fix issue when using environment variables in a generator plugin's path https://github.com/techtalk/SpecFlow/pull/1045
++ Adjust order of plugin search paths https://github.com/techtalk/SpecFlow/pull/1086
 
 API Changes:
 + Generator probing functionality was moved from GeneratorPluginLoader to GeneratorPluginLocator https://github.com/techtalk/SpecFlow/pull/1045


### PR DESCRIPTION
having the tools order as first makes problems with plugins, that ships a console program with reference to TechTalk.SpecFlow.dll
it could happen, that the wrong TechTalk.SpecFlow.dll is loaded