### PR TITLE
Support for marking Steps as Obsolete

### DIFF
--- a/TechTalk.SpecFlow/Bindings/BindingMatch.cs
+++ b/TechTalk.SpecFlow/Bindings/BindingMatch.cs
@@ -1,5 +1,4 @@
-using System;
-using System.Linq;
+using System.Diagnostics;
 
 namespace TechTalk.SpecFlow.Bindings
 {
@@ -9,7 +8,10 @@ namespace TechTalk.SpecFlow.Bindings
 
         public IStepDefinitionBinding StepBinding { get; private set; }
         public bool Success { get { return StepBinding != null; } }
-        
+
+        public BindingObsoletion BindingObsoletion { get; private set; }
+        public bool IsObsolete => BindingObsoletion.IsObsolete;
+
         public int ScopeMatches { get; private set; }
         public bool IsScoped { get { return ScopeMatches > 0; } }
 
@@ -22,6 +24,7 @@ namespace TechTalk.SpecFlow.Bindings
             ScopeMatches = scopeMatches;
             Arguments = arguments;
             StepContext = stepContext;
+            BindingObsoletion = new BindingObsoletion(stepBinding);
         }
     }
 }

--- a/TechTalk.SpecFlow/Bindings/BindingObsoletion.cs
+++ b/TechTalk.SpecFlow/Bindings/BindingObsoletion.cs
@@ -35,12 +35,12 @@ namespace TechTalk.SpecFlow.Bindings
             {
                 IsObsolete = true;
                 message = possibleObsoletionAttribute.Message ?? defaultObsoletionMessage;
-                methodName = stepBinding.Method.Name;
+                methodName = stepBinding?.Method.Name;
             }
         }
 
         public bool IsObsolete { get; private set; }
 
-        public string Message => $"The step {methodName} is obsolete because {message}";
+        public string Message => IsObsolete ? $"The step {methodName} is obsolete because {message}" : string.Empty;
     }
 }

--- a/TechTalk.SpecFlow/Bindings/BindingObsoletion.cs
+++ b/TechTalk.SpecFlow/Bindings/BindingObsoletion.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Linq;
+using TechTalk.SpecFlow.Bindings.Reflection;
+
+namespace TechTalk.SpecFlow.Bindings
+{
+    public class BindingObsoletion
+    {
+        private const string defaultObsoletionMessage = "it is marked with ObsoleteAttribute but no custom message was provided.";
+
+        private string message;
+        private string methodName;
+
+        public BindingObsoletion(IStepDefinitionBinding stepBinding)
+        {
+            ObsoleteAttribute possibleObsoletionAttribute;
+            try
+            {
+                possibleObsoletionAttribute = stepBinding?.Method.AssertMethodInfo()
+                            .GetCustomAttributes(false).OfType<ObsoleteAttribute>()
+                            .FirstOrDefault();
+            }
+            catch (Exception)
+            {
+                possibleObsoletionAttribute = null;
+            }
+
+            if (possibleObsoletionAttribute == null)
+            {
+                IsObsolete = false;
+                message = null;
+                methodName = null;
+            }
+            else
+            {
+                IsObsolete = true;
+                message = possibleObsoletionAttribute.Message ?? defaultObsoletionMessage;
+                methodName = stepBinding.Method.Name;
+            }
+        }
+
+        public bool IsObsolete { get; private set; }
+
+        public string Message => $"The step {methodName} is obsolete because {message}";
+    }
+}

--- a/TechTalk.SpecFlow/Configuration/AppConfig/AppConfigConfigurationLoader.cs
+++ b/TechTalk.SpecFlow/Configuration/AppConfig/AppConfigConfigurationLoader.cs
@@ -30,6 +30,7 @@ namespace TechTalk.SpecFlow.Configuration.AppConfig
             StepDefinitionSkeletonStyle stepDefinitionSkeletonStyle = specFlowConfiguration.StepDefinitionSkeletonStyle;
             List<string> additionalStepAssemblies = specFlowConfiguration.AdditionalStepAssemblies;
             List<PluginDescriptor> pluginDescriptors = specFlowConfiguration.Plugins;
