### PR TITLE
MsBuild Extended support for net.sdk project type system (targeting desktop framework, not core)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -380,3 +380,4 @@ Features.Generated/
 GitExtensions.settings.backup
 /Installer/NuGetPackages/SpecFlow.Tools.MsBuild.Generation/build/SpecFlow.Tools.MsBuild.Generation.targets
 /Installer/NuGetPackages/SpecFlow.Tools.MsBuild.Generation/build/SpecFlow.Tools.MsBuild.Generation.props
+/Tests/TechTalk.SpecFlow.MsBuildNetSdk.IntegrationTests/Features/dummy.feature.cs

--- a/Installer/NuGetPackages/.build/build.targets
+++ b/Installer/NuGetPackages/.build/build.targets
@@ -8,7 +8,7 @@
   <Target Name="Publish"/>
   <Target Name="GetNativeManifest" />
   <Target Name="GetCopyToOutputDirectoryItems" />
-
+  <Target Name="BuiltProjectOutputGroup" />
 
   <Target Name="AfterBuild" AfterTargets="Build" />
 

--- a/Installer/NuGetPackages/.build/build.targets
+++ b/Installer/NuGetPackages/.build/build.targets
@@ -9,6 +9,8 @@
   <Target Name="GetNativeManifest" />
   <Target Name="GetCopyToOutputDirectoryItems" />
   <Target Name="BuiltProjectOutputGroup" />
+  <Target Name="BuiltProjectOutputGroupDependencies" />
+  <Target Name="DebugSymbolsProjectOutputGroup" />
 
   <Target Name="AfterBuild" AfterTargets="Build" />
 

--- a/Installer/NuGetPackages/NuGetPackages.csproj
+++ b/Installer/NuGetPackages/NuGetPackages.csproj
@@ -36,14 +36,6 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Xml" />
-  </ItemGroup>
-  <ItemGroup>
     <None Include=".build\build.props" />
     <None Include=".build\build.targets" />
     <None Include="Properties\build.props" />

--- a/TechTalk.SpecFlow.Generator/Project/MsBuildProjectReader.cs
+++ b/TechTalk.SpecFlow.Generator/Project/MsBuildProjectReader.cs
@@ -123,7 +123,8 @@ namespace TechTalk.SpecFlow.Generator.Project
 
         private bool IsNewProjectSystem(XDocument xDocument)
         {
-            return xDocument.Root.Attribute("Sdk") != null;
+            // net.sdk way of detection based on: https://stackoverflow.com/questions/45943939/how-do-i-override-the-beforebuild-msbuild-task-in-a-vs-2017-net-standard-c-sh
+            return xDocument.Root.Attribute("Sdk") != null || xDocument.Root.Elements("Import").Where(e => e.HasAttributes).Attributes("Sdk").Any();
         }
 
         public static SpecFlowProject LoadSpecFlowProjectFromMsBuild(string projectFilePath)

--- a/TechTalk.SpecFlow.Tools/MsBuild/TechTalk.SpecFlow.props
+++ b/TechTalk.SpecFlow.Tools/MsBuild/TechTalk.SpecFlow.props
@@ -34,7 +34,8 @@
     <!--
       net.sdk support: feature flag to enable experimental support for net.sdk project system
     -->
-    <SpecFlow_EnableDefaultCompileItems Condition="'$(SpecFlow_EnableDefaultCompileItems)' == ''">false</SpecFlow_EnableDefaultCompileItems>
+    <SpecFlow_EnableDefaultCompileItems Condition="'$(SpecFlow_EnableDefaultCompileItems)'==''">false</SpecFlow_EnableDefaultCompileItems>
+    <SpecFlow_EnableWarnForFeatureCodeBehindFilesWithoutCorrespondingFeatureFile Condition="'$(SpecFlow_EnableWarnForFeatureCodeBehindFilesWithoutCorrespondingFeatureFile)'==''">$(SpecFlow_EnableDefaultCompileItems)</SpecFlow_EnableWarnForFeatureCodeBehindFilesWithoutCorrespondingFeatureFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/TechTalk.SpecFlow.Tools/MsBuild/TechTalk.SpecFlow.props
+++ b/TechTalk.SpecFlow.Tools/MsBuild/TechTalk.SpecFlow.props
@@ -14,13 +14,27 @@
     <OverwriteReadOnlyFiles Condition="'$(OverwriteReadOnlyFiles)'==''">false</OverwriteReadOnlyFiles>
     <ForceGeneration Condition="'$(ForceGeneration)'==''">false</ForceGeneration>
 
-    <SpecFlow_DeleteCodeBehindFilesOnCleanRebuild Condition="'$(SpecFlow_DeleteCodeBehindFilesOnCleanRebuild)'==''">false</SpecFlow_DeleteCodeBehindFilesOnCleanRebuild>
-
     <ShowTrace Condition="'$(ShowTrace)'==''">false</ShowTrace>
     <VerboseOutput Condition="'$(VerboseOutput)'==''">false</VerboseOutput>
     <SpecFlow_DebugMSBuildTask Condition="'$(SpecFlow_DebugMSBuildTask)' == ''">false</SpecFlow_DebugMSBuildTask>
 
     <_SpecFlowPropsImported Condition="'$(_SpecFlowPropsImported)'==''">true</_SpecFlowPropsImported>
