### PR TITLE
Fix for issue 936 - make sure container registrations are available in BeforeScenario hooks

### DIFF
--- a/TechTalk.SpecFlow.Generator/TestClassGenerationContext.cs
+++ b/TechTalk.SpecFlow.Generator/TestClassGenerationContext.cs
@@ -19,6 +19,7 @@ namespace TechTalk.SpecFlow.Generator
         public CodeMemberMethod TestInitializeMethod { get; private set; }
         public CodeMemberMethod TestCleanupMethod { get; private set; }
         public CodeMemberMethod ScenarioInitializeMethod { get; private set; }
+        public CodeMemberMethod ScenarioStartMethod { get; private set; }
         public CodeMemberMethod ScenarioCleanupMethod { get; private set; }
         public CodeMemberMethod FeatureBackgroundMethod { get; private set; }
         public CodeMemberField TestRunnerField { get; private set; }
@@ -27,7 +28,21 @@ namespace TechTalk.SpecFlow.Generator
 
         public IDictionary<string, object> CustomData { get; private set; }
 
-        public TestClassGenerationContext(IUnitTestGeneratorProvider unitTestGeneratorProvider, SpecFlowDocument document, CodeNamespace ns, CodeTypeDeclaration testClass, CodeMemberField testRunnerField, CodeMemberMethod testClassInitializeMethod, CodeMemberMethod testClassCleanupMethod, CodeMemberMethod testInitializeMethod, CodeMemberMethod testCleanupMethod, CodeMemberMethod scenarioInitializeMethod, CodeMemberMethod scenarioCleanupMethod, CodeMemberMethod featureBackgroundMethod, bool generateRowTests)
+        public TestClassGenerationContext(
+            IUnitTestGeneratorProvider unitTestGeneratorProvider,
+            SpecFlowDocument document,
+            CodeNamespace ns,
+            CodeTypeDeclaration testClass,
+            CodeMemberField testRunnerField,
+            CodeMemberMethod testClassInitializeMethod,
+            CodeMemberMethod testClassCleanupMethod,
+            CodeMemberMethod testInitializeMethod,
+            CodeMemberMethod testCleanupMethod,
+            CodeMemberMethod scenarioInitializeMethod,
+            CodeMemberMethod scenarioStartMethod,
+            CodeMemberMethod scenarioCleanupMethod,
+            CodeMemberMethod featureBackgroundMethod,
+            bool generateRowTests)
         {
             UnitTestGeneratorProvider = unitTestGeneratorProvider;
             Document = document;
@@ -39,6 +54,7 @@ namespace TechTalk.SpecFlow.Generator
             TestInitializeMethod = testInitializeMethod;
             TestCleanupMethod = testCleanupMethod;
             ScenarioInitializeMethod = scenarioInitializeMethod;
+            ScenarioStartMethod = scenarioStartMethod;
             ScenarioCleanupMethod = scenarioCleanupMethod;
             FeatureBackgroundMethod = featureBackgroundMethod;
             GenerateRowTests = generateRowTests;

--- a/TechTalk.SpecFlow.Generator/UnitTestFeatureGenerator.cs
+++ b/TechTalk.SpecFlow.Generator/UnitTestFeatureGenerator.cs
@@ -7,10 +7,9 @@ using System.Linq;
 using System.Reflection;
 using System.Text.RegularExpressions;
 using Gherkin.Ast;
-using TechTalk.SpecFlow.Configuration;
-using TechTalk.SpecFlow.Generator.Configuration;
 using TechTalk.SpecFlow.Generator.UnitTestConverter;
 using TechTalk.SpecFlow.Generator.UnitTestProvider;
+using TechTalk.SpecFlow.Infrastructure;
 using TechTalk.SpecFlow.Parser;
 using TechTalk.SpecFlow.Tracing;
 using TechTalk.SpecFlow.Utils;
@@ -23,7 +22,8 @@ namespace TechTalk.SpecFlow.Generator
         const string TESTCLASS_NAME_FORMAT = "{0}Feature";
         const string TEST_NAME_FORMAT = "{0}";
         private const string IGNORE_TAG = "@Ignore";
-        private const string SCENARIO_INITIALIZE_NAME = "ScenarioSetup";
+        private const string SCENARIO_INITIALIZE_NAME = "ScenarioInitialize";
+        private const string SCENARIO_START_NAME = "ScenarioStart";
         private const string SCENARIO_CLEANUP_NAME = "ScenarioCleanup";
         private const string TEST_INITIALIZE_NAME = "TestInitialize";
         private const string TEST_CLEANUP_NAME = "ScenarioTearDown";
@@ -76,8 +76,9 @@ namespace TechTalk.SpecFlow.Generator
                 CreateMethod(testClass),
                 CreateMethod(testClass),
                 CreateMethod(testClass),
+                CreateMethod(testClass),
                 HasFeatureBackground(document.SpecFlowFeature) ? CreateMethod(testClass) : null,
-                generateRowTests: testGeneratorProvider.GetTraits().HasFlag(UnitTestGeneratorTraits.RowTests) && _specFlowConfiguration.AllowRowTests);
+                testGeneratorProvider.GetTraits().HasFlag(UnitTestGeneratorTraits.RowTests) && _specFlowConfiguration.AllowRowTests);
         }
 
         private CodeNamespace CreateNamespace(string targetNamespace)
@@ -102,7 +103,7 @@ namespace TechTalk.SpecFlow.Generator
 
         public CodeNamespace GenerateUnitTestFixture(SpecFlowDocument document, string testClassName, string targetNamespace)
         {
-            CodeNamespace codeNamespace = CreateNamespace(targetNamespace);
+            var codeNamespace = CreateNamespace(targetNamespace);
             var feature = document.SpecFlowFeature;
 
             testClassName = testClassName ?? string.Format(TESTCLASS_NAME_FORMAT, feature.Name.ToIdentifier());
@@ -113,12 +114,12 @@ namespace TechTalk.SpecFlow.Generator
             SetupTestClassCleanupMethod(generationContext);
 
             SetupScenarioInitializeMethod(generationContext);
+            SetupScenarioStartMethod(generationContext);
             SetupFeatureBackground(generationContext);
             SetupScenarioCleanupMethod(generationContext);
 
             SetupTestInitializeMethod(generationContext);
             SetupTestCleanupMethod(generationContext);
-
 
             foreach (var scenarioDefinition in feature.ScenarioDefinitions)
             {
@@ -132,7 +133,7 @@ namespace TechTalk.SpecFlow.Generator
                     GenerateTest(generationContext, (Scenario)scenarioDefinition);
             }
 
-            //before return the generated code, call generate provider's method in case the provider want to customerize the generated code            
+            //before returning the generated code, call the provider's method in case the generated code needs to be customized            
             testGeneratorProvider.FinalizeTestClass(generationContext);
             return codeNamespace;
         }
@@ -299,20 +300,35 @@ namespace TechTalk.SpecFlow.Generator
 
         private void SetupScenarioInitializeMethod(TestClassGenerationContext generationContext)
         {
-            CodeMemberMethod scenarioInitializeMethod = generationContext.ScenarioInitializeMethod;
+            var scenarioInitializeMethod = generationContext.ScenarioInitializeMethod;
 
             scenarioInitializeMethod.Attributes = MemberAttributes.Public;
             scenarioInitializeMethod.Name = SCENARIO_INITIALIZE_NAME;
             scenarioInitializeMethod.Parameters.Add(
                 new CodeParameterDeclarationExpression(typeof(ScenarioInfo), "scenarioInfo"));
 
-            //testRunner.OnScenarioStart(scenarioInfo);
+            //testRunner.OnScenarioInitialize(scenarioInfo);
             var testRunnerField = GetTestRunnerExpression();
             scenarioInitializeMethod.Statements.Add(
                 new CodeMethodInvokeExpression(
                     testRunnerField,
-                    "OnScenarioStart",
+                    nameof(ITestExecutionEngine.OnScenarioInitialize),
                     new CodeVariableReferenceExpression("scenarioInfo")));
+        }
+
+        private void SetupScenarioStartMethod(TestClassGenerationContext generationContext)
+        {
+            var scenarioStartMethod = generationContext.ScenarioStartMethod;
+
+            scenarioStartMethod.Attributes = MemberAttributes.Public;
+            scenarioStartMethod.Name = SCENARIO_START_NAME;           
+
+            //testRunner.OnScenarioStart();
+            var testRunnerField = GetTestRunnerExpression();
+            scenarioStartMethod.Statements.Add(
+                new CodeMethodInvokeExpression(
+                    testRunnerField,
+                    nameof(ITestExecutionEngine.OnScenarioStart)));
         }
 
         private void SetupFeatureBackground(TestClassGenerationContext generationContext)
