### PR TITLE
Comparing Guid with string using case insensitivity to prevent throwing unnecessary exceptions

### DIFF
--- a/TechTalk.SpecFlow/Assist/ValueRetrievers/GuidValueRetriever.cs
+++ b/TechTalk.SpecFlow/Assist/ValueRetrievers/GuidValueRetriever.cs
@@ -11,7 +11,7 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
             try
             {
                 cleanedValue = RemoveUnnecessaryCharacters(value);
-                return AttempToBuildAGuidFromTheString(value);
+                return AttemptToBuildAGuidFromTheString(cleanedValue);
             }
             catch
             {
@@ -36,11 +36,11 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
             return propertyType == typeof(Guid);
         }
 
-        private static Guid AttempToBuildAGuidFromTheString(string value)
+        private static Guid AttemptToBuildAGuidFromTheString(string value)
         {
             var guid = new Guid(value);
 
-            if (RemoveUnnecessaryCharacters(guid) != value)
+            if (string.Compare(RemoveUnnecessaryCharacters(guid), value, true) != 0)
                 throw new Exception("The parsed value is not what was expected.");
 
             return guid;

--- a/changelog.txt
+++ b/changelog.txt
@@ -6,7 +6,7 @@ New Features:
 Fixes:
 + Expose ScenarioInfo.Description parameter to get from context https://github.com/techtalk/SpecFlow/pull/1078
 + Resolved loading plugins multiple times. Issue: https://github.com/techtalk/SpecFlow/issues/888 
-
++ Comparing Guid with string using case insensitivity to prevent throwing unnecessary exceptions https://github.com/techtalk/SpecFlow/pull/1145
 
 2.3.2 - 2018-04-17
 Fixes:


### PR DESCRIPTION
<!--- Describe your changes in detail -->
`GuidValueRetriever.cs` now compares a Guid with a string using case insensitivity to prevent throwing unnecessary exceptions.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added an entry to the changelog
