### PR TITLE
Improve value retriever/comparer registration

### DIFF
--- a/TechTalk.SpecFlow/Assist/Service.cs
+++ b/TechTalk.SpecFlow/Assist/Service.cs
@@ -26,26 +26,31 @@ namespace TechTalk.SpecFlow.Assist
             ValueRetrievers = new SpecFlowDefaultValueRetrieverList();
         }
 
+        [Obsolete("Use ValueComparers.Register")]
         public void RegisterValueComparer(IValueComparer valueComparer)
         {
             ValueComparers.Register(valueComparer);
         }
 
+        [Obsolete("Use ValueComparers.RegisterDefault")]
         public void RegisterDefaultValueComparer(IValueComparer valueComparer)
         {
             ValueComparers.RegisterDefault(valueComparer);
         }
 
+        [Obsolete("Use ValueComparers.Unregister")]
         public void UnregisterValueComparer(IValueComparer valueComparer)
         {
             ValueComparers.Unregister(valueComparer);
         }
 
+        [Obsolete("Use ValueRetrievers.Register")]
         public void RegisterValueRetriever(IValueRetriever valueRetriever)
         {
             ValueRetrievers.Register(valueRetriever);
         }
 
+        [Obsolete("Use ValueRetrievers.Unregister")]
         public void UnregisterValueRetriever(IValueRetriever valueRetriever)
         {
             ValueRetrievers.Unregister(valueRetriever);

--- a/TechTalk.SpecFlow/Assist/Service.cs
+++ b/TechTalk.SpecFlow/Assist/Service.cs
@@ -113,7 +113,8 @@ namespace TechTalk.SpecFlow.Assist
 
         public IValueRetriever GetValueRetrieverFor(TableRow row, Type targetType, Type propertyType)
         {
-            foreach(var valueRetriever in ValueRetrievers){
+            foreach (var valueRetriever in ValueRetrievers)
+            {
                 if (valueRetriever.CanRetrieve(new KeyValuePair<string, string>(row[0], row[1]), targetType, propertyType))
                     return valueRetriever;
             }

--- a/TechTalk.SpecFlow/Assist/Service.cs
+++ b/TechTalk.SpecFlow/Assist/Service.cs
@@ -1,7 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using TechTalk.SpecFlow.Assist.ValueComparers;
-using TechTalk.SpecFlow.Assist.ValueRetrievers;
 
 namespace TechTalk.SpecFlow.Assist
 {
@@ -26,7 +24,6 @@ namespace TechTalk.SpecFlow.Assist
         {
             ValueComparers = new SpecFlowDefaultValueComparerList();
             ValueRetrievers = new SpecFlowDefaultValueRetrieverList();
-            RegisterSpecFlowDefaults();
         }
 
         public void RegisterValueComparer(IValueComparer valueComparer)
@@ -52,11 +49,6 @@ namespace TechTalk.SpecFlow.Assist
         public void UnregisterValueRetriever(IValueRetriever valueRetriever)
         {
             ValueRetrievers.Unregister(valueRetriever);
-        }
-
-        public void RegisterSpecFlowDefaults()
-        {
-
         }
 
         public IValueRetriever GetValueRetrieverFor(TableRow row, Type targetType, Type propertyType)

--- a/TechTalk.SpecFlow/Assist/Service.cs
+++ b/TechTalk.SpecFlow/Assist/Service.cs
@@ -8,7 +8,7 @@ namespace TechTalk.SpecFlow.Assist
     public class Service
     {
 
-        private List<IValueComparer> _registeredValueComparers;
+        private ServiceComponentList<IValueComparer> _registeredValueComparers;
         private ServiceComponentList<IValueRetriever> _registeredValueRetrievers;
 
         public IEnumerable<IValueComparer> ValueComparers => _registeredValueComparers;
@@ -28,24 +28,24 @@ namespace TechTalk.SpecFlow.Assist
 
         public void RestoreDefaults()
         {
-            _registeredValueComparers = new List<IValueComparer>();
+            _registeredValueComparers = new ServiceComponentList<IValueComparer>();
             _registeredValueRetrievers = new SpecFlowDefaultValueRetrieverList();
             RegisterSpecFlowDefaults();
         }
 
         public void RegisterValueComparer(IValueComparer valueComparer)
         {
-            _registeredValueComparers.Insert(0, valueComparer);
+            _registeredValueComparers.Register(valueComparer);
         }
 
         public void RegisterDefaultValueComparer(IValueComparer valueComparer)
         {
-            _registeredValueComparers.Add(valueComparer);
+            _registeredValueComparers.RegisterDefault(valueComparer);
         }
 
         public void UnregisterValueComparer(IValueComparer valueComparer)
         {
-            _registeredValueComparers.Remove(valueComparer);
+            _registeredValueComparers.Unregister(valueComparer);
         }
 
         public void RegisterValueRetriever(IValueRetriever valueRetriever)

--- a/TechTalk.SpecFlow/Assist/Service.cs
+++ b/TechTalk.SpecFlow/Assist/Service.cs
@@ -24,7 +24,7 @@ namespace TechTalk.SpecFlow.Assist
 
         public void RestoreDefaults()
         {
-            ValueComparers = new ServiceComponentList<IValueComparer>();
+            ValueComparers = new SpecFlowDefaultValueComparerList();
             ValueRetrievers = new SpecFlowDefaultValueRetrieverList();
             RegisterSpecFlowDefaults();
         }
@@ -56,13 +56,6 @@ namespace TechTalk.SpecFlow.Assist
 
         public void RegisterSpecFlowDefaults()
         {
-            RegisterValueComparer(new DateTimeValueComparer());
-            RegisterValueComparer(new BoolValueComparer());
-            RegisterValueComparer(new GuidValueComparer(new GuidValueRetriever()));
-            RegisterValueComparer(new DecimalValueComparer());
-            RegisterValueComparer(new DoubleValueComparer());
-            RegisterValueComparer(new FloatValueComparer());
-            RegisterDefaultValueComparer(new DefaultValueComparer());
 
         }
 

--- a/TechTalk.SpecFlow/Assist/Service.cs
+++ b/TechTalk.SpecFlow/Assist/Service.cs
@@ -29,7 +29,7 @@ namespace TechTalk.SpecFlow.Assist
         public void RestoreDefaults()
         {
             _registeredValueComparers = new List<IValueComparer>();
-            _registeredValueRetrievers = new ServiceComponentList<IValueRetriever>();
+            _registeredValueRetrievers = new SpecFlowDefaultValueRetrieverList();
             RegisterSpecFlowDefaults();
         }
 
@@ -68,47 +68,6 @@ namespace TechTalk.SpecFlow.Assist
             RegisterValueComparer(new FloatValueComparer());
             RegisterDefaultValueComparer(new DefaultValueComparer());
 
-            RegisterValueRetriever(new StringValueRetriever());
-            RegisterValueRetriever(new ByteValueRetriever());
-            RegisterValueRetriever(new SByteValueRetriever());
-            RegisterValueRetriever(new IntValueRetriever());
-            RegisterValueRetriever(new UIntValueRetriever());
-            RegisterValueRetriever(new ShortValueRetriever());
-            RegisterValueRetriever(new UShortValueRetriever());
-            RegisterValueRetriever(new LongValueRetriever());
-            RegisterValueRetriever(new ULongValueRetriever());
-            RegisterValueRetriever(new FloatValueRetriever());
-            RegisterValueRetriever(new DoubleValueRetriever());
-            RegisterValueRetriever(new DecimalValueRetriever());
-            RegisterValueRetriever(new CharValueRetriever());
-            RegisterValueRetriever(new BoolValueRetriever());
-            RegisterValueRetriever(new DateTimeValueRetriever());
-            RegisterValueRetriever(new GuidValueRetriever());
-            RegisterValueRetriever(new EnumValueRetriever());
-            RegisterValueRetriever(new TimeSpanValueRetriever());
-            RegisterValueRetriever(new DateTimeOffsetValueRetriever());
-            RegisterValueRetriever(new NullableGuidValueRetriever());
-            RegisterValueRetriever(new NullableDateTimeValueRetriever());
-            RegisterValueRetriever(new NullableBoolValueRetriever());
-            RegisterValueRetriever(new NullableCharValueRetriever());
-            RegisterValueRetriever(new NullableDecimalValueRetriever());
-            RegisterValueRetriever(new NullableDoubleValueRetriever());
-            RegisterValueRetriever(new NullableFloatValueRetriever());
-            RegisterValueRetriever(new NullableULongValueRetriever());
-            RegisterValueRetriever(new NullableByteValueRetriever());
-            RegisterValueRetriever(new NullableSByteValueRetriever());
-            RegisterValueRetriever(new NullableIntValueRetriever());
-            RegisterValueRetriever(new NullableUIntValueRetriever());
-            RegisterValueRetriever(new NullableShortValueRetriever());
-            RegisterValueRetriever(new NullableUShortValueRetriever());
-            RegisterValueRetriever(new NullableLongValueRetriever());
-            RegisterValueRetriever(new NullableTimeSpanValueRetriever());
-            RegisterValueRetriever(new NullableDateTimeOffsetValueRetriever());
-
-            RegisterValueRetriever(new StringArrayValueRetriever());
-            RegisterValueRetriever(new StringListValueRetriever());
-            RegisterValueRetriever(new EnumArrayValueRetriever());
-            RegisterValueRetriever(new EnumListValueRetriever());
         }
 
         public IValueRetriever GetValueRetrieverFor(TableRow row, Type targetType, Type propertyType)

--- a/TechTalk.SpecFlow/Assist/Service.cs
+++ b/TechTalk.SpecFlow/Assist/Service.cs
@@ -7,12 +7,8 @@ namespace TechTalk.SpecFlow.Assist
 {
     public class Service
     {
-
-        private ServiceComponentList<IValueComparer> _registeredValueComparers;
-        private ServiceComponentList<IValueRetriever> _registeredValueRetrievers;
-
-        public IEnumerable<IValueComparer> ValueComparers => _registeredValueComparers;
-        public IEnumerable<IValueRetriever> ValueRetrievers => _registeredValueRetrievers;
+        public ServiceComponentList<IValueComparer> ValueComparers { get; private set; }
+        public ServiceComponentList<IValueRetriever> ValueRetrievers { get; private set; }
 
         public static Service Instance { get; internal set; }
 
@@ -28,34 +24,34 @@ namespace TechTalk.SpecFlow.Assist
 
         public void RestoreDefaults()
         {
-            _registeredValueComparers = new ServiceComponentList<IValueComparer>();
-            _registeredValueRetrievers = new SpecFlowDefaultValueRetrieverList();
+            ValueComparers = new ServiceComponentList<IValueComparer>();
+            ValueRetrievers = new SpecFlowDefaultValueRetrieverList();
             RegisterSpecFlowDefaults();
         }
 
         public void RegisterValueComparer(IValueComparer valueComparer)
         {
-            _registeredValueComparers.Register(valueComparer);
+            ValueComparers.Register(valueComparer);
         }
 
         public void RegisterDefaultValueComparer(IValueComparer valueComparer)
         {
-            _registeredValueComparers.RegisterDefault(valueComparer);
+            ValueComparers.RegisterDefault(valueComparer);
         }
 
         public void UnregisterValueComparer(IValueComparer valueComparer)
         {
-            _registeredValueComparers.Unregister(valueComparer);
+            ValueComparers.Unregister(valueComparer);
         }
 
         public void RegisterValueRetriever(IValueRetriever valueRetriever)
         {
-            _registeredValueRetrievers.Register(valueRetriever);
+            ValueRetrievers.Register(valueRetriever);
         }
 
         public void UnregisterValueRetriever(IValueRetriever valueRetriever)
         {
-            _registeredValueRetrievers.Unregister(valueRetriever);
+            ValueRetrievers.Unregister(valueRetriever);
         }
 
         public void RegisterSpecFlowDefaults()

--- a/TechTalk.SpecFlow/Assist/Service.cs
+++ b/TechTalk.SpecFlow/Assist/Service.cs
@@ -9,7 +9,7 @@ namespace TechTalk.SpecFlow.Assist
     {
 
         private List<IValueComparer> _registeredValueComparers;
-        private List<IValueRetriever> _registeredValueRetrievers;
+        private ServiceComponentList<IValueRetriever> _registeredValueRetrievers;
 
         public IEnumerable<IValueComparer> ValueComparers => _registeredValueComparers;
         public IEnumerable<IValueRetriever> ValueRetrievers => _registeredValueRetrievers;
@@ -29,7 +29,7 @@ namespace TechTalk.SpecFlow.Assist
         public void RestoreDefaults()
         {
             _registeredValueComparers = new List<IValueComparer>();
-            _registeredValueRetrievers = new List<IValueRetriever>();
+            _registeredValueRetrievers = new ServiceComponentList<IValueRetriever>();
             RegisterSpecFlowDefaults();
         }
 
@@ -50,12 +50,12 @@ namespace TechTalk.SpecFlow.Assist
 
         public void RegisterValueRetriever(IValueRetriever valueRetriever)
         {
-            _registeredValueRetrievers.Add(valueRetriever);
+            _registeredValueRetrievers.Register(valueRetriever);
         }
 
         public void UnregisterValueRetriever(IValueRetriever valueRetriever)
         {
-            _registeredValueRetrievers.Remove(valueRetriever);
+            _registeredValueRetrievers.Unregister(valueRetriever);
         }
 
         public void RegisterSpecFlowDefaults()

--- a/TechTalk.SpecFlow/Assist/ServiceComponentList.cs
+++ b/TechTalk.SpecFlow/Assist/ServiceComponentList.cs
@@ -21,6 +21,11 @@ namespace TechTalk.SpecFlow.Assist
             components.Insert(0, component);
         }
 
+        public void Register<TImpl>() where TImpl : T, new()
+        {
+            Register(new TImpl());
+        }
+
         public void RegisterDefault(T component)
         {
             components.Add(component);

--- a/TechTalk.SpecFlow/Assist/ServiceComponentList.cs
+++ b/TechTalk.SpecFlow/Assist/ServiceComponentList.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace TechTalk.SpecFlow.Assist
 {
@@ -34,6 +35,11 @@ namespace TechTalk.SpecFlow.Assist
         public void Unregister(T component)
         {
             components.Remove(component);
+        }
+
+        public void Unregister<TImpl>() where TImpl : T
+        {
+            components.OfType<TImpl>().ToList().ForEach(component => components.Remove(component));
         }
     }
 }

--- a/TechTalk.SpecFlow/Assist/ServiceComponentList.cs
+++ b/TechTalk.SpecFlow/Assist/ServiceComponentList.cs
@@ -20,5 +20,10 @@ namespace TechTalk.SpecFlow.Assist
         {
             components.Insert(0, component);
         }
+
+        public void Unregister(T component)
+        {
+            components.Remove(component);
+        }
     }
 }

--- a/TechTalk.SpecFlow/Assist/ServiceComponentList.cs
+++ b/TechTalk.SpecFlow/Assist/ServiceComponentList.cs
@@ -18,7 +18,7 @@ namespace TechTalk.SpecFlow.Assist
 
         public void Register(T component)
         {
-            components.Add(component);
+            components.Insert(0, component);
         }
     }
 }

--- a/TechTalk.SpecFlow/Assist/ServiceComponentList.cs
+++ b/TechTalk.SpecFlow/Assist/ServiceComponentList.cs
@@ -5,7 +5,7 @@ namespace TechTalk.SpecFlow.Assist
 {
     public class ServiceComponentList<T> : IEnumerable<T>
     {
-        private readonly IEnumerable<T> components;
+        private readonly List<T> components;
 
         IEnumerator<T> IEnumerable<T>.GetEnumerator() => components.GetEnumerator();
 
@@ -14,6 +14,11 @@ namespace TechTalk.SpecFlow.Assist
         public ServiceComponentList()
         {
             components = new List<T>();
+        }
+
+        public void Register(T component)
+        {
+            components.Add(component);
         }
     }
 }

--- a/TechTalk.SpecFlow/Assist/ServiceComponentList.cs
+++ b/TechTalk.SpecFlow/Assist/ServiceComponentList.cs
@@ -1,0 +1,19 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+
+namespace TechTalk.SpecFlow.Assist
+{
+    public class ServiceComponentList<T> : IEnumerable<T>
+    {
+        private readonly IEnumerable<T> components;
+
+        IEnumerator<T> IEnumerable<T>.GetEnumerator() => components.GetEnumerator();
+
+        IEnumerator IEnumerable.GetEnumerator() => ((IEnumerable)components).GetEnumerator();
+
+        public ServiceComponentList()
+        {
+            components = new List<T>();
+        }
+    }
+}

--- a/TechTalk.SpecFlow/Assist/ServiceComponentList.cs
+++ b/TechTalk.SpecFlow/Assist/ServiceComponentList.cs
@@ -21,6 +21,11 @@ namespace TechTalk.SpecFlow.Assist
             components.Insert(0, component);
         }
 
+        public void RegisterDefault(T component)
+        {
+            components.Add(component);
+        }
+
         public void Unregister(T component)
         {
             components.Remove(component);

--- a/TechTalk.SpecFlow/Assist/ServiceComponentList.cs
+++ b/TechTalk.SpecFlow/Assist/ServiceComponentList.cs
@@ -47,5 +47,11 @@ namespace TechTalk.SpecFlow.Assist
             Unregister(old);
             Register(@new);
         }
+
+        public void Replace<TOld, TNew>() where TOld : T where TNew : T, new()
+        {
+            Unregister<TOld>();
+            Register<TNew>();
+        }
     }
 }