@@ -548,6 +564,11 @@ namespace TechTalk.SpecFlow.Generator
                     new CodeThisReferenceExpression(),
                     generationContext.ScenarioInitializeMethod.Name,
                     new CodeVariableReferenceExpression("scenarioInfo")));
+
+            testMethod.Statements.Add(
+                new CodeMethodInvokeExpression(
+                    new CodeThisReferenceExpression(),
+                    generationContext.ScenarioStartMethod.Name));
 
             if (HasFeatureBackground(generationContext.Feature))
             {

--- a/TechTalk.SpecFlow.Generator/UnitTestProvider/MsTestGeneratorProvider.cs
+++ b/TechTalk.SpecFlow.Generator/UnitTestProvider/MsTestGeneratorProvider.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.CodeDom;
 using System.Collections.Generic;
-using System.Linq;
+using BoDi;
 using TechTalk.SpecFlow.Utils;
 
 namespace TechTalk.SpecFlow.Generator.UnitTestProvider
@@ -82,25 +82,24 @@ namespace TechTalk.SpecFlow.Generator.UnitTestProvider
 
         public virtual void FinalizeTestClass(TestClassGenerationContext generationContext)
         {
-            // testRunner.ScenarioContext.ScenarioContainer.RegisterInstanceAs<TestContext>(TestContext);
+            // testRunner.ScenarioContext.ScenarioContainer.RegisterInstanceAs<TestContext>(_testContext);
             generationContext.ScenarioInitializeMethod.Statements.Add(
                 new CodeMethodInvokeExpression(
                     new CodeMethodReferenceExpression(
                         new CodePropertyReferenceExpression(
                             new CodePropertyReferenceExpression(
                                 new CodeFieldReferenceExpression(null, generationContext.TestRunnerField.Name),
-                                "ScenarioContext"),
-                            "ScenarioContainer"),
-                        "RegisterInstanceAs",
+                                nameof(ScenarioContext)),
+                            nameof(ScenarioContext.ScenarioContainer)),
+                        nameof(IObjectContainer.RegisterInstanceAs),
                         new CodeTypeReference(TESTCONTEXT_TYPE)),
-                    new CodeVariableReferenceExpression(TESTCONTEXT_PROPERTY_NAME)));
+                    new CodeVariableReferenceExpression(TESTCONTEXT_FIELD_NAME)));
         }
 
         public void SetTestClassParallelize(TestClassGenerationContext generationContext)
         {
             //Not Supported
         }
-
 
         public virtual void SetTestClassInitializeMethod(TestClassGenerationContext generationContext)
         {
@@ -200,7 +199,6 @@ namespace TechTalk.SpecFlow.Generator.UnitTestProvider
             //MsTest does not support row tests... :(
             throw new NotSupportedException();
         }
-
 
         public virtual void SetTestMethodAsRow(TestClassGenerationContext generationContext, CodeMemberMethod testMethod, string scenarioTitle, string exampleSetName, string variantName, IEnumerable<KeyValuePair<string, string>> arguments)
         {

--- a/TechTalk.SpecFlow.Generator/UnitTestProvider/XUnit2TestGeneratorProvider.cs
+++ b/TechTalk.SpecFlow.Generator/UnitTestProvider/XUnit2TestGeneratorProvider.cs
@@ -2,26 +2,22 @@ using System;
 using System.CodeDom;
 using System.Collections.Generic;
 using System.Linq;
+using BoDi;
 using TechTalk.SpecFlow.Utils;
 
 namespace TechTalk.SpecFlow.Generator.UnitTestProvider
 {
     public class XUnit2TestGeneratorProvider : XUnitTestGeneratorProvider
     {
-        private const string FEATURE_TITLE_PROPERTY_NAME = "FeatureTitle";
-        private const string FACT_ATTRIBUTE = "Xunit.FactAttribute";
-        private const string FACT_ATTRIBUTE_SKIP_PROPERTY_NAME = "Skip";
-        private const string THEORY_ATTRIBUTE = "Xunit.TheoryAttribute";
-        private const string THEORY_ATTRIBUTE_SKIP_PROPERTY_NAME = "Skip";
+        private new const string THEORY_ATTRIBUTE = "Xunit.TheoryAttribute";
         private const string INLINEDATA_ATTRIBUTE = "Xunit.InlineDataAttribute";
-        private const string SKIP_REASON = "Ignored";
         private const string ICLASSFIXTURE_INTERFACE = "Xunit.IClassFixture";
         private const string COLLECTION_ATTRIBUTE = "Xunit.CollectionAttribute";
         private const string OUTPUT_INTERFACE = "Xunit.Abstractions.ITestOutputHelper";
         private const string OUTPUT_INTERFACE_PARAMETER_NAME = "testOutputHelper";
         private const string OUTPUT_INTERFACE_FIELD_NAME = "_testOutputHelper";
         private const string FIXTUREDATA_PARAMETER_NAME = "fixtureData";
-
+        
         public XUnit2TestGeneratorProvider(CodeDomHelper codeDomHelper)
             :base(codeDomHelper)
         {
@@ -62,7 +58,7 @@ namespace TechTalk.SpecFlow.Generator.UnitTestProvider
                 return;
 
             var args = arguments.Select(
-              arg => new CodeAttributeArgument(new CodePrimitiveExpression(arg))).ToList();
+                arg => new CodeAttributeArgument(new CodePrimitiveExpression(arg))).ToList();
 
             args.Add(
                 new CodeAttributeArgument(
@@ -128,9 +124,9 @@ namespace TechTalk.SpecFlow.Generator.UnitTestProvider
                         new CodePropertyReferenceExpression(
                             new CodePropertyReferenceExpression(
                                 new CodeFieldReferenceExpression(null, generationContext.TestRunnerField.Name),
-                                "ScenarioContext"),
-                            "ScenarioContainer"),
-                        "RegisterInstanceAs",
+                                nameof(ScenarioContext)),
+                            nameof(ScenarioContext.ScenarioContainer)),
+                        nameof(IObjectContainer.RegisterInstanceAs),
                         new CodeTypeReference(OUTPUT_INTERFACE)),
                     new CodeVariableReferenceExpression(OUTPUT_INTERFACE_FIELD_NAME)));
         }

