### PR TITLE
ComparisonException indicates which value comparer was used for each difference

### DIFF
--- a/TechTalk.SpecFlow/Assist/InstanceComparisonExtensionMethods.cs
+++ b/TechTalk.SpecFlow/Assist/InstanceComparisonExtensionMethods.cs
@@ -106,14 +106,16 @@ namespace TechTalk.SpecFlow.Assist
 
         private static Difference CreateDifferenceForThisRow<T>(T instance, TableRow row)
         {
+            var propertyName = row.Id();
+
             if (ThePropertyDoesNotExist(instance, row))
                 return new Difference
                 {
-                    Property = row.Id(),
+                    Property = propertyName,
                     DoesNotExist = true
                 };
 
-            var propertyValue = instance.GetPropertyValue(row.Id());
+            var propertyValue = instance.GetPropertyValue(propertyName);
 
             var valueComparers = Service.Instance.ValueComparers;
 
@@ -122,9 +124,9 @@ namespace TechTalk.SpecFlow.Assist
 
             return new Difference
             {
-                Property = row.Id(),
+                Property = propertyName,
                 Expected = row.Value(),
-                Actual = instance.GetPropertyValue(row.Id()),
+                Actual = instance.GetPropertyValue(propertyName),
                 Comparer = comparer,
             };
         }

--- a/TechTalk.SpecFlow/Assist/InstanceComparisonExtensionMethods.cs
+++ b/TechTalk.SpecFlow/Assist/InstanceComparisonExtensionMethods.cs
@@ -113,11 +113,19 @@ namespace TechTalk.SpecFlow.Assist
                     DoesNotExist = true
                 };
 
+            var propertyValue = instance.GetPropertyValue(row.Id());
+
+            var valueComparers = Service.Instance.ValueComparers;
+
+            var comparer = valueComparers
+                .FirstOrDefault(x => x.CanCompare(propertyValue));
+
             return new Difference
             {
                 Property = row.Id(),
                 Expected = row.Value(),
-                Actual = instance.GetPropertyValue(row.Id())
+                Actual = instance.GetPropertyValue(row.Id()),
+                Comparer = comparer,
             };
         }
 

--- a/TechTalk.SpecFlow/Assist/InstanceComparisonExtensionMethods.cs
+++ b/TechTalk.SpecFlow/Assist/InstanceComparisonExtensionMethods.cs
@@ -53,7 +53,7 @@ namespace TechTalk.SpecFlow.Assist
         {
             return difference.DoesNotExist
                 ? $"{difference.Property}: Property does not exist"
-                : $"{difference.Property}: Expected <{difference.Expected}>, Actual <{difference.Actual}>";
+                : $"{difference.Property}: Expected <{difference.Expected}>, Actual <{difference.Actual}>, Using '{difference.Comparer.GetType().FullName}'";
         }
 
         private static Difference[] FindAnyDifferences<T>(Table table, T instance)

--- a/TechTalk.SpecFlow/Assist/InstanceComparisonExtensionMethods.cs
+++ b/TechTalk.SpecFlow/Assist/InstanceComparisonExtensionMethods.cs
@@ -51,16 +51,16 @@ namespace TechTalk.SpecFlow.Assist
 
         private static string DescribeTheErrorForThisDifference(Difference difference)
         {
-            return difference.DoesNotExist 
-                ? $"{difference.Property}: Property does not exist" 
+            return difference.DoesNotExist
+                ? $"{difference.Property}: Property does not exist"
                 : $"{difference.Property}: Expected <{difference.Expected}>, Actual <{difference.Actual}>";
         }
 
         private static Difference[] FindAnyDifferences<T>(Table table, T instance)
         {
             return (from row in table.Rows
-                   where ThePropertyDoesNotExist(instance, row) || TheValuesDoNotMatch(instance, row)
-                   select CreateDifferenceForThisRow(instance, row)).ToArray();
+                    where ThePropertyDoesNotExist(instance, row) || TheValuesDoNotMatch(instance, row)
+                    select CreateDifferenceForThisRow(instance, row)).ToArray();
         }
 
         private static bool HasDifference<T>(Table table, T instance)