--- a/TechTalk.SpecFlow/Assist/ServiceComponentList.cs
+++ b/TechTalk.SpecFlow/Assist/ServiceComponentList.cs
@@ -41,5 +41,11 @@ namespace TechTalk.SpecFlow.Assist
         {
             components.OfType<TImpl>().ToList().ForEach(component => components.Remove(component));
         }
+
+        public void Replace(T old, T @new)
+        {
+            Unregister(old);
+            Register(@new);
+        }
     }
 }

--- a/TechTalk.SpecFlow/Assist/SpecFlowDefaultValueComparerList.cs
+++ b/TechTalk.SpecFlow/Assist/SpecFlowDefaultValueComparerList.cs
@@ -1,0 +1,19 @@
+﻿using TechTalk.SpecFlow.Assist.ValueComparers;
+using TechTalk.SpecFlow.Assist.ValueRetrievers;
+
+namespace TechTalk.SpecFlow.Assist
+{
+    public class SpecFlowDefaultValueComparerList : ServiceComponentList<IValueComparer>
+    {
+        public SpecFlowDefaultValueComparerList()
+        {
+            Register(new DateTimeValueComparer());
+            Register(new BoolValueComparer());
+            Register(new GuidValueComparer(new GuidValueRetriever()));
+            Register(new DecimalValueComparer());
+            Register(new DoubleValueComparer());
+            Register(new FloatValueComparer());
+            RegisterDefault(new DefaultValueComparer());
+        }
+    }
+}