--- a/TechTalk.SpecFlow.Generator/UnitTestProvider/XUnitTestGeneratorProvider.cs
+++ b/TechTalk.SpecFlow.Generator/UnitTestProvider/XUnitTestGeneratorProvider.cs
@@ -8,10 +8,10 @@ namespace TechTalk.SpecFlow.Generator.UnitTestProvider
 {
     public class XUnitTestGeneratorProvider : IUnitTestGeneratorProvider
     {
-        private const string FEATURE_TITLE_PROPERTY_NAME = "FeatureTitle";
+        protected const string FEATURE_TITLE_PROPERTY_NAME = "FeatureTitle";
         private const string DESCRIPTION_PROPERTY_NAME = "Description";
-        private const string FACT_ATTRIBUTE = "Xunit.FactAttribute";
-        private const string FACT_ATTRIBUTE_SKIP_PROPERTY_NAME = "Skip";
+        protected const string FACT_ATTRIBUTE = "Xunit.FactAttribute";
+        protected const string FACT_ATTRIBUTE_SKIP_PROPERTY_NAME = "Skip";
         internal const string THEORY_ATTRIBUTE = "Xunit.Extensions.TheoryAttribute";
         internal const string THEORY_ATTRIBUTE_SKIP_PROPERTY_NAME = "Skip";
         private const string INLINEDATA_ATTRIBUTE = "Xunit.Extensions.InlineDataAttribute";

--- a/TechTalk.SpecFlow/ITestRunner.cs
+++ b/TechTalk.SpecFlow/ITestRunner.cs
@@ -1,6 +1,3 @@
-using System;
-using TechTalk.SpecFlow.Infrastructure;
-
 namespace TechTalk.SpecFlow
 {
     public interface ITestRunner
@@ -16,7 +13,10 @@ namespace TechTalk.SpecFlow
 
         void OnFeatureStart(FeatureInfo featureInfo);
         void OnFeatureEnd();
-        void OnScenarioStart(ScenarioInfo scenarioInfo);
+
+        void OnScenarioInitialize(ScenarioInfo scenarioInfo);
+        void OnScenarioStart();
+
         void CollectScenarioErrors();
         void OnScenarioEnd();
 

--- a/TechTalk.SpecFlow/Infrastructure/ITestExecutionEngine.cs
+++ b/TechTalk.SpecFlow/Infrastructure/ITestExecutionEngine.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Linq;
-using TechTalk.SpecFlow.Bindings;
+﻿using TechTalk.SpecFlow.Bindings;
 
 namespace TechTalk.SpecFlow.Infrastructure
 {
@@ -15,7 +13,8 @@ namespace TechTalk.SpecFlow.Infrastructure
         void OnFeatureStart(FeatureInfo featureInfo);
         void OnFeatureEnd();
 
-        void OnScenarioStart(ScenarioInfo scenarioInfo);
+        void OnScenarioInitialize(ScenarioInfo scenarioInfo);
+        void OnScenarioStart();
         void OnAfterLastStep();
         void OnScenarioEnd();
 

--- a/TechTalk.SpecFlow/Infrastructure/TestExecutionEngine.cs
+++ b/TechTalk.SpecFlow/Infrastructure/TestExecutionEngine.cs
@@ -8,7 +8,6 @@ using TechTalk.SpecFlow.BindingSkeletons;
 using TechTalk.SpecFlow.Bindings;
 using TechTalk.SpecFlow.Bindings.Reflection;
 using TechTalk.SpecFlow.Compatibility;
-using TechTalk.SpecFlow.Configuration;
 using TechTalk.SpecFlow.ErrorHandling;
 using TechTalk.SpecFlow.Tracing;
 using TechTalk.SpecFlow.UnitTestProvider;
@@ -123,9 +122,13 @@ namespace TechTalk.SpecFlow.Infrastructure
             contextManager.CleanupFeatureContext();
         }
 
-        public void OnScenarioStart(ScenarioInfo scenarioInfo)
+        public void OnScenarioInitialize(ScenarioInfo scenarioInfo)
         {
             contextManager.InitializeScenarioContext(scenarioInfo);
+        }
+
+        public void OnScenarioStart()
+        {
             FireScenarioEvents(HookType.BeforeScenario);
         }
 

--- a/TechTalk.SpecFlow/TestRunner.cs
+++ b/TechTalk.SpecFlow/TestRunner.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Linq;
-using TechTalk.SpecFlow.Bindings;
+﻿using TechTalk.SpecFlow.Bindings;
 using TechTalk.SpecFlow.Infrastructure;
 
 namespace TechTalk.SpecFlow
@@ -46,9 +44,14 @@ namespace TechTalk.SpecFlow
             executionEngine.OnFeatureEnd();
         }
 
-        public void OnScenarioStart(ScenarioInfo scenarioInfo)
+        public void OnScenarioInitialize(ScenarioInfo scenarioInfo)
         {
-            executionEngine.OnScenarioStart(scenarioInfo);
+            executionEngine.OnScenarioInitialize(scenarioInfo);
+        }
+
+        public void OnScenarioStart()
+        {
+            executionEngine.OnScenarioStart();
         }
 
         public void CollectScenarioErrors()

--- a/Tests/TechTalk.SpecFlow.GeneratorTests/DecoratorRegistryTests.cs
+++ b/Tests/TechTalk.SpecFlow.GeneratorTests/DecoratorRegistryTests.cs
@@ -1,7 +1,5 @@
-﻿using System;
-using System.CodeDom;
+﻿using System.CodeDom;
 using System.Collections.Generic;
-using System.Linq;
 using BoDi;
 using Moq;
 using NUnit.Framework;
@@ -72,7 +70,7 @@ namespace TechTalk.SpecFlow.GeneratorTests
 
         private static TestClassGenerationContext CreateGenerationContext(string tag)
         {
-            return new TestClassGenerationContext(null, ParserHelper.CreateAnyDocument(new []{ tag }), null, null, null, null, null, null, null, null, null, null, true);
+            return new TestClassGenerationContext(null, ParserHelper.CreateAnyDocument(new []{ tag }), null, null, null, null, null, null, null, null, null, null, null, true);
         }
 
         [Test]

--- a/Tests/TechTalk.SpecFlow.GeneratorTests/MsTestGeneratorProviderTests.cs
+++ b/Tests/TechTalk.SpecFlow.GeneratorTests/MsTestGeneratorProviderTests.cs
@@ -4,8 +4,6 @@ using System.IO;
 using System.Linq;
 using FluentAssertions;
 using NUnit.Framework;
-using TechTalk.SpecFlow.Generator;
-using TechTalk.SpecFlow.Generator.Configuration;
 using TechTalk.SpecFlow.Generator.UnitTestProvider;
 using TechTalk.SpecFlow.Parser;
 using TechTalk.SpecFlow.Utils;

--- a/Tests/TechTalk.SpecFlow.GeneratorTests/XUnit2TestGeneratorProviderTests.cs
+++ b/Tests/TechTalk.SpecFlow.GeneratorTests/XUnit2TestGeneratorProviderTests.cs
@@ -2,14 +2,11 @@
 using System.Globalization;
 using System.IO;
 using System.Linq;
-
 using NUnit.Framework;
 using Microsoft.CSharp;
-
 using TechTalk.SpecFlow.Utils;
 using TechTalk.SpecFlow.Parser;
 using TechTalk.SpecFlow.Generator.UnitTestProvider;
-
 using FluentAssertions;
 
 namespace TechTalk.SpecFlow.GeneratorTests
@@ -53,6 +50,7 @@ namespace TechTalk.SpecFlow.GeneratorTests
                 testInitializeMethod: null,
                 testCleanupMethod: null,
                 scenarioInitializeMethod: null,
+                scenarioStartMethod:null,
                 scenarioCleanupMethod: null,
                 featureBackgroundMethod: null,
                 generateRowTests: false);
@@ -123,35 +121,5 @@ namespace TechTalk.SpecFlow.GeneratorTests
                 loggerInstance.Attributes.Should().Be(MemberAttributes.Private | MemberAttributes.Final);
             }
         }
-
-        [Test]
-        public void Should_register_testOutputHelper_on_scenario_setup()
-        {
-            SpecFlowGherkinParser parser = new SpecFlowGherkinParser(new CultureInfo("en-US"));
-            using (var reader = new StringReader(SampleFeatureFile))
-            {
-                SpecFlowDocument document = parser.Parse(reader, null);
-                Assert.IsNotNull(document);
-
-                var provider = new XUnit2TestGeneratorProvider(new CodeDomHelper(CodeDomProviderLanguage.CSharp));
-
-                var converter = provider.CreateUnitTestConverter();
-                CodeNamespace code = converter.GenerateUnitTestFixture(document, "TestClassName", "Target.Namespace");
-
-                Assert.IsNotNull(code);
-                var scenarioStartMethod = code.Class().Members().Single(m => m.Name == @"ScenarioSetup");
-
-                scenarioStartMethod.Statements.Count.Should().Be(2);
-                var expression = (scenarioStartMethod.Statements[1] as CodeExpressionStatement).Expression;
-                var method = (expression as CodeMethodInvokeExpression).Method;
-                (method.TargetObject as CodePropertyReferenceExpression).PropertyName.Should().Be("ScenarioContainer");
-                method.MethodName.Should().Be("RegisterInstanceAs");
-                method.TypeArguments.Should().NotBeNullOrEmpty();
-                method.TypeArguments[0].BaseType.Should().Be("Xunit.Abstractions.ITestOutputHelper");
-
-                ((expression as CodeMethodInvokeExpression).Parameters[0] as CodeVariableReferenceExpression).VariableName.Should().Be("_testOutputHelper");
-            }
-        }
-
     }
 }

