### PR TITLE
introduce constructor which takes pluginType as string and parse the …

### DIFF
--- a/TechTalk.SpecFlow/Infrastructure/GeneratorPluginAttribute.cs
+++ b/TechTalk.SpecFlow/Infrastructure/GeneratorPluginAttribute.cs
@@ -3,15 +3,21 @@ using System;
 namespace TechTalk.SpecFlow.Infrastructure
 {
     [AttributeUsage(AttributeTargets.Assembly, AllowMultiple = false)]
-    public class GeneratorPluginAttribute: Attribute
+    public class GeneratorPluginAttribute : Attribute
     {
         public Type PluginType { get; private set; }
 
         public GeneratorPluginAttribute(Type pluginType)
         {
-            if (pluginType == null) throw new ArgumentNullException("pluginType");
+            PluginType = pluginType ?? throw new ArgumentNullException(nameof(pluginType));
+        }
 
-            PluginType = pluginType;
+        public GeneratorPluginAttribute(string pluginType)
+        {
+            if (string.IsNullOrEmpty(pluginType)) throw new ArgumentNullException(nameof(pluginType));
+
+            var type = Type.GetType(pluginType);
+            PluginType = type ?? throw new ArgumentException(nameof(pluginType));
         }
     }
 }


### PR DESCRIPTION
introduce constructor in GeneratorPluginAttribute which takes pluginType as string and parse the type from it.

<!--- Describe your changes in detail -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added an entry to the changelog