--- a/TechTalk.SpecFlow/Assist/SpecFlowDefaultValueRetrieverList.cs
+++ b/TechTalk.SpecFlow/Assist/SpecFlowDefaultValueRetrieverList.cs
@@ -1,0 +1,52 @@
+﻿using TechTalk.SpecFlow.Assist.ValueRetrievers;
+
+namespace TechTalk.SpecFlow.Assist
+{
+    internal class SpecFlowDefaultValueRetrieverList : ServiceComponentList<IValueRetriever>
+    {
+        public SpecFlowDefaultValueRetrieverList()
+        {
+            Register(new StringValueRetriever());
+            Register(new ByteValueRetriever());
+            Register(new SByteValueRetriever());
+            Register(new IntValueRetriever());
+            Register(new UIntValueRetriever());
+            Register(new ShortValueRetriever());
+            Register(new UShortValueRetriever());
+            Register(new LongValueRetriever());
+            Register(new ULongValueRetriever());
+            Register(new FloatValueRetriever());
+            Register(new DoubleValueRetriever());
+            Register(new DecimalValueRetriever());
+            Register(new CharValueRetriever());
+            Register(new BoolValueRetriever());
+            Register(new DateTimeValueRetriever());
+            Register(new GuidValueRetriever());
+            Register(new EnumValueRetriever());
+            Register(new TimeSpanValueRetriever());
+            Register(new DateTimeOffsetValueRetriever());
+            Register(new NullableGuidValueRetriever());
+            Register(new NullableDateTimeValueRetriever());
+            Register(new NullableBoolValueRetriever());
+            Register(new NullableCharValueRetriever());
+            Register(new NullableDecimalValueRetriever());
+            Register(new NullableDoubleValueRetriever());
+            Register(new NullableFloatValueRetriever());
+            Register(new NullableULongValueRetriever());
+            Register(new NullableByteValueRetriever());
+            Register(new NullableSByteValueRetriever());
+            Register(new NullableIntValueRetriever());
+            Register(new NullableUIntValueRetriever());
+            Register(new NullableShortValueRetriever());
+            Register(new NullableUShortValueRetriever());
+            Register(new NullableLongValueRetriever());
+            Register(new NullableTimeSpanValueRetriever());
+            Register(new NullableDateTimeOffsetValueRetriever());
+
+            Register(new StringArrayValueRetriever());
+            Register(new StringListValueRetriever());
+            Register(new EnumArrayValueRetriever());
+            Register(new EnumListValueRetriever());
+        }
+    }
+}