+  </PropertyGroup>
+
+  <!--
+    property group for feature flags
+  -->
+  <PropertyGroup>
+
+    <!--
+      feature flag to enable experimental support for cleaning up generated code-behind files during rebuild and clean scenarios
+    -->
+    <SpecFlow_DeleteCodeBehindFilesOnCleanRebuild Condition="'$(SpecFlow_DeleteCodeBehindFilesOnCleanRebuild)'==''">false</SpecFlow_DeleteCodeBehindFilesOnCleanRebuild>
+
+    <!--
+      net.sdk support: feature flag to enable experimental support for net.sdk project system
+    -->
+    <SpecFlow_EnableDefaultCompileItems Condition="'$(SpecFlow_EnableDefaultCompileItems)' == ''">false</SpecFlow_EnableDefaultCompileItems>
   </PropertyGroup>
 
   <ItemGroup>

--- a/TechTalk.SpecFlow.Tools/MsBuild/TechTalk.SpecFlow.targets
+++ b/TechTalk.SpecFlow.Tools/MsBuild/TechTalk.SpecFlow.targets
@@ -6,6 +6,15 @@
   <PropertyGroup Condition="'$(BuildServerMode)' == ''">
     <BuildServerMode Condition="'$(BuildingInsideVisualStudio)'=='true'">false</BuildServerMode>
     <BuildServerMode Condition="'$(BuildingInsideVisualStudio)'!='true'">true</BuildServerMode>
+
+    <!--
+      net.sdk experimental support:
+      - currently we only want to support either classic project system or netsdk project system.
+      - currently we don't want to support globbing with classic project system => ensure globbing only get enabled with 'UsingMicrosoftNETSdk'
+      - currently we are supporting $(EnableDefaultCompileItems) for disabling globbing support for codebehind files
+    -->
+    <_SpecFlow_EnableDefaultCompileItems Condition="'$(SpecFlow_EnableDefaultCompileItems)' == '' And '$(UsingMicrosoftNETSdk)' == 'true'">true</_SpecFlow_EnableDefaultCompileItems>
+    <_SpecFlow_EnableDefaultCompileItems Condition="'$(SpecFlow_EnableDefaultCompileItems)' == 'true' And '$(UsingMicrosoftNETSdk)' == 'true'">true</_SpecFlow_EnableDefaultCompileItems>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -25,6 +34,21 @@
     </RebuildDependsOn>
   </PropertyGroup>
 
+
+  <!--
+    net.sdk support: update default compile items to show generated files as nested items
+  -->
+  <ItemGroup Condition="'$(_SpecFlow_EnableDefaultCompileItems)' == 'true' and '$(EnableDefaultItems)' == 'true' ">
+    <Compile Update="@(SpecFlowFeatureFiles->'%(CodeBehindFile)')"
+             DependentUpon="%(Filename)"
+             AutoGen="true"
+             DesignTime="true"
+             Visible="true"
+             Condition="'$(EnableDefaultCompileItems)' == 'true'"
+    />
+  </ItemGroup>
+
+
   <Target Name="SwitchToForceGenerate">
     <PropertyGroup>
       <ForceGeneration>true</ForceGeneration>
@@ -35,6 +59,8 @@
           DependsOnTargets="BeforeUpdateFeatureFilesInProject"
           Inputs="@(SpecFlowFeatureFiles)"
           Outputs="@(SpecFlowFeatureFiles->'%(CodeBehindFile)')">
+
+    <Message Text="SpecFlowFeatureFiles: @(SpecFlowFeatureFiles)" Importance="high" Condition="'$(VerboseOutput)' == 'true'" />
 
     <GenerateAll ProjectPath="$(MSBuildProjectFullPath)"
 
@@ -49,14 +75,43 @@
       <Output TaskParameter="GeneratedFiles" ItemName="SpecFlowGeneratedFiles" />
     </GenerateAll>
 