--- a/Tests/TechTalk.SpecFlow.GeneratorTests/XUnitTestGeneratorProviderTests.cs
+++ b/Tests/TechTalk.SpecFlow.GeneratorTests/XUnitTestGeneratorProviderTests.cs
@@ -1,11 +1,7 @@
-﻿using System;
-using System.CodeDom;
+﻿using System.CodeDom;
 using System.Linq;
-using Gherkin.Ast;
 using Microsoft.CSharp;
-
 using NUnit.Framework;
-
 using TechTalk.SpecFlow.Generator.UnitTestProvider;
 using TechTalk.SpecFlow.Parser;
 using TechTalk.SpecFlow.Utils;
@@ -75,6 +71,7 @@ namespace TechTalk.SpecFlow.GeneratorTests
                 testInitializeMethod: null,
                 testCleanupMethod: null,
                 scenarioInitializeMethod: null,
+                scenarioStartMethod: null,
                 scenarioCleanupMethod: null,
                 featureBackgroundMethod: null,
                 generateRowTests: false);

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/Infrastructure/TestExecutionEngineTests.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/Infrastructure/TestExecutionEngineTests.cs
@@ -14,7 +14,6 @@ using TechTalk.SpecFlow.Infrastructure;
 using TechTalk.SpecFlow.Tracing;
 using TechTalk.SpecFlow.UnitTestProvider;
 using FluentAssertions;
-using ScenarioExecutionStatus = TechTalk.SpecFlow.ScenarioExecutionStatus;
 
 namespace TechTalk.SpecFlow.RuntimeTests.Infrastructure
 {
@@ -50,6 +49,17 @@ namespace TechTalk.SpecFlow.RuntimeTests.Infrastructure
         private List<IHookBinding> afterTestRunEvents;
         private List<IHookBinding> beforeScenarioBlockEvents;
         private List<IHookBinding> afterScenarioBlockEvents;
+
+        class DummyClass
+        {
+            public static DummyClass LastInstance = null;
+            public DummyClass()
+            {
+                LastInstance = this;
+            }
+        }
+
+        class AnotherDummyClass { }
 
         [SetUp]
         public void Setup()
@@ -159,7 +169,6 @@ namespace TechTalk.SpecFlow.RuntimeTests.Infrastructure
             return stepDefStub;
         }
 
-
         private void RegisterFailingStepDefinition()
         {
             var stepDefStub = RegisterStepDefinition();
@@ -183,6 +192,14 @@ namespace TechTalk.SpecFlow.RuntimeTests.Infrastructure
                 RuntimeBindingType.Void);
             hookMock.Setup(h => h.Method).Returns(bindingMethod);
             return hookMock;
+        }
+
+        private void AssertHooksWasCalledWithParam(Mock<IHookBinding> hookMock, object paramObj)
+        {
+            TimeSpan duration;
+            methodBindingInvokerMock.Verify(i => i.InvokeBinding(hookMock.Object, contextManagerStub.Object,
+                It.Is((object[] args) => args != null && args.Length > 0 && args.Any(arg => arg == paramObj)),
+                testTracerStub.Object, out duration), Times.Once());
         }
 
         [Test]
@@ -360,31 +377,6 @@ namespace TechTalk.SpecFlow.RuntimeTests.Infrastructure
             methodBindingInvokerMock.Verify(i => i.InvokeBinding(afterStepMock.Object, contextManagerStub.Object, null, testTracerStub.Object, out duration), Times.Never());
         }
 
-        class DummyClass
-        {
-            public static DummyClass LastInstance = null;
-            public DummyClass()
-            {
-                LastInstance = this;
-            }
-        }
-
-        private void AssertHooksWasCalledWithParam(Mock<IHookBinding> hookMock, Type paramType)
-        {
-            TimeSpan duration;
-            methodBindingInvokerMock.Verify(i => i.InvokeBinding(hookMock.Object, contextManagerStub.Object,
-                It.Is((object[] args) => args != null && args.Length == 1 && paramType.IsInstanceOfType(args[0])),
-                testTracerStub.Object, out duration), Times.Once());
-        }
-
-        private void AssertHooksWasCalledWithParam(Mock<IHookBinding> hookMock, object paramObj)
-        {
-            TimeSpan duration;
-            methodBindingInvokerMock.Verify(i => i.InvokeBinding(hookMock.Object, contextManagerStub.Object,
-                It.Is((object[] args) => args != null && args.Length > 0 && args.Any(arg => arg == paramObj)),
-                testTracerStub.Object, out duration), Times.Once());
-        }
-
         [Test]
         public void Should_resolve_FeautreContext_hook_parameter()
         {
@@ -462,13 +454,37 @@ namespace TechTalk.SpecFlow.RuntimeTests.Infrastructure
             var beforeHook = CreateParametrizedHookMock(beforeScenarioEvents, typeof(DummyClass));
             var afterHook = CreateParametrizedHookMock(afterScenarioEvents, typeof(DummyClass));
 
-            testExecutionEngine.OnScenarioStart(scenarioInfo);
+            testExecutionEngine.OnScenarioInitialize(scenarioInfo);
+            testExecutionEngine.OnScenarioStart();
             testExecutionEngine.OnScenarioEnd();
 
             AssertHooksWasCalledWithParam(beforeHook, DummyClass.LastInstance);
             AssertHooksWasCalledWithParam(afterHook, DummyClass.LastInstance);
             testObjectResolverMock.Verify(bir => bir.ResolveBindingInstance(typeof(DummyClass), scenarioContainer),
                 Times.Exactly(2));
+        }
+
+        [Test]
+        public void Should_be_possible_to_register_instance_in_scenario_container_before_firing_scenario_events()
+        {
+            var testExecutionEngine = CreateTestExecutionEngine();
+            var instanceToAddBeforeScenarioEventFiring = new AnotherDummyClass();
+            var beforeHook = CreateParametrizedHookMock(beforeScenarioEvents, typeof(DummyClass));
+
+            // Setup binding method mock so it attempts to resolve an instance from the scenario container.
+            // If this fails, then the instance was not registered before the method was invoked.
+            TimeSpan dummyOutTimeSpan;
+            AnotherDummyClass actualInstance = null;
+            methodBindingInvokerMock.Setup(s => s.InvokeBinding(It.IsAny<IBinding>(), It.IsAny<IContextManager>(), 
+                    It.IsAny<object[]>(),It.IsAny<ITestTracer>(), out dummyOutTimeSpan))
+                .Callback(() => actualInstance = testExecutionEngine.ScenarioContext.ScenarioContainer.Resolve<AnotherDummyClass>());
+
+            testExecutionEngine.OnScenarioInitialize(scenarioInfo);
+            testExecutionEngine.ScenarioContext.ScenarioContainer.RegisterInstanceAs(instanceToAddBeforeScenarioEventFiring);
+            testExecutionEngine.OnScenarioStart();
+            actualInstance.Should().BeSameAs(instanceToAddBeforeScenarioEventFiring);
+
+            AssertHooksWasCalledWithParam(beforeHook, DummyClass.LastInstance);
         }
 
         [Test]

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/TestRunnerManagerRunnerCreationTests.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/TestRunnerManagerRunnerCreationTests.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Globalization;
-using System.Linq;
+﻿using System.Globalization;
 using System.Reflection;
 using BoDi;
 using FluentAssertions;