--- a/TechTalk.SpecFlow/TechTalk.SpecFlow.csproj
+++ b/TechTalk.SpecFlow/TechTalk.SpecFlow.csproj
@@ -69,6 +69,7 @@
     <Compile Include="Assist\ServiceComponentList.cs" />
     <Compile Include="Assist\SetComparer.cs" />
     <Compile Include="Assist\Attributes\TableAliasesAttribute.cs" />
+    <Compile Include="Assist\SpecFlowDefaultValueRetrieverList.cs" />
     <Compile Include="Assist\TableDifferenceItem.cs" />
     <Compile Include="Assist\TableDifferenceResults.cs" />
     <Compile Include="Assist\TableDiffExceptionBuilder.cs" />

--- a/TechTalk.SpecFlow/TechTalk.SpecFlow.csproj
+++ b/TechTalk.SpecFlow/TechTalk.SpecFlow.csproj
@@ -69,6 +69,7 @@
     <Compile Include="Assist\ServiceComponentList.cs" />
     <Compile Include="Assist\SetComparer.cs" />
     <Compile Include="Assist\Attributes\TableAliasesAttribute.cs" />
+    <Compile Include="Assist\SpecFlowDefaultValueComparerList.cs" />
     <Compile Include="Assist\SpecFlowDefaultValueRetrieverList.cs" />
     <Compile Include="Assist\TableDifferenceItem.cs" />
     <Compile Include="Assist\TableDifferenceResults.cs" />

