### PR TITLE
RegistrationKey.Equals changed to ignore culture

### DIFF
--- a/TechTalk.SpecFlow/BoDi/BoDi.cs
+++ b/TechTalk.SpecFlow/BoDi/BoDi.cs
@@ -291,7 +291,7 @@ namespace BoDi
             bool Equals(RegistrationKey other)
             {
                 var isInvertable = other.TypeGroup == Type || other.Type == TypeGroup || other.Type == Type;
-                return isInvertable && String.Equals(other.Name, Name, StringComparison.CurrentCultureIgnoreCase);
+                return isInvertable && String.Equals(other.Name, Name, StringComparison.OrdinalIgnoreCase);
             }
 
             public override bool Equals(object obj)


### PR DESCRIPTION
Notice: this change was made to RegistrationKey but probably we should do it for other comparisons made in the code.

**Problem**
Because this RegistrationKey.Equals() implementation does a string comparison based on the current culture, we may encounter some problems.
String comparison varies based on culture. Here is some documentation: https://msdn.microsoft.com/en-us/library/ms973919.aspx

That documentation shows some examples of differences between different cultures. "tr-TR" lower and upper case for the "i"/"I" char is different from "en-US". But there are other differences.

In this particular case, for SpecFlow, lets use the default value for `IUnitTestRuntimeProvider`, which is the `NUnit3RuntimeProvider` implementation. 
This is registered as lowercase: `container.RegisterTypeAs<NUnit3RuntimeProvider, IUnitTestRuntimeProvider>("nunit");`. However, `ConfigDefaults.cs` has the following value: `public const string UnitTestProviderName = "NUnit";`. Notice the difference in case sensitivity.

**Example of cultures in which this can fail**

I know that I'm going to use a *bad* example because SpecFlow is not yet compatible with dotnetcore, but I guess in the future it will be. The default linux locale is `C` or `POSIX` locale, which in dotnetcore translates to something like `en_US_POSIX`. In this `en_US_POSIX` culture, case sensitivy or insensitity comparisons won't work the same way as in the `en_US` culture.

`String.Equals("nunit", NUnit", StringComparison. CurrentCultureIgnoreCase` actually returns `false` in `en_US_POSIX` as it may or may not return the same in other cultures.

**The solution**

Since we are talking about constant strings, there is no apparent reason to make string comparison culture dependant, so my suggestion is making an ordinal comparison ignoring case between the two strings.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added an entry to the changelog