+            ObsoleteBehavior obsoleteBehavior = specFlowConfiguration.ObsoleteBehavior;
 
             bool allowRowTests = specFlowConfiguration.AllowRowTests;
             bool allowDebugGeneratedFiles = specFlowConfiguration.AllowDebugGeneratedFiles;
@@ -52,6 +53,7 @@ namespace TechTalk.SpecFlow.Configuration.AppConfig
             {
                 stopAtFirstError = configSection.Runtime.StopAtFirstError;
                 missingOrPendingStepsOutcome = configSection.Runtime.MissingOrPendingStepsOutcome;
+                obsoleteBehavior = configSection.Runtime.ObsoleteBehavior;
 
                 if (IsSpecified(configSection.Runtime.Dependencies))
                 {
@@ -138,7 +140,8 @@ namespace TechTalk.SpecFlow.Configuration.AppConfig
                                             allowDebugGeneratedFiles,
                                             allowRowTests,
                                             markFeaturesParallelizable,
-                                            skipParallelizableMarkerForTags
+                                            skipParallelizableMarkerForTags,
+                                            obsoleteBehavior
                                             );
         }
 

--- a/TechTalk.SpecFlow/Configuration/AppConfig/RuntimeConfigElement.cs
+++ b/TechTalk.SpecFlow/Configuration/AppConfig/RuntimeConfigElement.cs
@@ -33,5 +33,12 @@ namespace TechTalk.SpecFlow.Configuration.AppConfig
             get { return (MissingOrPendingStepsOutcome)this["missingOrPendingStepsOutcome"]; }
             set { this["missingOrPendingStepsOutcome"] = value; }
         }
+
+        [ConfigurationProperty("obsoleteBehavior", DefaultValue = ConfigDefaults.ObsoleteBehavior, IsRequired = false)]
+        public ObsoleteBehavior ObsoleteBehavior
+        {
+            get { return (ObsoleteBehavior)this["obsoleteBehavior"]; }
+            set { this["obsoleteBehavior"] = value; }
+        }
     }
 }

--- a/TechTalk.SpecFlow/Configuration/ConfigDefaults.cs
+++ b/TechTalk.SpecFlow/Configuration/ConfigDefaults.cs
@@ -19,6 +19,7 @@ namespace TechTalk.SpecFlow.Configuration
         public const bool TraceTimings = false;
         public const string MinTracedDuration = "0:0:0.1";
         public const StepDefinitionSkeletonStyle StepDefinitionSkeletonStyle = TechTalk.SpecFlow.BindingSkeletons.StepDefinitionSkeletonStyle.RegexAttribute;
+        public const ObsoleteBehavior ObsoleteBehavior = Configuration.ObsoleteBehavior.Warn;
 
         public const bool AllowDebugGeneratedFiles = false;
         public const bool AllowRowTests = true;

--- a/TechTalk.SpecFlow/Configuration/ConfigurationLoader.cs
+++ b/TechTalk.SpecFlow/Configuration/ConfigurationLoader.cs
@@ -63,6 +63,8 @@ namespace TechTalk.SpecFlow.Configuration
         public static bool DefaultMarkFeaturesParallelizable => ConfigDefaults.MarkFeaturesParallelizable;
         public static string[] DefaultSkipParallelizableMarkerForTags => ConfigDefaults.SkipParallelizableMarkerForTags;
 
+        public static ObsoleteBehavior DefaultObsoleteBehavior => ConfigDefaults.ObsoleteBehavior;
+
         public bool HasAppConfig => ConfigurationManager.GetSection("specFlow") != null;
 
         public bool HasJsonConfig
@@ -149,7 +151,8 @@ namespace TechTalk.SpecFlow.Configuration
                 DefaultAllowDebugGeneratedFiles, 
                 DefaultAllowRowTests,
                 DefaultMarkFeaturesParallelizable,
-                DefaultSkipParallelizableMarkerForTags
+                DefaultSkipParallelizableMarkerForTags,
+                DefaultObsoleteBehavior
                 );
         }
 