--- a/TechTalk.SpecFlow/TechTalk.SpecFlow.csproj
+++ b/TechTalk.SpecFlow/TechTalk.SpecFlow.csproj
@@ -66,6 +66,7 @@
     <Compile Include="Assist\FindInSetExtensionMethods.cs" />
     <Compile Include="Assist\FormattingTableDiffExceptionBuilder.cs" />
     <Compile Include="Assist\SafetyTableDiffExceptionBuilder.cs" />
+    <Compile Include="Assist\ServiceComponentList.cs" />
     <Compile Include="Assist\SetComparer.cs" />
     <Compile Include="Assist\Attributes\TableAliasesAttribute.cs" />
     <Compile Include="Assist\TableDifferenceItem.cs" />

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/ServiceComponentListTests.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/ServiceComponentListTests.cs
@@ -1,4 +1,5 @@
-﻿using FluentAssertions;
+﻿using System.Linq;
+using FluentAssertions;
 using NUnit.Framework;
 using TechTalk.SpecFlow.Assist;
 
@@ -23,6 +24,18 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests
             sut.Register(component);
 
             sut.Should().Equal(component);
+        }
+
+        [Test]
+        public void Should_reverse_registration_order_of_added_components()
+        {
+            var sut = new ServiceComponentList<ITestComponent>();
+
+            var components = Enumerable.Range(0, 100).Select(_ => new TestComponentImpl()).ToList();
+            components.ForEach(sut.Register);
+
+            components.Reverse();
+            sut.Should().Equal(components);
         }
 
         private interface ITestComponent

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/ServiceComponentListTests.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/ServiceComponentListTests.cs
@@ -115,6 +115,17 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests
             sut.Should().Equal(newComponent);
         }
 