@@ -108,17 +108,17 @@ namespace TechTalk.SpecFlow.Assist
         {
             if (ThePropertyDoesNotExist(instance, row))
                 return new Difference
-                           {
-                               Property = row.Id(),
-                               DoesNotExist = true
-                           };
+                {
+                    Property = row.Id(),
+                    DoesNotExist = true
+                };
 
             return new Difference
-                       {
-                           Property = row.Id(),
-                           Expected = row.Value(),
-                           Actual = instance.GetPropertyValue(row.Id())
-                       };
+            {
+                Property = row.Id(),
+                Expected = row.Value(),
+                Actual = instance.GetPropertyValue(row.Id())
+            };
         }
 
         private class Difference

--- a/TechTalk.SpecFlow/Assist/InstanceComparisonExtensionMethods.cs
+++ b/TechTalk.SpecFlow/Assist/InstanceComparisonExtensionMethods.cs
@@ -46,12 +46,7 @@ namespace TechTalk.SpecFlow.Assist
         private static string CreateDescriptiveErrorMessage(IEnumerable<Difference> differences)
         {
             return differences.Aggregate(@"The following fields did not match:",
-                                         (sum, next) => sum + (Environment.NewLine + DescribeTheErrorForThisDifference(next)));
-        }
-
-        private static string DescribeTheErrorForThisDifference(Difference difference)
-        {
-            return difference.Description;
+                                         (sum, next) => sum + (Environment.NewLine + next.Description));
         }
 
         private static Difference[] FindAnyDifferences<T>(Table table, T instance)

--- a/TechTalk.SpecFlow/Assist/InstanceComparisonExtensionMethods.cs
+++ b/TechTalk.SpecFlow/Assist/InstanceComparisonExtensionMethods.cs
@@ -91,11 +91,9 @@ namespace TechTalk.SpecFlow.Assist
         {
             var expected = GetTheExpectedValue(row);
             var propertyValue = instance.GetPropertyValue(row.Id());
+            var comparer = FindValueComparerForValue(propertyValue);
 
-            var valueComparers = Service.Instance.ValueComparers;
-
-            return valueComparers
-                .FirstOrDefault(x => x.CanCompare(propertyValue))
+            return comparer
                 .Compare(expected, propertyValue) == false;
         }
 
@@ -115,12 +113,7 @@ namespace TechTalk.SpecFlow.Assist
                     DoesNotExist = true
                 };
 
-            var propertyValue = instance.GetPropertyValue(propertyName);
-
-            var valueComparers = Service.Instance.ValueComparers;
-
-            var comparer = valueComparers
-                .FirstOrDefault(x => x.CanCompare(propertyValue));
+            var comparer = FindValueComparerForProperty(instance, propertyName);
 
             return new Difference
             {
@@ -129,6 +122,21 @@ namespace TechTalk.SpecFlow.Assist
                 Actual = instance.GetPropertyValue(propertyName),
                 Comparer = comparer,
             };
+        }
+
+        private static IValueComparer FindValueComparerForProperty<T>(T instance, string propertyName)
+        {
+            var propertyValue = instance.GetPropertyValue(propertyName);
+
+            return FindValueComparerForValue(propertyValue);
+        }
+
+        private static IValueComparer FindValueComparerForValue(object propertyValue)
+        {
+            var valueComparers = Service.Instance.ValueComparers;
+
+            return valueComparers
+                .FirstOrDefault(x => x.CanCompare(propertyValue));
         }
 
         private class Difference

--- a/TechTalk.SpecFlow/Assist/InstanceComparisonExtensionMethods.cs
+++ b/TechTalk.SpecFlow/Assist/InstanceComparisonExtensionMethods.cs
@@ -127,6 +127,7 @@ namespace TechTalk.SpecFlow.Assist
             public object Expected { get; set; }
             public object Actual { get; set; }
             public bool DoesNotExist { get; set; }
+            public IValueComparer Comparer { get; set; }
         }
     }
 

--- a/TechTalk.SpecFlow/Assist/InstanceComparisonExtensionMethods.cs
+++ b/TechTalk.SpecFlow/Assist/InstanceComparisonExtensionMethods.cs
@@ -124,20 +124,13 @@ namespace TechTalk.SpecFlow.Assist
             };
         }
 