--- a/TechTalk.SpecFlow/Configuration/JsonConfig/JsonConfigurationLoader.cs
+++ b/TechTalk.SpecFlow/Configuration/JsonConfig/JsonConfigurationLoader.cs
@@ -35,6 +35,7 @@ namespace TechTalk.SpecFlow.Configuration.JsonConfig
             bool allowDebugGeneratedFiles = specFlowConfiguration.AllowDebugGeneratedFiles;
             bool markFeaturesParallelizable = specFlowConfiguration.MarkFeaturesParallelizable;
             string[] skipParallelizableMarkerForTags = specFlowConfiguration.SkipParallelizableMarkerForTags;
+            ObsoleteBehavior obsoleteBehavior = specFlowConfiguration.ObsoleteBehavior;
 
             var specFlowElement = jsonConfig.SpecFlow;
             if (specFlowElement.Language != null)
@@ -65,6 +66,7 @@ namespace TechTalk.SpecFlow.Configuration.JsonConfig
             {
                 missingOrPendingStepsOutcome = specFlowElement.Runtime.MissingOrPendingStepsOutcome;
                 stopAtFirstError = specFlowElement.Runtime.StopAtFirstError;
+                obsoleteBehavior = specFlowElement.Runtime.ObsoleteBehavior;
             }
 
             if (specFlowElement.Generator != null)
@@ -121,7 +123,8 @@ namespace TechTalk.SpecFlow.Configuration.JsonConfig
                                             allowDebugGeneratedFiles,
                                             allowRowTests,
                                             markFeaturesParallelizable,
-                                            skipParallelizableMarkerForTags);
+                                            skipParallelizableMarkerForTags,
+                                            obsoleteBehavior);
         }
     }
 }

--- a/TechTalk.SpecFlow/Configuration/JsonConfig/RuntimeElement.cs
+++ b/TechTalk.SpecFlow/Configuration/JsonConfig/RuntimeElement.cs
@@ -8,10 +8,13 @@ namespace TechTalk.SpecFlow.Configuration.JsonConfig
         [JsonProperty("stopAtFirstError", DefaultValueHandling = DefaultValueHandling.Populate, NullValueHandling = NullValueHandling.Ignore)]
         [DefaultValue(ConfigDefaults.StopAtFirstError)]
         public bool StopAtFirstError { get; set; }
-
-
+        
         [JsonProperty("missingOrPendingStepsOutcome", DefaultValueHandling = DefaultValueHandling.Populate, NullValueHandling = NullValueHandling.Ignore)]
         [DefaultValue(ConfigDefaults.MissingOrPendingStepsOutcome)]
         public MissingOrPendingStepsOutcome MissingOrPendingStepsOutcome { get; set; }
+
+        [JsonProperty("obsoleteBehavior", DefaultValueHandling = DefaultValueHandling.Populate, NullValueHandling = NullValueHandling.Ignore)]
+        [DefaultValue(ConfigDefaults.ObsoleteBehavior)]
+        public ObsoleteBehavior ObsoleteBehavior { get; set; }
     }
 }

--- a/TechTalk.SpecFlow/Configuration/ObsoleteBehavior.cs
+++ b/TechTalk.SpecFlow/Configuration/ObsoleteBehavior.cs
@@ -1,0 +1,14 @@
+﻿namespace TechTalk.SpecFlow.Configuration
+{
+    /// <summary>
+    /// Describes possibilities what to do when a test is marked with <see cref="ObsoleteAttribute"/>
+    /// The default is <see cref="Warn"/> 
+    /// </summary>
+    public enum ObsoleteBehavior
+    {
+        None = 0,
+        Warn = 1,
+        Pending = 2,
+        Error = 3
+    }
+}

--- a/TechTalk.SpecFlow/Configuration/SpecFlowConfiguration.cs
+++ b/TechTalk.SpecFlow/Configuration/SpecFlowConfiguration.cs
@@ -36,7 +36,8 @@ namespace TechTalk.SpecFlow.Configuration
             bool allowDebugGeneratedFiles,
             bool allowRowTests,
             bool markFeaturesParallelizable,