+        [Test]
+        public void Should_allow_to_replace_a_component_with_another_one_via_generic_overload()
+        {
+            var sut = new ServiceComponentList<ITestComponent>();
+            sut.Register(new TestComponentImpl());
+            sut.Replace<TestComponentImpl, AnotherImpl>();
+
+            sut.Should().NotBeEmpty();
+            sut.Should().AllBeOfType<AnotherImpl>();
+        }
+
         private interface ITestComponent
         {
         }

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/ServiceComponentListTests.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/ServiceComponentListTests.cs
@@ -27,6 +27,16 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests
         }
 
         [Test]
+        public void Should_allow_the_addition_of_new_components_via_generic_overload()
+        {
+            var sut = new ServiceComponentList<ITestComponent>();
+            sut.Register<TestComponentImpl>();
+
+            sut.Should().NotBeEmpty();
+            sut.Should().AllBeOfType<TestComponentImpl>();
+        }
+
+        [Test]
         public void Should_reverse_registration_order_of_added_components()
         {
             var sut = new ServiceComponentList<ITestComponent>();

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/ServiceComponentListTests.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/ServiceComponentListTests.cs
@@ -15,7 +15,21 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests
             sut.Should().BeEmpty();
         }
 
+        [Test]
+        public void Should_allow_the_addition_of_new_components()
+        {
+            var sut = new ServiceComponentList<ITestComponent>();
+            var component = new TestComponentImpl();
+            sut.Register(component);
+
+            sut.Should().Equal(component);
+        }
+
         private interface ITestComponent
