### PR TITLE
Use case-insensitive parameter name checking when calling CreateInstance

### DIFF
--- a/TechTalk.SpecFlow/Assist/TEHelpers.cs
+++ b/TechTalk.SpecFlow/Assist/TEHelpers.cs
@@ -54,7 +54,7 @@ namespace TechTalk.SpecFlow.Assist
             return (from constructor in typeof(T).GetConstructors()
                     where !projectedPropertyNames.Except(
                         from parameter in constructor.GetParameters()
-                        select parameter.Name).Any()
+                        select parameter.Name, StringComparer.OrdinalIgnoreCase).Any()
                     select constructor).FirstOrDefault();
         }
 

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/TableHelperExtensionMethods/CreateInstanceHelperMethodTests.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/TableHelperExtensionMethods/CreateInstanceHelperMethodTests.cs
@@ -38,6 +38,19 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.TableHelperExtensionMethods
             @class.FourthColor.Should().Be(AClassWithMultipleEnums.ColorAgain.Green);
         }
 
+        [Test]
+        public void Can_create_an_instance_with_a_constructor()
+        {
+            var table = new Table("Field", "Value");
+            table.AddRow("Field2", "Entry2");
+            table.AddRow("Field1", "Entry1");
+
+            var @class = table.CreateInstance<AClassWithAConstructor>();
+
+            @class.Field1.Should().Be("Entry1");
+            @class.Field2.Should().Be("Entry2");
+        }
+
         public class AClassWithMultipleEnums
         {
             public Color FirstColor { get; set; }
@@ -47,6 +60,18 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.TableHelperExtensionMethods
 
             public enum Color { Red, Green, Blue }
             public enum ColorAgain { Red, Green, Blue}
+        }
+
+        public class AClassWithAConstructor
+        {
+            public AClassWithAConstructor(string field1, string field2)
+            {
+                Field1 = field1;
+                Field2 = field2;
+            }
+
+            public string Field1 { get; }
+            public string Field2 { get; }
         }
     }
 }

--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
 New Features:
 + Separate addition of default and non-default value comparers https://github.com/techtalk/SpecFlow/pull/1257
 + ComparisonException indicates which value comparer was used for each difference https://github.com/techtalk/SpecFlow/issues/1253
++ Check for non-default constructors using case-insensitive comparison https://github.com/techtalk/SpecFlow/pull/1265
 
 2.4 - 2018-08-20
 New Features:


### PR DESCRIPTION
CreateInstance can currently use a non-default constructor, but it checks for parameters case-sensitively to exactly match the names of the properties. If a PascalCased property is set using a camelCased parameter, it is not found.

This change adds the ability to use a constructor where the parameters match the property names case-insensitively.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added an entry to the changelog
