### PR TITLE
Add utility to get enum field value from TableRow

### DIFF
--- a/TechTalk.SpecFlow/Assist/RowExtensionMethods.cs
+++ b/TechTalk.SpecFlow/Assist/RowExtensionMethods.cs
@@ -75,6 +75,11 @@ namespace TechTalk.SpecFlow.Assist
             return GetTheEnumValue<T>(row[1], row[0]);
         }
 
+        public static TEnum GetEnumValue<TEnum>(this TableRow row, string id)
+        {
+            return (TEnum)Enum.Parse(typeof(TEnum), row[id]);
+        }
+
         public static Enum GetEnum<T>(this TableRow row, string id)
         {
             return GetTheEnumValue<T>(row[id], id);

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/RowExtensionMethodTests.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/RowExtensionMethodTests.cs
@@ -5,6 +5,7 @@ using System.Threading;
 using FluentAssertions;
 using NUnit.Framework;
 using TechTalk.SpecFlow.Assist;
+using TechTalk.SpecFlow.RuntimeTests.AssistTests.ExampleEntities;
 
 namespace TechTalk.SpecFlow.RuntimeTests.AssistTests
 {
@@ -269,6 +270,52 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests
             table.AddRow(11.11F.ToString());
             table.Rows.First()
                 .GetSingle("SomethingThatDoesNotExist").Should().Be(Single.MinValue);
+        }
+
+        [Test]
+        public void GetEnumValue_should_return_the_enum_field_form_the_row()
+        {
+            var table = new Table("Enum");
+            table.AddRow("Male");
+            var firstRow = table.Rows.First();
+
+            firstRow.GetEnumValue<Sex>("Enum").Should().Be(Sex.Male);
+        }
+
+        [Test]
+        public void GetEnumValue_should_throw_when_the_given_value_does_not_exist()
+        {
+            var table = new Table("Enum");
+            table.AddRow("MemberDoesNotExist");
+            var firstRow = table.Rows.First();
+
+            Action act = () => firstRow.GetEnumValue<Sex>("Enum");
+
+            act.ShouldThrow<ArgumentException>();
+        }
+
+        [Test]
+        public void GetEnumValue_should_throw_when_the_given_value_does_not_match_case()
+        {
+            var table = new Table("Enum");
+            table.AddRow("female");
+            var firstRow = table.Rows.First();
+
+            Action act = () => firstRow.GetEnumValue<Sex>("Enum");
+
+            act.ShouldThrow<ArgumentException>();
+        }
+
+        [Test]
+        public void GetSingle_should_throw_when_the_given_value_is_not_defined()
+        {
+            var table = new Table("Enum");
+            table.AddRow("Female");
+            var firstRow = table.Rows.First();
+
+            Action act = () => firstRow.GetEnumValue<Sex>("SomethingThatDoesNotExist");
+
+            act.ShouldThrow<IndexOutOfRangeException>();
         }
     }
 }

--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
 New Features:
 + Separate addition of default and non-default value comparers https://github.com/techtalk/SpecFlow/pull/1257
 + ComparisonException indicates which value comparer was used for each difference https://github.com/techtalk/SpecFlow/issues/1253
++ Add utility to get enum field value from TableRow.
 
 2.4 - 2018-08-20
 New Features:


### PR DESCRIPTION
Enchancement to retrieve Enum field value from table row.

Before in test we should do:
```
   var sex = (Sex) Enum.Parse(typeof(Sex), row["RowColName"])
```

Now in test we can do:
```
   var sex = row.GetEnumValue<Sex>("RowColName");
```

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added an entry to the changelog