+        {
+        }
+
+        private class TestComponentImpl : ITestComponent
         {
         }
     }

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/ServiceComponentListTests.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/ServiceComponentListTests.cs
@@ -103,6 +103,18 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests
             sut.Should().NotBeEmpty();
         }
 
+        [Test]
+        public void Should_allow_to_replace_a_component_with_another_one()
+        {
+            var sut = new ServiceComponentList<ITestComponent>();
+            var oldComponent = new TestComponentImpl();
+            var newComponent = new TestComponentImpl();
+            sut.Register(oldComponent);
+            sut.Replace(oldComponent, newComponent);
+
+            sut.Should().Equal(newComponent);
+        }
+
         private interface ITestComponent
         {
         }

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/ServiceComponentListTests.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/ServiceComponentListTests.cs
@@ -38,6 +38,27 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests
             sut.Should().Equal(components);
         }
 
+        [Test]
+        public void Should_allow_unregistration_of_existing_component()
+        {
+            var sut = new ServiceComponentList<ITestComponent>();
+            var component = new TestComponentImpl();
+            sut.Register(component);
+            sut.Unregister(component);
+
+            sut.Should().BeEmpty();
+        }
+
+        [Test]
+        public void Should_ignore_unregistration_of_nonexisting_component()
+        {
+            var sut = new ServiceComponentList<ITestComponent>();
+            sut.Register(new TestComponentImpl());
+            sut.Unregister(new TestComponentImpl());
+
+            sut.Should().NotBeEmpty();
+        }
+
         private interface ITestComponent
         {
         }

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/ServiceComponentListTests.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/ServiceComponentListTests.cs
@@ -1,0 +1,22 @@
+﻿using FluentAssertions;
+using NUnit.Framework;
+using TechTalk.SpecFlow.Assist;
+
+namespace TechTalk.SpecFlow.RuntimeTests.AssistTests
+{
+    [TestFixture]
+    public class ServiceComponentListTests
+    {
+        [Test]
+        public void Should_be_empty_when_created()
+        {
+            var sut = new ServiceComponentList<ITestComponent>();
+
+            sut.Should().BeEmpty();
+        }
+
+        private interface ITestComponent
+        {
+        }
+    }
+}

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/ServiceComponentListTests.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/ServiceComponentListTests.cs
@@ -39,6 +39,20 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests
         }
 
         [Test]