-    <Message Text="%(SpecFlowGeneratedFiles.Identity)" Importance="high" Condition="'$(VerboseOutput)'=='true'" />
+    <Message Text="SpecFlowGeneratedFiles: %(SpecFlowGeneratedFiles.Identity)" Importance="high" Condition="'$(VerboseOutput)' == 'true'" />
+
+    <!--
+      net.sdk support: globbing does not support including files which are dynamically generated inside targets, we have to manually update compile items
+    -->
+    <ItemGroup Condition="'$(_SpecFlow_EnableDefaultCompileItems)' == 'true' and '$(EnableDefaultItems)' == 'true' ">
+
+      <!-- if this is the first time generation of codebehind files, we have to manually add them as compile items -->
+      <Compile Include="@(SpecFlowFeatureFiles->'%(CodeBehindFile)')"
+               Exclude="@(Compile)"
+               Condition="'$(EnableDefaultCompileItems)' == 'true'"
+      />
+
+      <!-- eather if codebehind files are added manually to compile item group or are added by net.sdk globbing support, ensure they are nested under feature files like in previous specflow versions -->
+      <Compile Update="@(SpecFlowFeatureFiles->'%(CodeBehindFile)')"
+               DependentUpon="%(Filename)"
+               AutoGen="true"
+               DesignTime="true"
+               Visible="true"
+               Condition="'$(EnableDefaultCompileItems)' == 'true'"
+      />
+
+      <!-- remove files which got obsolete, typically after rename operation, or getting changes from source control -->
+      <Compile Remove="@(SpecFlowObsoleteCodeBehindFiles)" />
+    </ItemGroup>
+
+    <Warning Text="Existing generated codebehind files for not existing feature files will be ignored '$(SpecFlowObsoleteCodeBehindFiles)'" Condition="'$(SpecFlowObsoleteCodeBehindFiles)' != ''" />
   </Target>
+
 
   <Target Name="BeforeUpdateFeatureFilesInProject">
   </Target>
 
+
   <Target Name="AfterUpdateFeatureFilesInProject" DependsOnTargets="UpdateFeatureFilesInProject">
   </Target>
+
 
   <Target Name="CleanFeatureFilesInProject" Condition="'$(SpecFlow_DeleteCodeBehindFilesOnCleanRebuild)' == 'true'">
     <!-- remove known codebehind files for existing feature files -->
@@ -69,5 +124,6 @@
      -->
     <Delete Files="@(SpecFlowObsoleteCodeBehindFiles)" ContinueOnError="true" />
   </Target>
+
 
 </Project>

--- a/TechTalk.SpecFlow.Tools/MsBuild/TechTalk.SpecFlow.targets
+++ b/TechTalk.SpecFlow.Tools/MsBuild/TechTalk.SpecFlow.targets
@@ -53,11 +53,13 @@
     <Warning Text="For codebehind file '@(SpecFlowObsoleteCodeBehindFiles)', no feature file was found." File="@(SpecFlowObsoleteCodeBehindFiles)" Condition="'@(SpecFlowObsoleteCodeBehindFiles)' != ''" />
   </Target>
 
+
   <Target Name="SwitchToForceGenerate">
     <PropertyGroup>
       <ForceGeneration>true</ForceGeneration>
     </PropertyGroup>
   </Target>
+
 
   <Target Name="UpdateFeatureFilesInProject"
           DependsOnTargets="BeforeUpdateFeatureFilesInProject"
@@ -81,29 +83,34 @@
 
     <Message Text="SpecFlowGeneratedFiles: %(SpecFlowGeneratedFiles.Identity)" Importance="high" Condition="'$(VerboseOutput)' == 'true'" />
 
+
     <!--
       net.sdk support: globbing does not support including files which are dynamically generated inside targets, we have to manually update compile items
     -->
-    <ItemGroup Condition="'$(_SpecFlow_EnableDefaultCompileItems)' == 'true' and '$(EnableDefaultItems)' == 'true' ">
+    <ItemGroup Condition="'$(_SpecFlow_EnableDefaultCompileItems)' == 'true' and '$(EnableDefaultItems)' == 'true' and '$(EnableDefaultCompileItems)' == 'true'">
 
       <!-- if this is the first time generation of codebehind files, we have to manually add them as compile items -->
       <Compile Include="@(SpecFlowFeatureFiles->'%(CodeBehindFile)')"
-               Exclude="@(Compile)"
-               Condition="'$(EnableDefaultCompileItems)' == 'true'"
-      />
+               Exclude="@(Compile)"/>
 
-      <!-- eather if codebehind files are added manually to compile item group or are added by net.sdk globbing support, ensure they are nested under feature files like in previous specflow versions -->
-      <Compile Update="@(SpecFlowFeatureFiles->'%(CodeBehindFile)')"
-               DependentUpon="%(Filename)"
+      <!--
+        eather if codebehind files are added manually to compile item group or are added by net.sdk globbing support,
+        ensure they are nested under feature files like in previous specflow versions
+        currently, we cannot use itemgroup update attribute inside a target because of some bugs in MSBuild (all items will be updated)
+        - https://github.com/Microsoft/msbuild/issues/1618
+        - https://github.com/Microsoft/msbuild/issues/2835
+        - https://github.com/Microsoft/msbuild/issues/1124
+      -->
+      <Compile DependentUpon="@(SpecFlowFeatureFiles)"
                AutoGen="true"
                DesignTime="true"
                Visible="true"
-               Condition="'$(EnableDefaultCompileItems)' == 'true'"
-      />
+               Condition="'%(Compile.Identity)' == '@(SpecFlowFeatureFiles->'%(CodeBehindFile)')'" />
 
       <!-- remove files which got obsolete, typically after rename operation, or getting changes from source control -->
       <Compile Remove="@(SpecFlowObsoleteCodeBehindFiles)" />
     </ItemGroup>