-            string[] skipParallelizableMarkerForTags)
+            string[] skipParallelizableMarkerForTags,
+            ObsoleteBehavior obsoleteBehavior)
         {
             ConfigSource = configSource;
             CustomDependencies = customDependencies;
@@ -56,6 +57,7 @@ namespace TechTalk.SpecFlow.Configuration
             AllowRowTests = allowRowTests;
             MarkFeaturesParallelizable = markFeaturesParallelizable;
             SkipParallelizableMarkerForTags = skipParallelizableMarkerForTags;
+            ObsoleteBehavior = obsoleteBehavior;
         }
 
         public ConfigSource ConfigSource { get; set; }
@@ -77,6 +79,8 @@ namespace TechTalk.SpecFlow.Configuration
 
         public bool AllowDebugGeneratedFiles { get; set; }
         public bool AllowRowTests { get; set; }
+
+        public ObsoleteBehavior ObsoleteBehavior { get; set; }
 
         //tracing settings
         public bool TraceSuccessfulSteps { get; set; }
@@ -103,7 +107,8 @@ namespace TechTalk.SpecFlow.Configuration
 
         protected bool Equals(SpecFlowConfiguration other)
         {
-            return ConfigSource == other.ConfigSource && Equals(CustomDependencies, other.CustomDependencies) && Equals(GeneratorCustomDependencies, other.GeneratorCustomDependencies) && Equals(FeatureLanguage, other.FeatureLanguage) && Equals(BindingCulture, other.BindingCulture) && string.Equals(UnitTestProvider, other.UnitTestProvider) && StopAtFirstError == other.StopAtFirstError && MissingOrPendingStepsOutcome == other.MissingOrPendingStepsOutcome && AllowDebugGeneratedFiles == other.AllowDebugGeneratedFiles && AllowRowTests == other.AllowRowTests && TraceSuccessfulSteps == other.TraceSuccessfulSteps && TraceTimings == other.TraceTimings && MinTracedDuration.Equals(other.MinTracedDuration) && StepDefinitionSkeletonStyle == other.StepDefinitionSkeletonStyle && Equals(AdditionalStepAssemblies, other.AdditionalStepAssemblies) && Equals(Plugins, other.Plugins) && MarkFeaturesParallelizable == other.MarkFeaturesParallelizable && Equals(SkipParallelizableMarkerForTags, other.SkipParallelizableMarkerForTags);
+            return ConfigSource == other.ConfigSource && Equals(CustomDependencies, other.CustomDependencies) && Equals(GeneratorCustomDependencies, other.GeneratorCustomDependencies) && Equals(FeatureLanguage, other.FeatureLanguage)&& Equals(BindingCulture, other.BindingCulture) && string.Equals(UnitTestProvider, other.UnitTestProvider) && StopAtFirstError == other.StopAtFirstError && MissingOrPendingStepsOutcome == other.MissingOrPendingStepsOutcome && AllowDebugGeneratedFiles == other.AllowDebugGeneratedFiles && AllowRowTests == other.AllowRowTests && TraceSuccessfulSteps == other.TraceSuccessfulSteps && TraceTimings == other.TraceTimings && MinTracedDuration.Equals(other.MinTracedDuration) && StepDefinitionSkeletonStyle == other.StepDefinitionSkeletonStyle && Equals(AdditionalStepAssemblies, other.AdditionalStepAssemblies) && Equals(Plugins, other.Plugins) && MarkFeaturesParallelizable == other.MarkFeaturesParallelizable && Equals(SkipParallelizableMarkerForTags, other.SkipParallelizableMarkerForTags) 
+              && Equals(ObsoleteBehavior, other.ObsoleteBehavior);
         }
 
         public override bool Equals(object obj)
@@ -136,6 +141,7 @@ namespace TechTalk.SpecFlow.Configuration
                 hashCode = (hashCode * 397) ^ (Plugins != null ? Plugins.GetHashCode() : 0);
                 hashCode = (hashCode * 397) ^ MarkFeaturesParallelizable.GetHashCode();
                 hashCode = (hashCode * 397) ^ (SkipParallelizableMarkerForTags != null ? SkipParallelizableMarkerForTags.GetHashCode() : 0);