@@ -20,7 +18,7 @@ namespace TechTalk.SpecFlow.RuntimeTests
         private readonly Mock<ITestRunner> testRunnerFake = new Mock<ITestRunner>();
         private readonly Mock<IObjectContainer> objectContainerStub = new Mock<IObjectContainer>();
         private readonly Mock<IObjectContainer> globalObjectContainerStub = new Mock<IObjectContainer>();
-        private readonly SpecFlow.Configuration.SpecFlowConfiguration _specFlowConfigurationStub = ConfigurationLoader.GetDefault();
+        private readonly SpecFlowConfiguration _specFlowConfigurationStub = ConfigurationLoader.GetDefault();
         private readonly Assembly anAssembly = Assembly.GetExecutingAssembly();
         private readonly Assembly anotherAssembly = typeof(TestRunnerManager).Assembly;
 
@@ -92,18 +90,18 @@ namespace TechTalk.SpecFlow.RuntimeTests
             {
                 var testRunner1 = TestRunnerManager.GetTestRunner(anAssembly, 0);
                 testRunner1.OnFeatureStart(new FeatureInfo(new CultureInfo("en-US"), "sds", "sss"));
-                testRunner1.OnScenarioStart(new ScenarioInfo("foo", "foo_desc"));
+                testRunner1.OnScenarioInitialize(new ScenarioInfo("foo", "foo_desc"));
+                testRunner1.OnScenarioStart();
                 var tracer1 = testRunner1.ScenarioContext.ScenarioContainer.Resolve<ITestTracer>();
 
                 var testRunner2 = TestRunnerManager.GetTestRunner(anAssembly, 1);
                 testRunner2.OnFeatureStart(new FeatureInfo(new CultureInfo("en-US"), "sds", "sss"));
-                testRunner2.OnScenarioStart(new ScenarioInfo("foo", "foo_desc"));
+                testRunner2.OnScenarioInitialize(new ScenarioInfo("foo", "foo_desc"));
+                testRunner1.OnScenarioStart();
                 var tracer2 = testRunner2.ScenarioContext.ScenarioContainer.Resolve<ITestTracer>();
 
                 tracer1.Should().NotBeSameAs(tracer2);
-            }
-            
+            }       
         }
     }
-
 }

--- a/Tests/TechTalk.SpecFlow.Specs/Features/MsTestProvider.feature
+++ b/Tests/TechTalk.SpecFlow.Specs/Features/MsTestProvider.feature
@@ -2,181 +2,219 @@
 Feature: MsTest unit test provider
 
 Scenario Outline: Should be able to execute scenarios with basic results
-	Given there is a SpecFlow project
-	And the project is configured to use the MsTest provider
-	And a scenario 'Simple Scenario' as
-		"""
-		When I do something
-		"""
-	And all steps are bound and <step definition status>
-	When I execute the tests with MsTest
-	Then the execution summary should contain
-		| Total | <result> |
-		| 1     | 1        |
+    Given there is a SpecFlow project
+    And the project is configured to use the MsTest provider
+    And a scenario 'Simple Scenario' as
+        """
+        When I do something
+        """
+    And all steps are bound and <step definition status>
+    When I execute the tests with MsTest
+    Then the execution summary should contain
+        | Total | <result> |
+        | 1     | 1        |
 
 Examples: 
-	| result    | step definition status |
-	| Succeeded | pass                   |
-	| Failed    | fail                   |
+    | result    | step definition status |
+    | Succeeded | pass                   |
+    | Failed    | fail                   |
 
 Scenario: Should handle scenario outlines
-	Given there is a SpecFlow project
-	And the project is configured to use the MsTest provider
-	Given there is a feature file in the project as
-		"""
-			Feature: Simple Feature
-			Scenario Outline: Simple Scenario Outline
-				Given there is something
-				When I do <what>
-				Then something should happen
-			Examples: 
-				| what           |
-				| something      |
-				| something else |
-		"""
-	And all steps are bound and pass
-	When I execute the tests with MsTest
-	Then the execution summary should contain
-		| Succeeded |
-		| 2         |
+    Given there is a SpecFlow project
+    And the project is configured to use the MsTest provider
+    Given there is a feature file in the project as
+        """
+            Feature: Simple Feature
+            Scenario Outline: Simple Scenario Outline
+                Given there is something
+                When I do <what>
+                Then something should happen
+            Examples: 
+                | what           |
+                | something      |
+                | something else |
+        """
+    And all steps are bound and pass
+    When I execute the tests with MsTest
+    Then the execution summary should contain
+        | Succeeded |
+        | 2         |
 
 Scenario: Should be able to access TestContext in Steps
-Given there is a SpecFlow project
-And the project is configured to use the MsTest provider
-And a scenario 'Simple Scenario' as
-		"""
-		When I do something
-		"""	
-And the following step definition
-         """
-         [When(@"I do something")]
-		 public void WhenIDoSomething()
-		 {
-			System.Console.WriteLine(ScenarioContext.Current.ScenarioContainer.Resolve<Microsoft.VisualStudio.TestTools.UnitTesting.TestContext>().TestName);
-		 }
-         """
-		 When I execute the tests with MsTest
-	Then the execution summary should contain
-		| Succeeded |
-		| 1         |
+    Given there is a SpecFlow project
+    And the project is configured to use the MsTest provider
+    And a scenario 'Simple Scenario' as
+        """
+        When I do something
+        """	
+    And the following step definition
+        """
+        [When(@"I do something")]
+        public void WhenIDoSomething()
+        {
+            System.Console.WriteLine(ScenarioContext.Current.ScenarioContainer.Resolve<Microsoft.VisualStudio.TestTools.UnitTesting.TestContext>().TestName);
+        }
+        """
+    When I execute the tests with MsTest
+    Then the execution summary should contain
+        | Succeeded |
+        | 1         |
 
 @config
 Scenario: Should be able to specify MsTest provider in the configuration
-	Given there is a SpecFlow project
-	And a scenario 'Simple Scenario' as
-		"""
-		When I do something
-		"""
-	And all steps are bound and pass
-	And the specflow configuration is
-		"""
-		<specFlow>
-			<unitTestProvider name="MsTest"/>
-		</specFlow>
-		"""
-	When I execute the tests with MsTest
-	Then the execution summary should contain
-		| Total | 
-		| 1     | 
-	
+    Given there is a SpecFlow project
+    And a scenario 'Simple Scenario' as
+        """
+        When I do something
+        """
+    And all steps are bound and pass
+    And the specflow configuration is
+        """
+        <specFlow>
+            <unitTestProvider name="MsTest"/>
+        </specFlow>
+        """
+    When I execute the tests with MsTest
+    Then the execution summary should contain
+        | Total | 
+        | 1     | 
+    
 @config
 Scenario: Should be able to deploy files
     Given there is a SpecFlow project
-	And the following binding class
+    And the following binding class
         """
-		using Microsoft.VisualStudio.TestTools.UnitTesting;
+        using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-		[Binding]
-		public class DeploymentItemSteps
-		{
-			[Then(@"the file '(.*)' exists")]
-			public void ThenTheFileExists(string fileName)
-			{
-			    Assert.IsTrue(File.Exists(fileName));
-			}
-		}
+        [Binding]
+        public class DeploymentItemSteps
+        {
+            [Then(@"the file '(.*)' exists")]
+            public void ThenTheFileExists(string fileName)
+            {
+                Assert.IsTrue(File.Exists(fileName));
+            }
+        }
         """
-	And there is a feature file in the project as
+    And there is a feature file in the project as
          """
-		 @MsTest:DeploymentItem:DeploymentItemTestFile.txt
-		 Feature: Deployment Item Feature
-	
-		 Scenario: Deployment Item Scenario
-			Then the file 'DeploymentItemTestFile.txt' exists
+         @MsTest:DeploymentItem:DeploymentItemTestFile.txt
+         Feature: Deployment Item Feature
+    
+         Scenario: Deployment Item Scenario
+            Then the file 'DeploymentItemTestFile.txt' exists
          """
