### PR TITLE
Separate addition of default and non-default value comparers.

### DIFF
--- a/TechTalk.SpecFlow/Assist/Service.cs
+++ b/TechTalk.SpecFlow/Assist/Service.cs
@@ -35,10 +35,12 @@ namespace TechTalk.SpecFlow.Assist
 
         public void RegisterValueComparer(IValueComparer valueComparer)
         {
-            if (valueComparer.GetType() == typeof(DefaultValueComparer))
-              _registeredValueComparers.Add(valueComparer);
-            else
-              _registeredValueComparers.Insert(0, valueComparer);
+            _registeredValueComparers.Insert(0, valueComparer);
+        }
+
+        public void RegisterDefaultValueComparer(IValueComparer valueComparer)
+        {
+            _registeredValueComparers.Add(valueComparer);
         }
 
         public void UnregisterValueComparer(IValueComparer valueComparer)
@@ -64,7 +66,7 @@ namespace TechTalk.SpecFlow.Assist
             RegisterValueComparer(new DecimalValueComparer());
             RegisterValueComparer(new DoubleValueComparer());
             RegisterValueComparer(new FloatValueComparer());
-            RegisterValueComparer(new DefaultValueComparer());
+            RegisterDefaultValueComparer(new DefaultValueComparer());
 
             RegisterValueRetriever(new StringValueRetriever());
             RegisterValueRetriever(new ByteValueRetriever());

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/ServiceTests.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/ServiceTests.cs
@@ -97,6 +97,16 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests
         }
 
         [Test]
+        public void Should_allow_the_addition_of_new_default_value_comparers()
+        {
+            var service = new Service();
+
+            var thing = new IExistsForTestingValueComparing();
+            service.RegisterDefaultValueComparer(thing);
+            Assert.AreSame(thing, service.ValueComparers.Last());
+        }
+
+        [Test]
         public void Should_allow_the_removal_and_addition_of_new_value_retrievers()
         {
             var service = new Service();

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,7 @@
+2.5 - 2018-??-??
+New Features:
++ Separate addition of default and non-default value comparers https://github.com/techtalk/SpecFlow/pull/1257
+
 2.4 - 2018-08-20
 New Features:
 + Added ability to convert type to same type or one of the base types https://github.com/techtalk/SpecFlow/pull/1110


### PR DESCRIPTION
Currently, replacing only the default value comparer while keeping all others the same involves rather a lot of code:

	var existingComparers = Service.Instance.ValueComparers.ToList();
	foreach (var existingComparer in existingComparers)
	{
		Service.Instance.UnregisterValueComparer(existingComparer);
	}

	Service.Instance.RegisterValueComparer(new NullConversionDefaultValueComparer());
	foreach (var existingComparer in existingComparers.Where(x => !(x is DefaultValueComparer)))
	{
		Service.Instance.RegisterValueComparer(existingComparer);
	}

This change separates the handling of default and non-default value comparers, and stops it splitting on the type.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added an entry to the changelog
