### PR TITLE
Explicitly catch errors in the server startup inside tests

### DIFF
--- a/TechTalk.SpecFlow.Rpc.Tests/Integration/SameProcess.cs
+++ b/TechTalk.SpecFlow.Rpc.Tests/Integration/SameProcess.cs
@@ -41,12 +41,31 @@ namespace TechTalk.SpecFlow.Rpc.Tests.Integration
         private BuildServerController _buildServerController;
         private readonly ObjectContainer _container;
         private readonly TestServerInterface _featureCodeBehindGeneratorMock;
+        private bool _serverStarted;
+        private Exception _serverStartupException;
 
 
         private void Start()
         {
-            _buildServerController = new BuildServerController(_container);
-            _buildServerController.Run(4635);
+            try
+            {
+                _buildServerController = new BuildServerController(_container);
+                _buildServerController.Run(4635);
+                _serverStarted = true;
+            }
+            catch (Exception e)
+            {
+                _serverStartupException = e;
+            }
+        }
+
+        private void EnsureServerStarted()
+        {
+            Thread.Sleep(1000);
+            if (!_serverStarted)
+            {
+                throw new InvalidOperationException("Server startup exception", _serverStartupException);
+            }
         }
 
 
@@ -57,8 +76,7 @@ namespace TechTalk.SpecFlow.Rpc.Tests.Integration
 
             var thread = new Thread(Start);
             thread.Start();
-
-            Thread.Sleep(1000);
+            EnsureServerStarted();
 
             using (var client = new Client<ITestServerInterface>(port))
             {
@@ -75,8 +93,7 @@ namespace TechTalk.SpecFlow.Rpc.Tests.Integration
 
             var thread = new Thread(Start);
             thread.Start();
-
-            Thread.Sleep(1000);
+            EnsureServerStarted();
 
             using (var client = new Client<ITestServerInterface>(port))
             {
@@ -95,8 +112,7 @@ namespace TechTalk.SpecFlow.Rpc.Tests.Integration
 
             var thread = new Thread(Start);
             thread.Start();
-
-            Thread.Sleep(1000);
+            EnsureServerStarted();
 
             using (var client = new Client<ITestServerInterface>(port))
             {

--- a/TechTalk.SpecFlow.Rpc/Server/ClientConnection.cs
+++ b/TechTalk.SpecFlow.Rpc/Server/ClientConnection.cs
@@ -65,8 +65,15 @@ namespace TechTalk.SpecFlow.Rpc.Server
                     return new ConnectionData(CompletionReason.CompilationNotStarted);
                 }
 
-                return await ExecuteRequest(request, container, cancellationToken).ConfigureAwait(false);
-
+                try
+                {
+                    return await ExecuteRequest(request, container, cancellationToken).ConfigureAwait(false);
+                }
+                catch (Exception e)
+                {
+                    LogException(e, "Error executing request.");
+                    return new ConnectionData(CompletionReason.ClientException);
+                }
             }
             finally
             {


### PR DESCRIPTION
Adding this code lead to interesting obsevation that all 3 tests is now failed with client not able to connect to server. But for example when  run SingleCall + Shutdown tests where in Shutdown test I disable starting server thread and verification of server creation, SingleCall fails and Shutdown pass. Looks like this is indication of passing tests here reuse server instance from previous tests. I think this could be fixed, but adding property IsRunning which will verify that server is started, and use that property insted of using Thread.Sleep(1000) in the code.

<!--- Describe your changes in detail -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added an entry to the changelog
- [X] Changes to the existing tests
