### PR TITLE
Fixed test body generation order for outline tests

### DIFF
--- a/TechTalk.SpecFlow.Generator/UnitTestFeatureGenerator.cs
+++ b/TechTalk.SpecFlow.Generator/UnitTestFeatureGenerator.cs
@@ -366,8 +366,6 @@ namespace TechTalk.SpecFlow.Generator
 
             var scenatioOutlineTestMethod = CreateScenatioOutlineTestMethod(generationContext, scenarioOutline, paramToIdentifier);
             var exampleTagsParam = new CodeVariableReferenceExpression(SCENARIO_OUTLINE_EXAMPLE_TAGS_PARAMETER);
-            GenerateTestBody(generationContext, scenarioOutline, scenatioOutlineTestMethod, exampleTagsParam, paramToIdentifier);
-
             if (generationContext.GenerateRowTests)
             {
                 GenerateScenarioOutlineExamplesAsRowTests(generationContext, scenarioOutline, scenatioOutlineTestMethod);
@@ -376,6 +374,7 @@ namespace TechTalk.SpecFlow.Generator
             {
                 GenerateScenarioOutlineExamplesAsIndividualMethods(scenarioOutline, generationContext, scenatioOutlineTestMethod, paramToIdentifier);
             }
+            GenerateTestBody(generationContext, scenarioOutline, scenatioOutlineTestMethod, exampleTagsParam, paramToIdentifier);
         }
 
         private void GenerateScenarioOutlineExamplesAsIndividualMethods(ScenarioOutline scenarioOutline, TestClassGenerationContext generationContext, CodeMemberMethod scenatioOutlineTestMethod, ParameterSubstitution paramToIdentifier)

--- a/changelog.txt
+++ b/changelog.txt
@@ -10,6 +10,7 @@ Fixes:
 + Expose ScenarioInfo.Description parameter to get from context https://github.com/techtalk/SpecFlow/pull/1078
 + Resolved loading plugins multiple times. Issue: https://github.com/techtalk/SpecFlow/issues/888 
 + Comparing Guid with string using case insensitivity to prevent throwing unnecessary exceptions https://github.com/techtalk/SpecFlow/pull/1145
++ Fixed test body generation order for outline tests
 
 2.3.2 - 2018-04-17
 Fixes:


### PR DESCRIPTION
<!--- Describe your changes in detail -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added an entry to the changelog


This fix was created as a result of using generator plugin: for ordinary tests custom code was generated before test body, for outline tests it was generated after test body.