-	And there is a content file 'DeploymentItemTestFile.txt' in the project as
-		"""
-		This is a deployment item file
-		"""
-	And the specflow configuration is
-		"""
-		<specFlow>
-			<unitTestProvider name="MsTest"/>
-		</specFlow>
-		"""
-	And there is a test settings file 'Local.testsettings'
-		"""
-		<?xml version="1.0" encoding="UTF-8"?>
-		<TestSettings
-		  id="b8f2810b-cd53-4519-8b18-d0e599219d54"
-		  name="Local"
-		  enableDefaultDataCollectors="false"
-		  xmlns="http://microsoft.com/schemas/VisualStudio/TeamTest/2010">
-		  <Deployment enabled="true" />
-		</TestSettings>
-		"""
-	When I execute the tests with MsTest
-	Then the execution summary should contain
-         | Succeeded |
-         | 1         |
+    And there is a content file 'DeploymentItemTestFile.txt' in the project as
+        """
+        This is a deployment item file
+        """
+    And the specflow configuration is
+        """
+        <specFlow>
+            <unitTestProvider name="MsTest"/>
+        </specFlow>
+        """
+    And there is a test settings file 'Local.testsettings'
+        """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <TestSettings
+          id="b8f2810b-cd53-4519-8b18-d0e599219d54"
+          name="Local"
+          enableDefaultDataCollectors="false"
+          xmlns="http://microsoft.com/schemas/VisualStudio/TeamTest/2010">
+          <Deployment enabled="true" />
+        </TestSettings>
+        """
+    When I execute the tests with MsTest
+    Then the execution summary should contain
+        | Succeeded |
+        | 1         |
 
 @config
 Scenario: Should be able to deploy files to specific folder
     Given there is a SpecFlow project
-	And the following binding class
+    And the following binding class
         """
-		using Microsoft.VisualStudio.TestTools.UnitTesting;
+        using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-		[Binding]
-		public class DeploymentItemSteps
-		{
-			[Then(@"the file '(.*)' exists")]
-			public void ThenTheFileExists(string fileName)
-			{
-			    Assert.IsTrue(File.Exists(fileName));
-			}
-		}
+        [Binding]
+        public class DeploymentItemSteps
+        {
+            [Then(@"the file '(.*)' exists")]
+            public void ThenTheFileExists(string fileName)
+            {
+                Assert.IsTrue(File.Exists(fileName));
+            }
+        }
         """
-	And there is a feature file in the project as
-         """
-		 @MsTest:DeploymentItem:Resources\DeploymentItemTestFile.txt:Data
-		 Feature: Deployment Item Feature
-	
-		 Scenario: Deployment Item Scenario
-			Then the file 'Data\DeploymentItemTestFile.txt' exists
-         """
-	And there is a content file 'Resources\DeploymentItemTestFile.txt' in the project as
-		"""
-		This is a deployment item file
-		"""
-	And the specflow configuration is
-		"""
-		<specFlow>
-			<unitTestProvider name="MsTest"/>
-		</specFlow>
-		"""
-	And there is a test settings file 'Local.testsettings'
-		"""
-		<?xml version="1.0" encoding="UTF-8"?>
-		<TestSettings
-		  id="b8f2810b-cd53-4519-8b18-d0e599219d54"
-		  name="Local"
-		  enableDefaultDataCollectors="false"
-		  xmlns="http://microsoft.com/schemas/VisualStudio/TeamTest/2010">
-		  <Deployment enabled="true" />
-		</TestSettings>
-		"""
-	When I execute the tests with MsTest
-	Then the execution summary should contain
-         | Succeeded |
-         | 1         |
+    And there is a feature file in the project as
+        """
+        @MsTest:DeploymentItem:Resources\DeploymentItemTestFile.txt:Data
+        Feature: Deployment Item Feature
+    
+        Scenario: Deployment Item Scenario
+            Then the file 'Data\DeploymentItemTestFile.txt' exists
+        """
+    And there is a content file 'Resources\DeploymentItemTestFile.txt' in the project as
+        """
+        This is a deployment item file
+        """
+    And the specflow configuration is
+        """
+        <specFlow>
+            <unitTestProvider name="MsTest"/>
+        </specFlow>
+        """
+    And there is a test settings file 'Local.testsettings'
+        """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <TestSettings
+          id="b8f2810b-cd53-4519-8b18-d0e599219d54"
+          name="Local"
+          enableDefaultDataCollectors="false"
+          xmlns="http://microsoft.com/schemas/VisualStudio/TeamTest/2010">
+          <Deployment enabled="true" />
+        </TestSettings>
+        """
+    When I execute the tests with MsTest
+    Then the execution summary should contain
+        | Succeeded |
+        | 1         |
+
+Scenario: Should be able to access TestContext using injection and BeforeScenario hook
+    Given there is a SpecFlow project
+    And the project is configured to use the MsTest provider
+    And the following binding class
+        """
+        using Microsoft.VisualStudio.TestTools.UnitTesting;
+        [Binding]
+        public class StepsWithTestContextAndBeforeScenario
+        {
+            private TestContext _testContext;
+            public StepsWithTestContextAndBeforeScenario(TestContext testContext)
+            {
+                _testContext = testContext;
+                Assert.IsNotNull(_testContext);
+            }
+
+            [BeforeScenario()]
+            public void BeforeScenario()
+            {
+                Assert.IsNotNull(_testContext);
+            }
+
+            [When(@"I do something")]
+            public void WhenIDoSomething()
+            {
+                Assert.IsNotNull(_testContext);
+            }
+        }
+        """
+    And a scenario 'Simple Scenario' as
+        """
+        When I do something         
+        """
+    When I execute the tests with MsTest
+    Then the execution summary should contain
+        | Succeeded |
+        | 1         |

--- a/Tests/TechTalk.SpecFlow.Specs/Features/NUnitProvider.feature
+++ b/Tests/TechTalk.SpecFlow.Specs/Features/NUnitProvider.feature
@@ -1,66 +1,103 @@
 ﻿Feature: NUnit unit test provider
 
 Scenario Outline: Should be able to execute scenarios with basic results
-	Given there is a SpecFlow project
-	And the project is configured to use the NUnit provider
-	And a scenario 'Simple Scenario' as
-		"""
-		When I do something
-		"""
-	And all steps are bound and <step definition status>
-	When I execute the tests with NUnit
-	Then the execution summary should contain
-		| Total | <result> |
-		| 1     | 1        |
+    Given there is a SpecFlow project
+    And the project is configured to use the NUnit provider
+    And a scenario 'Simple Scenario' as
+        """
+        When I do something
+        """
+    And all steps are bound and <step definition status>
+    When I execute the tests with NUnit
+    Then the execution summary should contain
+        | Total | <result> |
+        | 1     | 1        |
 
 Examples: 
-	| result    | step definition status |
-	| Succeeded | pass                   |
-	| Failed    | fail                   |
+    | result    | step definition status |
+    | Succeeded | pass                   |
+    | Failed    | fail                   |
 
 Scenario Outline: Should handle scenario outlines
-	Given there is a SpecFlow project
-	And the project is configured to use the NUnit provider
-	And row testing is <row test>
-	Given there is a feature file in the project as
-		"""
-			Feature: Simple Feature
-			Scenario Outline: Simple Scenario Outline
-				Given there is something
-				When I do <what>
-				Then something should happen
-			Examples: 
-				| what           |
-				| something      |
-				| something else |
-		"""
-	And all steps are bound and pass
-	When I execute the tests with NUnit
-	Then the execution summary should contain
-		| Succeeded |
-		| 2         |
+    Given there is a SpecFlow project
+    And the project is configured to use the NUnit provider
+    And row testing is <row test>
+    Given there is a feature file in the project as
+        """
+            Feature: Simple Feature
+            Scenario Outline: Simple Scenario Outline
+                Given there is something
+                When I do <what>
+                Then something should happen
+            Examples: 
+                | what           |
+                | something      |
+                | something else |
+        """
+    And all steps are bound and pass
+    When I execute the tests with NUnit
+    Then the execution summary should contain
+        | Succeeded |
+        | 2         |
 
 Examples: 