+
   </Target>
 
 

--- a/TechTalk.SpecFlow.Tools/MsBuild/TechTalk.SpecFlow.targets
+++ b/TechTalk.SpecFlow.Tools/MsBuild/TechTalk.SpecFlow.targets
@@ -49,7 +49,8 @@
   </ItemGroup>
 
 
-  <Target Name="WarnForFeatureCodeBehindFilesWithoutCorrespondingFeatureFile" AfterTargets="CoreCompile">
+  <Target Name="WarnForFeatureCodeBehindFilesWithoutCorrespondingFeatureFile" AfterTargets="CoreCompile"
+          Condition="'$(SpecFlow_EnableWarnForFeatureCodeBehindFilesWithoutCorrespondingFeatureFile)' == 'true'">
     <Warning Text="For codebehind file '@(SpecFlowObsoleteCodeBehindFiles)', no feature file was found." File="@(SpecFlowObsoleteCodeBehindFiles)" Condition="'@(SpecFlowObsoleteCodeBehindFiles)' != ''" />
   </Target>
 

--- a/TechTalk.SpecFlow.Tools/MsBuild/TechTalk.SpecFlow.targets
+++ b/TechTalk.SpecFlow.Tools/MsBuild/TechTalk.SpecFlow.targets
@@ -49,6 +49,10 @@
   </ItemGroup>
 
 
+  <Target Name="WarnForFeatureCodeBehindFilesWithoutCorrespondingFeatureFile" AfterTargets="CoreCompile">
+    <Warning Text="For codebehind file '@(SpecFlowObsoleteCodeBehindFiles)', no feature file was found." File="@(SpecFlowObsoleteCodeBehindFiles)" Condition="'@(SpecFlowObsoleteCodeBehindFiles)' != ''" />
+  </Target>
+
   <Target Name="SwitchToForceGenerate">
     <PropertyGroup>
       <ForceGeneration>true</ForceGeneration>
@@ -100,8 +104,6 @@
       <!-- remove files which got obsolete, typically after rename operation, or getting changes from source control -->
       <Compile Remove="@(SpecFlowObsoleteCodeBehindFiles)" />
     </ItemGroup>
-
-    <Warning Text="Existing generated codebehind files for not existing feature files will be ignored '$(SpecFlowObsoleteCodeBehindFiles)'" Condition="'$(SpecFlowObsoleteCodeBehindFiles)' != ''" />
   </Target>
 
 

--- a/TechTalk.SpecFlow.Tools/MsBuild/TechTalk.SpecFlow.tasks
+++ b/TechTalk.SpecFlow.Tools/MsBuild/TechTalk.SpecFlow.tasks
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
   <PropertyGroup>
     <SpecFlowTasksPath Condition="'$(SpecFlowTasksPath)'==''">specflow.exe</SpecFlowTasksPath>
   </PropertyGroup>
@@ -8,10 +9,9 @@
     <!-- handle absolute / targets-relative tasks path -->
     <__SpecFlowTasksFullPath>$(SpecFlowTasksPath)</__SpecFlowTasksFullPath>
     <!-- handle relative tasks path -->
-    <__SpecFlowTasksFullPath Condition="Exists('$(MSBuildProjectDirectory)\$(SpecFlowTasksPath)')"
-      >$(MSBuildProjectDirectory)\$(SpecFlowTasksPath)</__SpecFlowTasksFullPath>
+    <__SpecFlowTasksFullPath Condition="Exists('$(MSBuildProjectDirectory)\$(SpecFlowTasksPath)')">$(MSBuildProjectDirectory)\$(SpecFlowTasksPath)</__SpecFlowTasksFullPath>
   </PropertyGroup>
-  
+
   <UsingTask TaskName="TechTalk.SpecFlow.Tools.MsBuild.GenerateAll" AssemblyFile="$(__SpecFlowTasksFullPath)" />
 
 </Project>

