### PR TITLE
Allow use binary expression in method call

### DIFF
--- a/TechTalk.SpecFlow.Rpc.Tests/Client/ExtractMethodInfoTests.cs
+++ b/TechTalk.SpecFlow.Rpc.Tests/Client/ExtractMethodInfoTests.cs
@@ -119,5 +119,13 @@ namespace TechTalk.SpecFlow.Rpc.Tests.Client
 
             AssertInterfaceMethodInfo(interfaceFunctionInfo, "MethodWithoutParameter");
         }
+
+        [Fact]
+        public void ExtractMethod_ExpressionArgument()
+        {
+            var interfaceMethodInfo = _extractMethodInfo
+                .ExtractMethod(c => c.MethodWithParameter("local_variable" + 1));
+            AssertInterfaceMethodInfo(interfaceMethodInfo, "MethodWithParameter", "local_variable1");
+        }
     }
 }

--- a/TechTalk.SpecFlow.Rpc/Client/ExtractMethodInfo.cs
+++ b/TechTalk.SpecFlow.Rpc/Client/ExtractMethodInfo.cs
@@ -46,6 +46,9 @@ namespace TechTalk.SpecFlow.Rpc.Client
                     case MemberExpression memberExpression:
                         arguments[index] = GetValue(memberExpression);
                         break;
+                    case BinaryExpression binaryExpression:
+                        arguments[index] = GetValue(binaryExpression);
+                        break;
                     default:
                         throw new NotSupportedException($"Expression of type {bodyArgument.GetType()} is not supported");
                 }
@@ -55,7 +58,7 @@ namespace TechTalk.SpecFlow.Rpc.Client
             return arguments;
         }
 
-        private object GetValue(MemberExpression member)
+        private object GetValue(Expression member)
         {
             var objectMember = Expression.Convert(member, typeof(object));
 


### PR DESCRIPTION
This change to allow test in `TechTalk.SpecFlow.Rpc.Tests.SameProcess.MultipleCalls()` use expression `"FeatureFilePath" + i`. Related to #1121

I now have feeling that when such code should be applied to all cases, to account for all possible way to pass parameters.

<!--- Describe your changes in detail -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added an entry to the changelog
- [X] Changes to the existing tests