-        private static IValueComparer FindValueComparerForProperty<T>(T instance, string propertyName)
-        {
-            var propertyValue = instance.GetPropertyValue(propertyName);
+        private static IValueComparer FindValueComparerForProperty<T>(T instance, string propertyName) =>
+            FindValueComparerForValue(
+                instance.GetPropertyValue(propertyName));
 
-            return FindValueComparerForValue(propertyValue);
-        }
-
-        private static IValueComparer FindValueComparerForValue(object propertyValue)
-        {
-            var valueComparers = Service.Instance.ValueComparers;
-
-            return valueComparers
+        private static IValueComparer FindValueComparerForValue(object propertyValue) =>
+            Service.Instance.ValueComparers
                 .FirstOrDefault(x => x.CanCompare(propertyValue));
-        }
 
         private class Difference
         {

--- a/TechTalk.SpecFlow/Assist/InstanceComparisonExtensionMethods.cs
+++ b/TechTalk.SpecFlow/Assist/InstanceComparisonExtensionMethods.cs
@@ -102,10 +102,9 @@ namespace TechTalk.SpecFlow.Assist
             if (ThePropertyDoesNotExist(instance, row))
                 return new PropertyDoesNotExist(propertyName);
 
-            var comparer = FindValueComparerForProperty(instance, propertyName);
-
             var expected = row.Value();
             var actual = instance.GetPropertyValue(propertyName);
+            var comparer = FindValueComparerForProperty(instance, propertyName);
             return new PropertyDiffers(propertyName, expected, actual, comparer);
         }
 

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/InstanceComparisonExtensionMethodsTests.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/InstanceComparisonExtensionMethodsTests.cs
@@ -125,7 +125,7 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests
 
             exception.Message.AgnosticLineBreak().Should().Be(
                 @"The following fields did not match:
-StringProperty: Expected <Howard Roark>, Actual <Peter Keating>".AgnosticLineBreak());
+StringProperty: Expected <Howard Roark>, Actual <Peter Keating>, Using 'TechTalk.SpecFlow.Assist.ValueComparers.DefaultValueComparer'".AgnosticLineBreak());
         }
 
         [Test]
@@ -145,8 +145,8 @@ StringProperty: Expected <Howard Roark>, Actual <Peter Keating>".AgnosticLineBre
 
             exception.Message.AgnosticLineBreak().Should().Be(
                 @"The following fields did not match:
-StringProperty: Expected <Howard Roark>, Actual <Peter Keating>
-IntProperty: Expected <1>, Actual <2>".AgnosticLineBreak());
+StringProperty: Expected <Howard Roark>, Actual <Peter Keating>, Using 'TechTalk.SpecFlow.Assist.ValueComparers.DefaultValueComparer'
+IntProperty: Expected <1>, Actual <2>, Using 'TechTalk.SpecFlow.Assist.ValueComparers.DefaultValueComparer'".AgnosticLineBreak());
         }
 
         [Test]

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/InstanceComparisonExtensionMethodsTests.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/InstanceComparisonExtensionMethodsTests.cs
@@ -51,10 +51,10 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests
             table.AddRow("IntProperty", "20");
 
             var test = new InstanceComparisonTestObject
-                           {
-                               StringProperty = "Howard Roark",
-                               IntProperty = 10
-                           };
+            {
+                StringProperty = "Howard Roark",
+                IntProperty = 10
+            };
 
             ComparisonTestResult comparisonResult = ExceptionWasThrownByThisComparison(table, test);
 
@@ -136,10 +136,10 @@ StringProperty: Expected <Howard Roark>, Actual <Peter Keating>".AgnosticLineBre
             table.AddRow("IntProperty", "1");
 
             var test = new InstanceComparisonTestObject
-                           {
-                               StringProperty = "Peter Keating",
-                               IntProperty = 2
-                           };
+            {
+                StringProperty = "Peter Keating",
+                IntProperty = 2
+            };
 
             var exception = GetExceptionThrownByThisComparison(table, test);
 