+                hashCode = (hashCode * 397) ^ (int) ObsoleteBehavior;
                 return hashCode;
             }
         }

--- a/TechTalk.SpecFlow/ErrorHandling/ErrorProvider.cs
+++ b/TechTalk.SpecFlow/ErrorHandling/ErrorProvider.cs
@@ -22,6 +22,7 @@ namespace TechTalk.SpecFlow.ErrorHandling
         void ThrowPendingError(ScenarioExecutionStatus testStatus, string message);
         Exception GetTooManyBindingParamError(int maxParam);
         Exception GetNonStaticEventError(IBindingMethod method);
+        Exception GetObsoleteStepError(BindingObsoletion bindingObsoletion);
     }
 
     internal class ErrorProvider : IErrorProvider
@@ -127,6 +128,11 @@ namespace TechTalk.SpecFlow.ErrorHandling
             throw new BindingException(
                 string.Format("The binding methods for before/after feature and before/after test run events must be static! {0}",
                 GetMethodText(method)));
+        }
+
+        public Exception GetObsoleteStepError(BindingObsoletion bindingObsoletion)
+        {
+            throw new BindingException(bindingObsoletion.Message);
         }
     }
 }

--- a/TechTalk.SpecFlow/Infrastructure/DefaultDependencyProvider.cs
+++ b/TechTalk.SpecFlow/Infrastructure/DefaultDependencyProvider.cs
@@ -46,6 +46,8 @@ namespace TechTalk.SpecFlow.Infrastructure
 
             container.RegisterTypeAs<ConfigurationLoader, IConfigurationLoader>();
 
+            container.RegisterTypeAs<ObsoleteStepHandler, IObsoleteStepHandler>();
+
             RegisterUnitTestProviders(container);
         }
 

--- a/TechTalk.SpecFlow/Infrastructure/IObsoleteStepHandler.cs
+++ b/TechTalk.SpecFlow/Infrastructure/IObsoleteStepHandler.cs
@@ -1,0 +1,9 @@
+﻿using TechTalk.SpecFlow.Bindings;
+
+namespace TechTalk.SpecFlow.Infrastructure
+{
+    public interface IObsoleteStepHandler
+    {
+        void Handle(BindingMatch bindingMatch);
+    }
+}

--- a/TechTalk.SpecFlow/Infrastructure/ObsoleteStepHandler.cs
+++ b/TechTalk.SpecFlow/Infrastructure/ObsoleteStepHandler.cs
@@ -1,0 +1,40 @@
+﻿using TechTalk.SpecFlow.Bindings;
+using TechTalk.SpecFlow.Configuration;
+using TechTalk.SpecFlow.ErrorHandling;
+using TechTalk.SpecFlow.Tracing;
+
+namespace TechTalk.SpecFlow.Infrastructure
+{
+    public class ObsoleteStepHandler : IObsoleteStepHandler
+    {
+        private readonly IErrorProvider errorProvider;
+        private readonly ITestTracer testTracer;
+        protected readonly SpecFlowConfiguration specFlowConfiguration;
+
+        public ObsoleteStepHandler(IErrorProvider errorProvider, ITestTracer testTracer, SpecFlowConfiguration specFlowConfiguration)
+        {
+            this.errorProvider = errorProvider;
+            this.testTracer = testTracer;
+            this.specFlowConfiguration = specFlowConfiguration;
+        }
+
+        public void Handle(BindingMatch bindingMatch)
+        {
+            if(bindingMatch.IsObsolete)
+            {
+                switch (specFlowConfiguration.ObsoleteBehavior)
+                {
+                    case ObsoleteBehavior.None:
+                        break;
+                    case ObsoleteBehavior.Warn:
+                        testTracer.TraceWarning(bindingMatch.BindingObsoletion.Message);
+                        break;
+                    case ObsoleteBehavior.Pending:
+                        throw errorProvider.GetPendingStepDefinitionError();
+                    case ObsoleteBehavior.Error:
+                        throw errorProvider.GetObsoleteStepError(bindingMatch.BindingObsoletion);
+                }
+            }
+        }
+    }
+}