-	| case           | row test |
-	| Normal testing | disabled |
-	| Row testing    | enabled  |
+    | case           | row test |
+    | Normal testing | disabled |
+    | Row testing    | enabled  |
 
 @config
 Scenario: Should be able to specify NUnit provider in the configuration
-	Given there is a SpecFlow project
-	And a scenario 'Simple Scenario' as
-		"""
-		When I do something
-		"""
-	And all steps are bound and pass
-	And the specflow configuration is
-		"""
-		<specFlow>
-			<unitTestProvider name="NUnit"/>
-		</specFlow>
-		"""
-	When I execute the tests with NUnit
-	Then the execution summary should contain
-		| Total | 
-		| 1     | 
-	
+    Given there is a SpecFlow project
+    And a scenario 'Simple Scenario' as
+        """
+        When I do something
+        """
+    And all steps are bound and pass
+    And the specflow configuration is
+        """
+        <specFlow>
+            <unitTestProvider name="NUnit"/>
+        </specFlow>
+        """
+    When I execute the tests with NUnit
+    Then the execution summary should contain
+        | Total | 
+        | 1     | 
+
+Scenario: Should be able to access TestContext using injection and BeforeScenario hook
+    Given there is a SpecFlow project
+    And the project is configured to use the NUnit provider
+    And the following binding class
+        """
+        using NUnit.Framework;
+        [Binding]
+        public class StepsWithTestContextAndBeforeScenario
+        {
+            private NUnit.Framework.TestContext _testContext;
+            public StepsWithTestContextAndBeforeScenario(TestContext testContext)
+            {
+                _testContext = testContext;
+                Assert.IsNotNull(_testContext);
+            }
+
+            [BeforeScenario()]
+            public void BeforeScenario()
+            {
+                Assert.IsNotNull(_testContext);
+            }
+
+            [When(@"I do something")]
+            public void WhenIDoSomething()
+            {
+                Assert.IsNotNull(_testContext);
+            }
+        }
+        """
+    And a scenario 'Simple Scenario' as
+        """
+        When I do something         
+        """
+    When I execute the tests with NUnit
+    Then the execution summary should contain
+        | Succeeded |
+        | 1         |

--- a/Tests/TechTalk.SpecFlow.Specs/Features/XUnit2Provider.feature
+++ b/Tests/TechTalk.SpecFlow.Specs/Features/XUnit2Provider.feature
@@ -1,52 +1,52 @@
 ﻿Feature: XUnit v2 unit test provider
 
 Scenario Outline: Should be able to execute scenarios with basic results
-	Given there is a SpecFlow project
-	And the project is configured to use the xUnit provider
-	And a scenario 'Simple Scenario' as
-		"""
-		When I do something
-		"""
-	And all steps are bound and <step definition status>
-	When I execute the tests with xUnit
-	Then the execution summary should contain
-		| Total | <result> |
-		| 1     | 1        |
+    Given there is a SpecFlow project
+    And the project is configured to use the xUnit provider
+    And a scenario 'Simple Scenario' as
+        """
+        When I do something
+        """
+    And all steps are bound and <step definition status>
+    When I execute the tests with xUnit
+    Then the execution summary should contain
+        | Total | <result> |
+        | 1     | 1        |
 
 Examples: 
-	| result    | step definition status |
-	| Succeeded | pass                   |
-	| Failed    | fail                   |
+    | result    | step definition status |
+    | Succeeded | pass                   |
+    | Failed    | fail                   |
 
-	Scenario: Should be able to ignore a scenario outline
-	Given there is a SpecFlow project
-	And the project is configured to use the xUnit provider
-	And there is a feature file in the project as
-		"""
-			Feature: Simple Feature
-			@ignore
-			Scenario Outline: Simple Scenario Outline
-				Given there is something
-				When I do <what>
-				Then something should happen
-			Examples: 
-				| what           |
-				| something      |
-				| something else |
-		"""
-	And all steps are bound and pass
-	When I execute the tests with xUnit
-	Then the execution summary should contain
-		| Succeeded |
-		| 0         |
+    Scenario: Should be able to ignore a scenario outline
+    Given there is a SpecFlow project
+    And the project is configured to use the xUnit provider
+    And there is a feature file in the project as
+        """
+            Feature: Simple Feature
+            @ignore
+            Scenario Outline: Simple Scenario Outline
+                Given there is something
+                When I do <what>
+                Then something should happen
+            Examples: 
+                | what           |
+                | something      |
+                | something else |
+        """
+    And all steps are bound and pass
+    When I execute the tests with xUnit
+    Then the execution summary should contain
+        | Succeeded |
+        | 0         |
 
 Scenario: Should be able to ignore a scenario
-	Given there is a SpecFlow project
-	And the project is configured to use the xUnit provider
-	And there is a feature file in the project as
-		"""
-			Feature: Simple Feature
-			
+    Given there is a SpecFlow project
+    And the project is configured to use the xUnit provider
+    And there is a feature file in the project as
+        """
+            Feature: Simple Feature
+            
             Scenario: First
                 Given there is something
                 Then something should happen
@@ -55,21 +55,21 @@ Scenario: Should be able to ignore a scenario
             Scenario: Second
                 Given there is something
                 Then something should happen
-		"""
-	And all steps are bound and pass
-	When I execute the tests with xUnit
-	Then the execution summary should contain
-		| Succeeded | Ignored |
-		| 1         | 1       |
+        """
+    And all steps are bound and pass
+    When I execute the tests with xUnit
+    Then the execution summary should contain
+        | Succeeded | Ignored |
+        | 1         | 1       |
 
 Scenario: Should be able to ignore all Scenarios in a feature
-	Given there is a SpecFlow project
-	And the project is configured to use the xUnit provider
-	And there is a feature file in the project as
-		"""
+    Given there is a SpecFlow project
+    And the project is configured to use the xUnit provider
+    And there is a feature file in the project as
+        """
             @ignore
-			Feature: Simple Feature
-			
+            Feature: Simple Feature
+            
             Scenario: First
                 Given there is something
                 Then something should happen
@@ -82,150 +82,160 @@ Scenario: Should be able to ignore all Scenarios in a feature
             Scenario: Third
                 Given there is something else
                 Then something else should happen
-		"""
-	And all steps are bound and pass
-	When I execute the tests with xUnit
-	Then the execution summary should contain
-		| Succeeded | Ignored |
-		| 0         | 3       |
+        """
+    And all steps are bound and pass
+    When I execute the tests with xUnit
+    Then the execution summary should contain
+        | Succeeded | Ignored |
+        | 0         | 3       |
 
 Scenario: Should be able to ignore all Scenarios and Scenario Outlines in a feature
-	Given there is a SpecFlow project
-	And the project is configured to use the xUnit provider
-	And there is a feature file in the project as
-		"""
+    Given there is a SpecFlow project
+    And the project is configured to use the xUnit provider
+    And there is a feature file in the project as
+        """
             @ignore
-			Feature: Simple Feature
-			
+            Feature: Simple Feature
+            
             Scenario: First
                 Given there is something
                 Then something should happen
 
             Scenario Outline: First Outline
-				Given there is something
-				When I do <what>
-				Then something should happen
-			Examples: 
-				| what           |
-				| something      |
-				| something else |
+                Given there is something
+                When I do <what>
+                Then something should happen
+            Examples: 
+                | what           |
+                | something      |
+                | something else |
 
             @ignore
             Scenario Outline: Second Outline
-				Given there is something
-				When I do <what>
-				Then something should happen
-			Examples: 
-				| what           |
-				| something      |
-				| something else |
+                Given there is something
+                When I do <what>
+                Then something should happen
+            Examples: 
+                | what           |
+                | something      |
+                | something else |
 
             Scenario: Last
                 Given there is something
                 Then something should happen