--- a/TechTalk.SpecFlow.sln
+++ b/TechTalk.SpecFlow.sln
@@ -71,6 +71,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Licenses", "Licenses", "{D7
 		Licenses\System.ValueTuple-LICENSE-MIT.txt = Licenses\System.ValueTuple-LICENSE-MIT.txt
 	EndProjectSection
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TechTalk.SpecFlow.MsBuildNetSdk.IntegrationTests", "Tests\TechTalk.SpecFlow.MsBuildNetSdk.IntegrationTests\TechTalk.SpecFlow.MsBuildNetSdk.IntegrationTests.csproj", "{02A08F81-B90F-4EB3-9C30-CE7447DE2012}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -173,6 +175,12 @@ Global
 		{FA04B445-D04C-4075-9EB0-4D0A70E47FC4}.Release|Any CPU.Build.0 = Release|Any CPU
 		{FA04B445-D04C-4075-9EB0-4D0A70E47FC4}.VS2010IntegrationTest|Any CPU.ActiveCfg = Debug|Any CPU
 		{FA04B445-D04C-4075-9EB0-4D0A70E47FC4}.VS2010IntegrationTest|Any CPU.Build.0 = Debug|Any CPU
+		{02A08F81-B90F-4EB3-9C30-CE7447DE2012}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{02A08F81-B90F-4EB3-9C30-CE7447DE2012}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{02A08F81-B90F-4EB3-9C30-CE7447DE2012}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{02A08F81-B90F-4EB3-9C30-CE7447DE2012}.Release|Any CPU.Build.0 = Release|Any CPU
+		{02A08F81-B90F-4EB3-9C30-CE7447DE2012}.VS2010IntegrationTest|Any CPU.ActiveCfg = Debug|Any CPU
+		{02A08F81-B90F-4EB3-9C30-CE7447DE2012}.VS2010IntegrationTest|Any CPU.Build.0 = Debug|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -189,6 +197,7 @@ Global
 		{D87E7021-4926-4F5A-AC81-92AFC575FB7E} = {577A0375-1436-446C-802B-3C75C8CEF94F}
 		{DBEEB615-5991-46BC-B274-1516BD0F3D91} = {A10B5CD6-38EC-4D7E-9D1C-2EBA8017E437}
 		{FA04B445-D04C-4075-9EB0-4D0A70E47FC4} = {A10B5CD6-38EC-4D7E-9D1C-2EBA8017E437}
+		{02A08F81-B90F-4EB3-9C30-CE7447DE2012} = {A10B5CD6-38EC-4D7E-9D1C-2EBA8017E437}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {6C32F919-B9E8-48E8-BD8D-566E54B9A27D}

--- a/Tests/TechTalk.SpecFlow.IntegrationTests/App.config
+++ b/Tests/TechTalk.SpecFlow.IntegrationTests/App.config
@@ -3,7 +3,7 @@
   <configSections>
     <section name="specFlow" type="TechTalk.SpecFlow.Configuration.ConfigurationSectionHandler, TechTalk.SpecFlow"/>
   </configSections>
-  
+
   <appSettings>
     <add key="testProjectFolder" value="SpecFlowTestProject"/>
   </appSettings>
@@ -11,11 +11,15 @@
     <!-- For additional details on SpecFlow configuration options see http://go.specflow.org/doc-config -->
     <generator allowRowTests="false" markFeaturesParallelizable="true">
       <skipParallelizableMarkerForTags>
-         <tag value="NotParallel"/>
+        <tag value="NotParallel"/>
       </skipParallelizableMarkerForTags>
     </generator>
     <stepAssemblies>
       <stepAssembly assembly="TechTalk.SpecFlow.Specs"/>
     </stepAssemblies>
-  <!-- For additional details on SpecFlow configuration options see http://go.specflow.org/doc-config --></specFlow>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6"/></startup></configuration>
+    <!-- For additional details on SpecFlow configuration options see http://go.specflow.org/doc-config -->
+  </specFlow>
+  <startup>
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6"/>
+  </startup>
+</configuration>

--- a/Tests/TechTalk.SpecFlow.IntegrationTests/TechTalk.SpecFlow.IntegrationTests.csproj
+++ b/Tests/TechTalk.SpecFlow.IntegrationTests/TechTalk.SpecFlow.IntegrationTests.csproj
@@ -46,13 +46,31 @@
       <HintPath>..\..\packages\FluentAssertions.4.19.0\lib\net45\FluentAssertions.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.Build" />
+    <Reference Include="Microsoft.Build, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Build.15.3.409\lib\net46\Microsoft.Build.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Build.Framework, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Build.Framework.15.3.409\lib\net46\Microsoft.Build.Framework.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Build.Utilities.Core, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Build.Utilities.Core.15.3.409\lib\net46\Microsoft.Build.Utilities.Core.dll</HintPath>
+    </Reference>
     <Reference Include="nunit.framework, Version=3.2.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
       <HintPath>..\..\packages\NUnit.3.2.1\lib\net45\nunit.framework.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Collections.Immutable, Version=1.2.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Collections.Immutable.1.3.1\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
+    </Reference>
+    <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Runtime.InteropServices.RuntimeInformation, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Runtime.InteropServices.RuntimeInformation.4.3.0\lib\net45\System.Runtime.InteropServices.RuntimeInformation.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Threading.Thread, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Threading.Thread.4.0.0\lib\net46\System.Threading.Thread.dll</HintPath>
+    </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />

--- a/Tests/TechTalk.SpecFlow.IntegrationTests/TechTalk.SpecFlow.IntegrationTests.csproj
+++ b/Tests/TechTalk.SpecFlow.IntegrationTests/TechTalk.SpecFlow.IntegrationTests.csproj
@@ -54,8 +54,6 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
     <Reference Include="xunit, Version=1.9.2.1705, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">

--- a/Tests/TechTalk.SpecFlow.IntegrationTests/packages.config
+++ b/Tests/TechTalk.SpecFlow.IntegrationTests/packages.config
@@ -2,9 +2,23 @@
 <packages>
   <package id="FluentAssertions" version="4.19.0" targetFramework="net45" />
   <package id="GitVersionTask" version="4.0.0-beta0012" targetFramework="net46" developmentDependency="true" />
+  <package id="Microsoft.Build" version="15.3.409" targetFramework="net46" />
+  <package id="Microsoft.Build.Framework" version="15.3.409" targetFramework="net46" />
+  <package id="Microsoft.Build.Utilities.Core" version="15.3.409" targetFramework="net46" />
   <package id="NUnit" version="3.2.1" targetFramework="net45" />
   <package id="NUnit3TestAdapter" version="3.9.0" targetFramework="net46" />
   <package id="SpecFlow" version="2.1.0" targetFramework="net45" />
+  <package id="System.Collections" version="4.0.11" targetFramework="net46" />
+  <package id="System.Collections.Immutable" version="1.3.1" targetFramework="net46" />
+  <package id="System.Diagnostics.Debug" version="4.0.11" targetFramework="net46" />
+  <package id="System.Globalization" version="4.0.11" targetFramework="net46" />
+  <package id="System.Linq" version="4.1.0" targetFramework="net46" />
+  <package id="System.Resources.ResourceManager" version="4.0.1" targetFramework="net46" />
+  <package id="System.Runtime" version="4.1.0" targetFramework="net46" />
+  <package id="System.Runtime.InteropServices" version="4.1.0" targetFramework="net46" />
+  <package id="System.Runtime.InteropServices.RuntimeInformation" version="4.3.0" targetFramework="net46" />
+  <package id="System.Threading" version="4.0.11" targetFramework="net46" />
+  <package id="System.Threading.Thread" version="4.0.0" targetFramework="net46" />
   <package id="xunit" version="1.9.2" targetFramework="net45" />
   <package id="xunit.extensions" version="1.9.2" targetFramework="net45" />
 </packages>

--- a/Tests/TechTalk.SpecFlow.MsBuildNetSdk.IntegrationTests/App.config
+++ b/Tests/TechTalk.SpecFlow.MsBuildNetSdk.IntegrationTests/App.config
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <configSections>
+    <section name="specFlow" type="TechTalk.SpecFlow.Configuration.ConfigurationSectionHandler, TechTalk.SpecFlow"/>
+  </configSections>
+  <appSettings>
+    <add key="testProjectFolder" value="SpecFlowTestProject"/>
+  </appSettings>
+  <specFlow>
+    <unitTestProvider name="NUnit"/>
+  </specFlow>
+  <startup>
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6"/>
+  </startup>
+</configuration>

--- a/Tests/TechTalk.SpecFlow.MsBuildNetSdk.IntegrationTests/Bindings/DoNothingBinding.cs
+++ b/Tests/TechTalk.SpecFlow.MsBuildNetSdk.IntegrationTests/Bindings/DoNothingBinding.cs
@@ -1,0 +1,21 @@
+﻿namespace TechTalk.SpecFlow.MsBuildNetSdk.IntegrationTests.Features
+{
+    [Binding]
+    public class DoNothingBinding
+    {
+        [Given(".*"), When(".*"), Then(".*")]
+        public void EmptyStep()
+        {
+        }
+
+        [Given(".*"), When(".*"), Then(".*")]
+        public void EmptyStep(string multiLineStringParam)
+        {
+        }
+
+        [Given(".*"), When(".*"), Then(".*")]
+        public void EmptyStep(Table tableParam)
+        {
+        }
+    }
+}

--- a/Tests/TechTalk.SpecFlow.MsBuildNetSdk.IntegrationTests/CodeBehindFileGenerationTests.cs
+++ b/Tests/TechTalk.SpecFlow.MsBuildNetSdk.IntegrationTests/CodeBehindFileGenerationTests.cs
@@ -1,0 +1,18 @@
+﻿using System.Reflection;
+using NUnit.Framework;
+using TechTalk.SpecFlow.MsBuildNetSdk.IntegrationTests.Features;
+
+namespace TechTalk.SpecFlow.MsBuildNetSdk.IntegrationTests
+{
+    [TestFixture]
+    public class CodeBehindFileGenerationTests
+    {
+        [Test]
+        public void TestIfCodeBehindFilesWasGeneratedAndCompiled()
+        {
+            var assemblyHoldingThisClass = Assembly.GetExecutingAssembly();
+            var typeOfGeneratedFeatureFile = assemblyHoldingThisClass.GetType(nameof(DummyFeatureFileToTestMSBuildNetsdkCodebehindFileGenerationFeature));
+            Assert.IsNotNull(typeOfGeneratedFeatureFile);
+        }
+    }
+}

--- a/Tests/TechTalk.SpecFlow.MsBuildNetSdk.IntegrationTests/Features/dummy.feature
+++ b/Tests/TechTalk.SpecFlow.MsBuildNetSdk.IntegrationTests/Features/dummy.feature
@@ -1,0 +1,7 @@
+﻿Feature: Dummy feature file to test MSBuild netsdk codebehind file generation
+
+Scenario: Dummy scenario
+	Given I have a net.sdk style project
+	When the project is build
+	Then msbuild integration will generate code behind files
+	And nest generated codebehind files under corresponding feature file

--- a/Tests/TechTalk.SpecFlow.MsBuildNetSdk.IntegrationTests/TechTalk.SpecFlow.MsBuildNetSdk.IntegrationTests.csproj
+++ b/Tests/TechTalk.SpecFlow.MsBuildNetSdk.IntegrationTests/TechTalk.SpecFlow.MsBuildNetSdk.IntegrationTests.csproj
@@ -1,0 +1,47 @@
+﻿<Project>
+
+  <!--
+    manual import sdk to be able to simulate nuget based imports
+
+  -->
+  <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
+
+  <PropertyGroup>
+    <TargetFramework>net462</TargetFramework>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <SpecFlowTasksPath>..\..\TechTalk.SpecFlow.Tools\bin\$(Configuration)\specflow.exe</SpecFlowTasksPath>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="NUnit" Version="3.2.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.9.0" />
+  </ItemGroup>
+
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\TechTalk.SpecFlow\TechTalk.SpecFlow.csproj" />
+  </ItemGroup>
+
+
+  <ItemGroup>
+    <None Update="App.config">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
+  <!-- manual import sdk to be able to simulate nuget based imports-->
+  <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
+
+  <PropertyGroup>
+    <!-- enable experimental support for net.sdk projects via feature flag -->
+    <SpecFlow_EnableDefaultCompileItems>true</SpecFlow_EnableDefaultCompileItems>
+  </PropertyGroup>
+
+  <!-- simulate nuget imports here-->
+  <Import Project="..\..\TechTalk.SpecFlow.Tools\MsBuild\TechTalk.SpecFlow.tasks" />
+  <Import Project="..\..\TechTalk.SpecFlow.Tools\MsBuild\TechTalk.SpecFlow.targets" />
+
+
+</Project>

--- a/Tests/TechTalk.SpecFlow.Specs/App.config
+++ b/Tests/TechTalk.SpecFlow.Specs/App.config
@@ -10,5 +10,7 @@
     <unitTestProvider name="NUnit"/>
     <generator allowRowTests="false"/>
   </specFlow>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6"/></startup></configuration>
- 
+  <startup>
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6"/>
+  </startup>
+</configuration>

--- a/Tests/TechTalk.SpecFlow.Specs/TechTalk.SpecFlow.Specs.csproj
+++ b/Tests/TechTalk.SpecFlow.Specs/TechTalk.SpecFlow.Specs.csproj
@@ -52,8 +52,15 @@
     <Reference Include="Gherkin, Version=5.0.0.0, Culture=neutral, PublicKeyToken=86496cfa5b4a5851, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Gherkin.5.1.0\lib\net45\Gherkin.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Build" />
-    <Reference Include="Microsoft.Build.Framework" />
+    <Reference Include="Microsoft.Build, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Build.15.3.409\lib\net46\Microsoft.Build.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Build.Framework, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Build.Framework.15.3.409\lib\net46\Microsoft.Build.Framework.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Build.Utilities.Core, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Build.Utilities.Core.15.3.409\lib\net46\Microsoft.Build.Utilities.Core.dll</HintPath>
+    </Reference>
     <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Newtonsoft.Json.10.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
@@ -65,8 +72,18 @@
       <HintPath>..\..\packages\NUnit.ConsoleRunner.3.2.1\tools\nunit3-console.exe</HintPath>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Collections.Immutable, Version=1.2.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Collections.Immutable.1.3.1\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
+    </Reference>
+    <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Runtime.InteropServices.RuntimeInformation, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Runtime.InteropServices.RuntimeInformation.4.3.0\lib\net45\System.Runtime.InteropServices.RuntimeInformation.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Threading.Thread, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Threading.Thread.4.0.0\lib\net46\System.Threading.Thread.dll</HintPath>
+    </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />

--- a/Tests/TechTalk.SpecFlow.Specs/packages.config
+++ b/Tests/TechTalk.SpecFlow.Specs/packages.config
@@ -3,6 +3,9 @@
   <package id="FluentAssertions" version="4.19.0" targetFramework="net45" />
   <package id="Gherkin" version="5.1.0" targetFramework="net46" />
   <package id="GitVersionTask" version="4.0.0-beta0012" targetFramework="net46" developmentDependency="true" />
+  <package id="Microsoft.Build" version="15.3.409" targetFramework="net46" />
+  <package id="Microsoft.Build.Framework" version="15.3.409" targetFramework="net46" />
+  <package id="Microsoft.Build.Utilities.Core" version="15.3.409" targetFramework="net46" />
   <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net46" />
   <package id="NUnit" version="3.2.1" targetFramework="net45" />
   <package id="NUnit.ConsoleRunner" version="3.2.1" targetFramework="net45" />
@@ -13,6 +16,17 @@
   <package id="NUnit.Runners" version="3.2.1" targetFramework="net45" />
   <package id="NUnit3TestAdapter" version="3.9.0" targetFramework="net46" />
   <package id="SpecFlow" version="2.1.0" targetFramework="net45" />
+  <package id="System.Collections" version="4.0.11" targetFramework="net46" />
+  <package id="System.Collections.Immutable" version="1.3.1" targetFramework="net46" />
+  <package id="System.Diagnostics.Debug" version="4.0.11" targetFramework="net46" />
+  <package id="System.Globalization" version="4.0.11" targetFramework="net46" />
+  <package id="System.Linq" version="4.1.0" targetFramework="net46" />
+  <package id="System.Resources.ResourceManager" version="4.0.1" targetFramework="net46" />
+  <package id="System.Runtime" version="4.1.0" targetFramework="net46" />
+  <package id="System.Runtime.InteropServices" version="4.1.0" targetFramework="net46" />
+  <package id="System.Runtime.InteropServices.RuntimeInformation" version="4.3.0" targetFramework="net46" />
+  <package id="System.Threading" version="4.0.11" targetFramework="net46" />
+  <package id="System.Threading.Thread" version="4.0.0" targetFramework="net46" />
   <package id="xunit" version="1.9.2" targetFramework="net45" />
   <package id="xunit.extensions" version="1.9.2" targetFramework="net45" />
   <package id="xunit.runner.console" version="2.0.0" />

--- a/changelog.txt
+++ b/changelog.txt
@@ -5,9 +5,10 @@ New Features:
 + Allow marking steps as Obsolete and have a configurable behavior for it https://github.com/techtalk/SpecFlow/pull/1140
 + IGherkinParser and IGherkinParserFactory interfaces added to support Gherkin Parser pluggability https://github.com/techtalk/SpecFlow/pull/1143
 + Assist: remove accents from column headers and property names when comparing objects to a table https://github.com/techtalk/SpecFlow/pull/1096
-+ MSBuild Generation: Experimental support for deleting code-behind files on clean and rebuild
 + Added NUnit current TestContext scenario container registration. See https://github.com/techtalk/SpecFlow/issues/936
 + Array & List support for strings and enums when instantiating class from Specflow table https://github.com/techtalk/SpecFlow/pull/1018
++ MSBuild: Experimental support for deleting code-behind files on clean and rebuild when MSBuild https://github.com/techtalk/SpecFlow/pull/1167, https://github.com/techtalk/SpecFlow/pull/1208
++ MSBuild: Experimental support for Net.SDK project system, only for targeting desktop framework, .net core is supported and won't work
 
 Fixes:
 + Expose ScenarioInfo.Description parameter to get from context https://github.com/techtalk/SpecFlow/pull/1078

--- a/changelog.txt
+++ b/changelog.txt
@@ -8,7 +8,7 @@ New Features:
 + Added NUnit current TestContext scenario container registration. See https://github.com/techtalk/SpecFlow/issues/936
 + Array & List support for strings and enums when instantiating class from Specflow table https://github.com/techtalk/SpecFlow/pull/1018
 + MSBuild: Experimental support for deleting code-behind files on clean and rebuild when MSBuild https://github.com/techtalk/SpecFlow/pull/1167, https://github.com/techtalk/SpecFlow/pull/1208
-+ MSBuild: Experimental support for Net.SDK project system, only for targeting desktop framework, .net core is supported and won't work
++ MSBuild: Experimental support for Net.SDK project system, only for targeting desktop framework, .net core is supported and won't work https://github.com/techtalk/SpecFlow/pull/1223
 
 Fixes:
 + Expose ScenarioInfo.Description parameter to get from context https://github.com/techtalk/SpecFlow/pull/1078


### PR DESCRIPTION
This pull request extends support for net.sdk project system when MSBuild Generation is used
- enables usage of net.sdk project type system when **targeting desktop framework => not .net core support**
- globbing support for nesting codebehind files under feature files
- fixed handling of added and removed codebehind files after regeneration
- added warning if codebehind files without corresponding feature file is present (only for net.sdk project system enabled by default)

As this integration is experimental, you have to enable it via the following MSBuild property
- inside your csproj
- or using on of the directory or solution extension points in MSBuild https://docs.microsoft.com/en-us/visualstudio/msbuild/customize-your-build

``` 
  <PropertyGroup>
    <!-- enable experimental support for net.sdk projects via feature flag -->
    <SpecFlow_EnableDefaultCompileItems>true</SpecFlow_EnableDefaultCompileItems>
    <!-- enable experimental support to warn if code behind files are exisiting without corresponding feature file -->
    <SpecFlow_EnableWarnForFeatureCodeBehindFilesWithoutCorrespondingFeatureFile>true</SpecFlow_EnableWarnForFeatureCodeBehindFilesWithoutCorrespondingFeatureFile>
  </PropertyGroup>
```

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've added tests for my code.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added an entry to the changelog