--- a/TechTalk.SpecFlow/Infrastructure/TestExecutionEngine.cs
+++ b/TechTalk.SpecFlow/Infrastructure/TestExecutionEngine.cs
@@ -30,6 +30,7 @@ namespace TechTalk.SpecFlow.Infrastructure
         private readonly IBindingInvoker bindingInvoker;
         private readonly IStepDefinitionSkeletonProvider stepDefinitionSkeletonProvider;
         private readonly ITestObjectResolver testObjectResolver;
+        private readonly IObsoleteStepHandler obsoleteStepHandler; 
 
         private ProgrammingLanguage defaultTargetLanguage = ProgrammingLanguage.CSharp;
         private CultureInfo defaultBindingCulture = CultureInfo.CurrentCulture;
@@ -37,7 +38,8 @@ namespace TechTalk.SpecFlow.Infrastructure
         public TestExecutionEngine(IStepFormatter stepFormatter, ITestTracer testTracer, IErrorProvider errorProvider, IStepArgumentTypeConverter stepArgumentTypeConverter, 
             Configuration.SpecFlowConfiguration specFlowConfiguration, IBindingRegistry bindingRegistry, IUnitTestRuntimeProvider unitTestRuntimeProvider, 
             IStepDefinitionSkeletonProvider stepDefinitionSkeletonProvider, IContextManager contextManager, IStepDefinitionMatchService stepDefinitionMatchService,
-            IDictionary<string, IStepErrorHandler> stepErrorHandlers, IBindingInvoker bindingInvoker, ITestObjectResolver testObjectResolver = null, IObjectContainer testThreadContainer = null) //TODO: find a better way to access the container
+            IDictionary<string, IStepErrorHandler> stepErrorHandlers, IBindingInvoker bindingInvoker, IObsoleteStepHandler obsoleteStepHandler, 
+            ITestObjectResolver testObjectResolver = null, IObjectContainer testThreadContainer = null) //TODO: find a better way to access the container
         {
             this.errorProvider = errorProvider;
             this.bindingInvoker = bindingInvoker;
@@ -53,6 +55,7 @@ namespace TechTalk.SpecFlow.Infrastructure
             this.stepDefinitionMatchService = stepDefinitionMatchService;
             this.testObjectResolver = testObjectResolver;
             this.TestThreadContainer = testThreadContainer;
+            this.obsoleteStepHandler = obsoleteStepHandler;
         }
 
         public FeatureContext FeatureContext
@@ -303,6 +306,8 @@ namespace TechTalk.SpecFlow.Infrastructure
                 }
                 else
                 {
+                    obsoleteStepHandler.Handle(match);
+
                     onStepStartExecuted = true;
                     OnStepStart();
                     TimeSpan duration = ExecuteStepMatch(match, arguments);

--- a/TechTalk.SpecFlow/TechTalk.SpecFlow.csproj
+++ b/TechTalk.SpecFlow/TechTalk.SpecFlow.csproj
@@ -130,6 +130,7 @@
     <Compile Include="BindingSkeletons\StepDefinitionSkeletonStyle.cs" />
     <Compile Include="BindingSkeletons\StepParameterNameGenerator.cs" />
     <Compile Include="BindingSkeletons\StepTextAnalyzer.cs" />
+    <Compile Include="Bindings\BindingObsoletion.cs" />
     <Compile Include="Bindings\HookType.cs" />
     <Compile Include="Bindings\BindingScope.cs" />
     <Compile Include="Bindings\Discovery\BindingSourceAttribute.cs" />
@@ -178,8 +179,11 @@
     <Compile Include="Configuration\JsonConfig\StepAssemblyElement.cs" />
     <Compile Include="Configuration\JsonConfig\TraceElement.cs" />
     <Compile Include="Configuration\JsonConfig\UnitTestProviderElement.cs" />
+    <Compile Include="Configuration\ObsoleteBehavior.cs" />
     <Compile Include="EnvironmentVariableNames.cs" />
     <Compile Include="HookAttributes.cs" />
+    <Compile Include="Infrastructure\IObsoleteStepHandler.cs" />
+    <Compile Include="Infrastructure\ObsoleteStepHandler.cs" />
     <Compile Include="Infrastructure\TestObjectResolver.cs" />
     <Compile Include="Infrastructure\ContextManager.cs" />
     <Compile Include="Infrastructure\ContextManagerExtensions.cs" />

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/Infrastructure/TestExecutionEngineTests.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/Infrastructure/TestExecutionEngineTests.cs
@@ -32,6 +32,7 @@ namespace TechTalk.SpecFlow.RuntimeTests.Infrastructure
         private Dictionary<string, IStepErrorHandler> stepErrorHandlers;
         private Mock<IStepDefinitionSkeletonProvider> stepDefinitionSkeletonProviderMock;
         private Mock<ITestObjectResolver> testObjectResolverMock;
+        private Mock<IObsoleteStepHandler> obsoleteTestHandlerMock;
         private FeatureInfo featureInfo;
         private ScenarioInfo scenarioInfo;
         private ObjectContainer testThreadContainer;
@@ -106,6 +107,7 @@ namespace TechTalk.SpecFlow.RuntimeTests.Infrastructure
             methodBindingInvokerMock = new Mock<IBindingInvoker>();
 
             stepErrorHandlers = new Dictionary<string, IStepErrorHandler>();
+            obsoleteTestHandlerMock = new Mock<IObsoleteStepHandler>();
         }
 
         private TestExecutionEngine CreateTestExecutionEngine()