+        public void Should_allow_the_addition_of_default_components_at_the_end_of_the_list()
+        {
+            var sut = new ServiceComponentList<ITestComponent>();
+            var registeredFirst = new TestComponentImpl();
+            var registeredLast = new TestComponentImpl();
+            var @default = new TestComponentImpl();
+            sut.Register(registeredFirst);
+            sut.Register(registeredLast);
+            sut.RegisterDefault(@default);
+
+            sut.Should().Equal(registeredLast, registeredFirst, @default);
+        }
+
+        [Test]
         public void Should_allow_unregistration_of_existing_component()
         {
             var sut = new ServiceComponentList<ITestComponent>();

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/ServiceComponentListTests.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/ServiceComponentListTests.cs
@@ -74,6 +74,16 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests
         }
 
         [Test]
+        public void Should_allow_unregistration_of_existing_component_via_generic_overload()
+        {
+            var sut = new ServiceComponentList<ITestComponent>();
+            sut.Register(new TestComponentImpl());
+            sut.Unregister<TestComponentImpl>();
+
+            sut.Should().BeEmpty();
+        }
+
+        [Test]
         public void Should_ignore_unregistration_of_nonexisting_component()
         {
             var sut = new ServiceComponentList<ITestComponent>();
@@ -83,11 +93,25 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests
             sut.Should().NotBeEmpty();
         }
 
+        [Test]
+        public void Should_ignore_unregistration_of_nonexisting_component_via_generic_overload()
+        {
+            var sut = new ServiceComponentList<ITestComponent>();
+            sut.Register(new TestComponentImpl());
+            sut.Unregister<AnotherImpl>();
+
+            sut.Should().NotBeEmpty();
+        }
+
         private interface ITestComponent
         {
         }
 
         private class TestComponentImpl : ITestComponent
+        {
+        }
+
+        private class AnotherImpl : ITestComponent
         {
         }
     }

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/RuntimeTests.csproj
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/RuntimeTests.csproj
@@ -92,6 +92,7 @@
     <Compile Include="AssistTests\RowExtensionMethodTests_GetEnum.cs" />
     <Compile Include="AssistTests\ProjectionTests.cs" />
     <Compile Include="AssistTests\SafetyTableDiffExceptionBuilderTests.cs" />
+    <Compile Include="AssistTests\ServiceComponentListTests.cs" />
     <Compile Include="AssistTests\SituationalTests\NullableEnumTests.cs" />
     <Compile Include="AssistTests\TableDiffExceptionBuilderTests.cs" />
     <Compile Include="AssistTests\TableHelperExtensionMethods\CreateInstanceHelperMethodTestBase.cs" />

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,9 +1,13 @@
 3.0 - 2018-??-??
+Breaking changes:
++ Registration of value retrievers and comparers changes from `RegisterValueComparer(___)` to `ValueComparers.Register(___)`
+
 New Features:
 + Separate addition of default and non-default value comparers https://github.com/techtalk/SpecFlow/pull/1257
 + ComparisonException indicates which value comparer was used for each difference https://github.com/techtalk/SpecFlow/issues/1253
 + BoolValueRetriver can now work with 1s and 0s https://github.com/techtalk/SpecFlow/issues/1216
 + Check for non-default constructors using case-insensitive comparison https://github.com/techtalk/SpecFlow/pull/1265
++ Syntax and structural changes in value retriever/comparer registration https://github.com/techtalk/SpecFlow/pull/1260
 
 2.4 - 2018-08-20
 New Features:


### PR DESCRIPTION
Fixes #1218

I think there is too much similarity in comparer and retriever handling in the Assist service, so I propose they could be merged into one with a small API change:

Before:
```
Service.Instance.RegisterValueComparer(___)
```

After:
```
Service.Instance.ValueComparers.Register(___)
```

Additions:
```
Service.Instance.ValueComparers.Register<MyClass>()
Service.Instance.ValueComparers.Unregister<MyClass>()
Service.Instance.ValueComparers.Replace(oldObj, newObj)
Service.Instance.ValueComparers.Replace<OldClass, NewClass>()
```

Pros:
- simplifies future maintenance

Cons:
- breaking change
- RegisterDefault only applied to comparers in the past (and it's weird to add more "default"s to a single list but I did not change this behavior)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've added tests for my code.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added an entry to the changelog