@@ -170,16 +170,16 @@ IDoNotExist: Property does not exist".AgnosticLineBreak());
             table.AddRow("BoolProperty", "true");
 
             ComparisonTestResult comparisonResult = ExceptionWasThrownByThisComparison(table, new InstanceComparisonTestObject
-                                                                                                        {
-                                                                                                            BoolProperty = true
-                                                                                                        });
+            {
+                BoolProperty = true
+            });
 
             comparisonResult.ExceptionWasThrown.Should().BeFalse(comparisonResult.ExceptionMessage);
 
             comparisonResult = ExceptionWasThrownByThisComparison(table, new InstanceComparisonTestObject
-                                                                                                    {
-                                                                                                        BoolProperty = false
-                                                                                                    });
+            {
+                BoolProperty = false
+            });
 
             comparisonResult.ExceptionWasThrown.Should().BeTrue(comparisonResult.ExceptionMessage);
         }
@@ -191,9 +191,9 @@ IDoNotExist: Property does not exist".AgnosticLineBreak());
             table.AddRow("GuidProperty", "DFFC3F4E-670A-400A-8212-C6841E2EA055");
 
             ComparisonTestResult comparisonResult = ExceptionWasThrownByThisComparison(table, new InstanceComparisonTestObject
-                                                                                                        {
-                                                                                                            GuidProperty = new Guid("DFFC3F4E-670A-400A-8212-C6841E2EA055")
-                                                                                                        });
+            {
+                GuidProperty = new Guid("DFFC3F4E-670A-400A-8212-C6841E2EA055")
+            });
 
             comparisonResult.ExceptionWasThrown.Should().BeFalse(comparisonResult.ExceptionMessage);
         }
@@ -204,9 +204,9 @@ IDoNotExist: Property does not exist".AgnosticLineBreak());
             var table = new Table("Field", "Value");
             table.AddRow("DecimalProperty", "4.23");
             var comparisonResult = ExceptionWasThrownByThisComparison(table, new InstanceComparisonTestObject
-                                                                                 {
-                                                                                     DecimalProperty = 4.23000000M
-                                                                                 });
+            {
+                DecimalProperty = 4.23000000M
+            });
 
             comparisonResult.ExceptionWasThrown.Should().BeFalse();
         }
@@ -264,12 +264,12 @@ IDoNotExist: Property does not exist".AgnosticLineBreak());
             table.AddRow("Test", "42", "23.01", "11.56");
 
             var test = new InstanceComparisonTestObject
-                           {
-                               StringProperty = "Test",
-                               IntProperty = 42,
-                               DecimalProperty = 23.01M,
-                               FloatProperty = 11.56F
-                           };
+            {
+                StringProperty = "Test",
+                IntProperty = 42,
+                DecimalProperty = 23.01M,
+                FloatProperty = 11.56F
+            };
 
             var comparisonResult = ExceptionWasThrownByThisComparison(table, test);
             comparisonResult.ExceptionWasThrown.Should().BeFalse(comparisonResult.ExceptionMessage);

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 3.0 - 2018-??-??
 New Features:
 + Separate addition of default and non-default value comparers https://github.com/techtalk/SpecFlow/pull/1257
++ ComparisonException indicates which value comparer was used for each difference https://github.com/techtalk/SpecFlow/issues/1253
 
 2.4 - 2018-08-20
 New Features:


### PR DESCRIPTION
Fixes #1253 

<!--- Describe your changes in detail -->
The ComparisonException indicates which `IValueComparer` was used for each difference, to help determine why two objects are seemingly different.

Before:
```
The following fields did not match:
StringProperty: Expected <Howard Roark>, Actual <Peter Keating>
IntProperty: Expected <1>, Actual <2>
```

After:
```
The following fields did not match:
StringProperty: Expected <Howard Roark>, Actual <Peter Keating>, Using 'TechTalk.SpecFlow.Assist.ValueComparers.DefaultValueComparer'
IntProperty: Expected <1>, Actual <2>, Using 'TechTalk.SpecFlow.Assist.ValueComparers.DefaultValueComparer'
```

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added an entry to the changelog