@@ -123,6 +125,7 @@ namespace TechTalk.SpecFlow.RuntimeTests.Infrastructure
                 stepDefinitionMatcherStub.Object, 
                 stepErrorHandlers, 
                 methodBindingInvokerMock.Object,
+                obsoleteTestHandlerMock.Object,
                 testObjectResolverMock.Object,
                 testThreadContainer);
         }

--- a/Tests/TechTalk.SpecFlow.Specs/Features/ObsoleteSteps.feature
+++ b/Tests/TechTalk.SpecFlow.Specs/Features/ObsoleteSteps.feature
@@ -1,6 +1,6 @@
 ﻿Feature: Obsolete Steps
     In order to be able to migrate steps to newer versions
-    I would like to be able to mark steps as obsolete
+    I would like to be able to mark steps as obsolete and decide in what behavior will that result
     As a developer
 
 Background: 
@@ -41,3 +41,26 @@ Scenario: Obsolete step should have default warning message
 	Given obsoleteBehavior configuration value is set to Warn
 	When I execute the tests
 	Then the execution log should contain text 'warning: The step GivenStuffIsDone is obsolete because it is marked with ObsoleteAttribute but no custom message was provided.'
+
+
+Scenario: Obsolete step should use Obsolete Attribute message if present
+	Given the following binding class
+        """
+		[Binding]
+		public class StepsWithReason
+		{
+			[Given(@"Some old stuff")]
+            [Obsolete("This step is old.")]
+			public void SomeOldStuff()
+			{
+				var x = 5+1;
+			}
+		}
+        """	
+	And a scenario 'Scenario With Obsolete Step with Message' as
+         """
+		 Given Some old stuff      
+         """
+	Given obsoleteBehavior configuration value is set to Warn
+	When I execute the tests
+	Then the execution log should contain text 'warning: The step SomeOldStuff is obsolete because This step is old.'

