### PR TITLE
Display differences with milliseconds and ticks between two DateTime fields in a ComparisonException.

### DIFF
--- a/TechTalk.SpecFlow/Assist/TableDiffExceptionBuilder.cs
+++ b/TechTalk.SpecFlow/Assist/TableDiffExceptionBuilder.cs
@@ -1,8 +1,9 @@
 ﻿using System;
 using System.Collections;
-using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Text;
+using System.Text.RegularExpressions;
 
 namespace TechTalk.SpecFlow.Assist
 {
@@ -43,7 +44,22 @@ namespace TechTalk.SpecFlow.Assist
         {
             var line = "+ |";
             foreach (var header in tableDifferenceResults.Table.Header)
-                line += $" {GetTheValue(item.Item, header)} |";
+            {
+                object value = GetTheValue(item.Item, header);
+
+                if (value is DateTime)
+                {
+                    DateTime dateValue = (DateTime)value;
+
+                    // Append millisecond and ticks, if any, to current culture's default date time format
+                    string dateTimeFormat = DateTimeFormatInfo.CurrentInfo.ShortDatePattern + " " + DateTimeFormatInfo.CurrentInfo.LongTimePattern;
+                    dateTimeFormat = Regex.Replace(dateTimeFormat, "(:ss|:s)", "$1.FFFFFFF");
+                    value = dateValue.ToString(dateTimeFormat);
+                }
+
+                line += $" {value} |";
+            }
+
             realData.AppendLine(line);
         }
 

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/SetComparisonExtensionMethods_MessageTests.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/SetComparisonExtensionMethods_MessageTests.cs
@@ -160,6 +160,29 @@ AnotherFieldThatDoesNotExist".AgnosticLineBreak());
 ".AgnosticLineBreak());
         }
 
+        [Fact]
+        public void Includes_milliseconds_and_ticks_in_error_for_date_time_fields()
+        {
+            var table = new Table("DateTimeProperty");
+            table.AddRow("3/28/2018 12:34:56 AM");
+
+            var items = new[]
+            {
+                new SetComparisonTestObject
+                {
+                    DateTimeProperty = new System.DateTime(2018, 3, 28, 0, 34, 56, 78).AddTicks(9)
+                }
+            };
+
+            var exception = GetTheExceptionThrowByComparingThese(table, items);
+
+            exception.Message.AgnosticLineBreak().Should().Be(@"
+  | DateTimeProperty              |
+- | 3/28/2018 12:34:56 AM         |
++ | 3/28/2018 12:34:56.0780009 AM |
+".AgnosticLineBreak());
+        }
+
         protected ComparisonException GetTheExceptionThrowByComparingThese(Table table, SetComparisonTestObject[] items)
         {
             try


### PR DESCRIPTION
Fixes issue #1094