-		"""
-	And all steps are bound and pass
-	When I execute the tests with xUnit
-	Then the execution summary should contain
-		| Succeeded | Ignored |
-		| 0         | 4       |
+        """
+    And all steps are bound and pass
+    When I execute the tests with xUnit
+    Then the execution summary should contain
+        | Succeeded | Ignored |
+        | 0         | 4       |
 
 Scenario Outline: Should handle scenario outlines
-	Given there is a SpecFlow project
-	And the project is configured to use the xUnit provider
-	And row testing is <row test>
-	Given there is a feature file in the project as
-		"""
-			Feature: Simple Feature
-			Scenario Outline: Simple Scenario Outline
-				Given there is something
-				When I do <what>
-				Then something should happen
-			Examples: 
-				| what           |
-				| something      |
-				| something else |
-		"""
-	And all steps are bound and pass
-	When I execute the tests with xUnit
-	Then the execution summary should contain
-		| Succeeded |
-		| 2         |
+    Given there is a SpecFlow project
+    And the project is configured to use the xUnit provider
+    And row testing is <row test>
+    Given there is a feature file in the project as
+        """
+            Feature: Simple Feature
+            Scenario Outline: Simple Scenario Outline
+                Given there is something
+                When I do <what>
+                Then something should happen
+            Examples: 
+                | what           |
+                | something      |
+                | something else |
+        """
+    And all steps are bound and pass
+    When I execute the tests with xUnit
+    Then the execution summary should contain
+        | Succeeded |
+        | 2         |
 
 Examples: 
-	| case           | row test |
-	| Normal testing | disabled |
-	| Row testing    | enabled  |
+    | case           | row test |
+    | Normal testing | disabled |
+    | Row testing    | enabled  |
 
 @config
 Scenario: Should be able to specify xUnit provider in the configuration
-	Given there is a SpecFlow project
-	And a scenario 'Simple Scenario' as
-		"""
-		When I do something
-		"""
-	And all steps are bound and pass
-	And the specflow configuration is
-		"""
-		<specFlow>
-			<unitTestProvider name="xUnit"/>
-		</specFlow>
-		"""
-	When I execute the tests with xUnit
-	Then the execution summary should contain
-		| Total | 
-		| 1     | 
-	
-Scenario: Should be able to log custom messages
-Given there is a SpecFlow project
-And the project is configured to use the xUnit provider
-And a scenario 'Simple Scenario' as
-		"""
-		When I do something
-		"""	
-And the following step definition
-         """
-         [When(@"I do something")]
-		 public void WhenIDoSomething()
-		 {
-			ScenarioContext.Current.ScenarioContainer.Resolve<Xunit.Abstractions.ITestOutputHelper>().WriteLine("hello");
-		 }
-         """
-		 When I execute the tests with xUnit
-	Then the execution summary should contain
-		| Succeeded |
-		| 1         |
-
-
-
-Scenario: Should be able to log custom messages using context injection
-	Given there is a SpecFlow project
-	And the project is configured to use the xUnit provider
-	And the following binding class
+    Given there is a SpecFlow project
+    And a scenario 'Simple Scenario' as
         """
-		[Binding]
-		public class StepsWithScenarioContext
-		{
-			private ScenarioContext _scenarioContext;
-			private Xunit.Abstractions.ITestOutputHelper _output;
-			public StepsWithScenarioContext(ScenarioContext scenarioContext)
-			{
-				_scenarioContext = scenarioContext;
-				_output = _scenarioContext.ScenarioContainer.Resolve<Xunit.Abstractions.ITestOutputHelper>();
-			}
+        When I do something
+        """
+    And all steps are bound and pass
+    And the specflow configuration is
+        """
+        <specFlow>
+            <unitTestProvider name="xUnit"/>
+        </specFlow>
+        """
+    When I execute the tests with xUnit
+    Then the execution summary should contain
+        | Total | 
+        | 1     | 
+    
+Scenario: Should be able to log custom messages
+    Given there is a SpecFlow project
+    And the project is configured to use the xUnit provider
+    And a scenario 'Simple Scenario' as
+        """
+        When I do something
+        """ 
+    And the following step definition
+        """
+        [When(@"I do something")]
+        public void WhenIDoSomething()
+        {
+           ScenarioContext.Current.ScenarioContainer.Resolve<Xunit.Abstractions.ITestOutputHelper>().WriteLine("hello");
+        }
+        """
+    When I execute the tests with xUnit
+    Then the execution summary should contain
+        | Succeeded |
+        | 1         |
 
-			[When(@"I do something")]
-			public void WhenIDoSomething()
-			{
-				_output.WriteLine("something");
-			}
-		}
-        """	
-	And a scenario 'Simple Scenario' as
-         """
-         When I do something         
-         """
-	When I execute the tests with xUnit
-	Then the execution summary should contain
-         | Succeeded |
-         | 1         |
+Scenario: Should be able to access ITestOutputHelper using injection and BeforeScenario hook
+    Given there is a SpecFlow project
+    And the project is configured to use the xUnit provider
+    And the following binding class
+        """
+        using Xunit;
+        using Xunit.Abstractions;
+        [Binding]
+        public class StepsWithTestOutputHelperAndBeforeScenario
+        {
+            private ITestOutputHelper _testOutputHelper;
+            private ITestOutputHelper _testOutputHelperViaScenarioContext;
+            public StepsWithTestOutputHelperAndBeforeScenario(ITestOutputHelper testOutputHelper, ScenarioContext scenarioContext)
+            {
+                _testOutputHelper = testOutputHelper;
+                _testOutputHelperViaScenarioContext = scenarioContext.ScenarioContainer.Resolve<ITestOutputHelper>();
+                Assert.NotNull(_testOutputHelper);
+                Assert.Equal(_testOutputHelper, _testOutputHelperViaScenarioContext);
+            }
+
+            [BeforeScenario()]
+            public void BeforeScenario()
+            {
+                Assert.NotNull(_testOutputHelper);
+                Assert.Equal(_testOutputHelper, _testOutputHelperViaScenarioContext);
+            }
+
+            [When(@"I do something")]
+            public void WhenIDoSomething()
+            {
+                Assert.NotNull(_testOutputHelper);
+                Assert.Equal(_testOutputHelper, _testOutputHelperViaScenarioContext);
+            }
+        }
+        """
+    And a scenario 'Simple Scenario' as
+        """
+        When I do something         
+        """
+    When I execute the tests with xUnit
+    Then the execution summary should contain
+        | Succeeded |
+        | 1         |

--- a/changelog.txt
+++ b/changelog.txt
@@ -6,6 +6,7 @@ New Features:
 + IGherkinParser and IGherkinParserFactory interfaces added to support Gherkin Parser pluggability https://github.com/techtalk/SpecFlow/pull/1143
 + Assist: remove accents from column headers and property names when comparing objects to a table https://github.com/techtalk/SpecFlow/pull/1096
 + MSBuild Generation: Experimental support for deleting code-behind files on clean and rebuild
++ Added NUnit current TestContext scenario container registration. See https://github.com/techtalk/SpecFlow/issues/936
 
 Fixes:
 + Expose ScenarioInfo.Description parameter to get from context https://github.com/techtalk/SpecFlow/pull/1078
@@ -13,6 +14,7 @@ Fixes:
 + Comparing Guid with string using case insensitivity to prevent throwing unnecessary exceptions https://github.com/techtalk/SpecFlow/pull/1145
 + MSBuild Generation: Visual Studio Incremental Build does not always regenerate files on feature file changes https://github.com/techtalk/SpecFlow/pull/1167
 + Fixed test body generation order for outline tests https://github.com/techtalk/SpecFlow/pull/1168
++ Fix XUnit ITestOutputhelper and MSTest TestContext container registrations so that they are available in BeforeScenario hooks. See https://github.com/techtalk/SpecFlow/issues/936
 
 2.3.2 - 2018-04-17
 Fixes:


### PR DESCRIPTION
Fix XUnit ITestOutputhelper and MSTest TestContext container registrations so that they are available in BeforeScenario hooks.