--- a/Tests/TechTalk.SpecFlow.Specs/Features/ObsoleteSteps.feature
+++ b/Tests/TechTalk.SpecFlow.Specs/Features/ObsoleteSteps.feature
@@ -1,0 +1,43 @@
+﻿Feature: Obsolete Steps
+    In order to be able to migrate steps to newer versions
+    I would like to be able to mark steps as obsolete
+    As a developer
+
+Background: 
+	Given the following binding class
+        """
+		[Binding]
+		public class StepsWithObsoletion
+		{
+			[Given(@"Stuff is done")]
+            [Obsolete]
+			public void GivenStuffIsDone()
+			{
+				var x = 2+3;
+			}
+		}
+        """	
+	And a scenario 'Scenario With Obsolete Step' as
+         """
+		 Given Stuff is done        
+         """
+
+Scenario Outline: Obsolete step should cause different behaviors based on configuration
+	Given obsoleteBehavior configuration value is set to <ObsoleteBehavior>
+	When I execute the tests
+	Then the execution summary should contain 
+         | Total | Succeeded        | Failed        | Pending        | Ignored |
+         | 1     | <SucceededCount> | <FailedCount> | <PendingCount> | 0       |
+
+Examples: 
+	| ObsoleteBehavior | SucceededCount | FailedCount | PendingCount |
+	| None             | 1              | 0           | 0            |
+	| Warn             | 1              | 0           | 0            |
+	| Pending          | 0              | 0           | 1            |
+	| Error            | 0              | 1           | 0            |
+
+
+Scenario: Obsolete step should have default warning message
+	Given obsoleteBehavior configuration value is set to Warn
+	When I execute the tests
+	Then the execution log should contain text 'warning: The step GivenStuffIsDone is obsolete because it is marked with ObsoleteAttribute but no custom message was provided.'

--- a/Tests/TechTalk.SpecFlow.Specs/StepDefinitions/SpecFlowConfigurationSteps.cs
+++ b/Tests/TechTalk.SpecFlow.Specs/StepDefinitions/SpecFlowConfigurationSteps.cs
@@ -39,6 +39,15 @@ namespace TechTalk.SpecFlow.Specs.StepDefinitions
             _specFlowJsonConfigurationDriver.IsUsed = true;
         }
 
+        [Given(@"obsoleteBehavior configuration value is set to (.*)")]
+        public void GivenObsoleteBehaviorConfigurationValueIsSetTo(string obsoleteBehaviorValue)
+        {
+            var configText = $@"<specFlow>
+			    <runtime obsoleteBehavior=""{obsoleteBehaviorValue}"" />
+                </specFlow >";
+
+            GivenTheSpecflowConfigurationIs(configText);
+        }
 
         [StepArgumentTransformation(@"enabled")]
         public bool ConvertEnabled() { return true; }

--- a/Tests/TechTalk.SpecFlow.Specs/TechTalk.SpecFlow.Specs.csproj
+++ b/Tests/TechTalk.SpecFlow.Specs/TechTalk.SpecFlow.Specs.csproj
@@ -148,6 +148,7 @@
     <None Include="Features\InAppDomainParallelExecution.feature" />
     <None Include="Features\InjectoContextToHooks.feature" />
     <None Include="Features\LanguageSupport.feature" />
+    <None Include="Features\ObsoleteSteps.feature" />
     <None Include="Features\Parser\DescriptionParser.feature" />
     <None Include="Features\Reports\StepDefinitionReport.feature" />
     <None Include="Features\ScopedHooks.feature" />

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,8 @@
 2.4 - 2018-??-??
 New Features:
++ Added ability to convert type to same type or one of the base types https://github.com/techtalk/SpecFlow/pull/1110
 + Allow marking steps as Obsolete and have a configurable behavior for it https://github.com/techtalk/SpecFlow/pull/1140
+
 Fixes:
 + Expose ScenarioInfo.Description parameter to get from context https://github.com/techtalk/SpecFlow/pull/1078
 + Resolved loading plugins multiple times. Issue: https://github.com/techtalk/SpecFlow/issues/888 

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,6 @@
 2.4 - 2018-??-??
+New Features:
++ Allow marking steps as Obsolete and have a configurable behavior for it https://github.com/techtalk/SpecFlow/pull/1140
 Fixes:
 + Expose ScenarioInfo.Description parameter to get from context https://github.com/techtalk/SpecFlow/pull/1078
 + Resolved loading plugins multiple times. Issue: https://github.com/techtalk/SpecFlow/issues/888 


### PR DESCRIPTION
<!--- Describe your changes in detail -->

This fixes #893 (or should). `ObsoleteAttribute` is used and the behavior is configurable, defaulted to warn, a non-breaking one.
I'm yet to update changelog and docs, but first I'd like a review.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've added tests for my code.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added an entry to the changelog
