### PR TITLE
Order sensitive comparison should display missing rows if there are more expected rows in the table than were returned

### DIFF
--- a/TechTalk.SpecFlow/Assist/SetComparer.cs
+++ b/TechTalk.SpecFlow/Assist/SetComparer.cs
@@ -119,6 +119,15 @@ namespace TechTalk.SpecFlow.Assist
                 actualItems.Skip(table.RowCount).Select(i => new TableDifferenceItem<T>(i)))
                 .ToList();
 
+            var extraTableItems = table.Rows.Count() - actualItems.Count;
+            if (extraTableItems > 0)
+            {
+                for (var index = actualItems.Count; index < table.Rows.Count(); index++)
+                {
+                    listOfMissingItems.Add(index + 1);
+                }
+            }
+
             return listOfMissingItems;
         }
 

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/SetComparisonExtensionMethods_MessageTests.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/SetComparisonExtensionMethods_MessageTests.cs
@@ -144,6 +144,22 @@ AnotherFieldThatDoesNotExist".AgnosticLineBreak());
 ".AgnosticLineBreak());
         }
 
+        [Test]
+        public void Returns_a_descriptive_error_when_no_results_exist_when_one_expected()
+        {
+            var table = new Table("StringProperty");
+            table.AddRow("orange");
+
+            var items = new SetComparisonTestObject[] { };
+
+            var exception = GetTheExceptionThrowByComparingThese(table, items);
+
+            exception.Message.AgnosticLineBreak().Should().Be(@"
+  | StringProperty |
+- | orange         |
+".AgnosticLineBreak());
+        }
+
         protected ComparisonException GetTheExceptionThrowByComparingThese(Table table, SetComparisonTestObject[] items)
         {
             try


### PR DESCRIPTION
Currently, if there are fewer returned results than the table has rows, using order insensitive comparison displays the absent rows, but order sensitive comparison does not. This adds a test for the latter case and fixes the implementation.

I also cleaned up the implementation slightly, hopefully without changing the behaviour: it now calculates missing items once, instead of three times, and no longer considers "there are results but should be none" separately to "there are more results than expected", as the former is a subcase of the latter.