### PR TITLE
SpecFlow.Assist: apply ToIdentifier transform to column headers when comparing tables

### DIFF
--- a/TechTalk.SpecFlow/Assist/TEHelpers.cs
+++ b/TechTalk.SpecFlow/Assist/TEHelpers.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Reflection;
 using System.Text.RegularExpressions;
 using TechTalk.SpecFlow.Assist.Attributes;
+using TechTalk.SpecFlow.Tracing;
 
 namespace TechTalk.SpecFlow.Assist
 {
@@ -79,7 +80,7 @@ namespace TechTalk.SpecFlow.Assist
         internal static string NormalizePropertyNameToMatchAgainstAColumnName(string name)
         {
             // we remove underscores, because they should be equivalent to spaces that were removed too from the column names
-            return name.Replace("_", string.Empty);
+            return name.Replace("_", string.Empty).ToIdentifier();
         }
 
         internal static void LoadInstanceWithKeyValuePairs(Table table, object instance)

--- a/TechTalk.SpecFlow/Assist/TEHelpers.cs
+++ b/TechTalk.SpecFlow/Assist/TEHelpers.cs
@@ -80,6 +80,7 @@ namespace TechTalk.SpecFlow.Assist
         internal static string NormalizePropertyNameToMatchAgainstAColumnName(string name)
         {
             // we remove underscores, because they should be equivalent to spaces that were removed too from the column names
+            // we also ignore accents
             return name.Replace("_", string.Empty).ToIdentifier();
         }
 

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/SetComparisonExtensionMethods_ThrowTests.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/SetComparisonExtensionMethods_ThrowTests.cs
@@ -194,6 +194,19 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests
         }
 
         [Test]
+        public void Does_not_throw_an_exception_if_the_property_being_checked_for_has_international_characters_mapped_to_identifier_name()
+        {
+            var table = new Table("ŠtríngPröpërtý");
+            table.AddRow("mustard");
+
+            var items = new[] { new SetComparisonTestObject { StringProperty = "mustard" } };
+
+            var comparisonResult = DetermineIfExceptionWasThrownByComparingThese(table, items);
+
+            comparisonResult.ExceptionWasThrown.Should().BeFalse();
+        }
+
+        [Test]
         public void Does_not_throw_exception_if_string_is_empty_in_table_and_null_on_item()
         {
             var table = new Table("StringProperty");

--- a/changelog.txt
+++ b/changelog.txt
@@ -4,6 +4,7 @@ New Features:
 + Added support for customization of dependency injection at feature level via a runtime plugin event to raise feature dependencies https://github.com/techtalk/SpecFlow/pull/1141
 + Allow marking steps as Obsolete and have a configurable behavior for it https://github.com/techtalk/SpecFlow/pull/1140
 + IGherkinParser and IGherkinParserFactory interfaces added to support Gherkin Parser pluggability https://github.com/techtalk/SpecFlow/pull/1143
++ Assist: remove accents from column headers and property names when comparing objects to a table https://github.com/techtalk/SpecFlow/pull/1096
 
 Fixes:
 + Expose ScenarioInfo.Description parameter to get from context https://github.com/techtalk/SpecFlow/pull/1078


### PR DESCRIPTION
```gherkin
Given the English word 'name' is 'név' in Hungarian
And I prefer to have a scenario containing correctly spelled column headers like this
    ```
    | Név       |
    | dr. X. Y. |
    ```
And I don't allow local characters in the source code

When I try to compare the table with this object
    ```
    public class C
    {
        public string Nev { get; set; } 
    }
    ```

Then the table and the object can be successfully compared
```