### PR TITLE
The `BoolValueRetriever` can now work with `1` and `0`s

### DIFF
--- a/TechTalk.SpecFlow/Assist/ValueRetrievers/BoolValueRetriever.cs
+++ b/TechTalk.SpecFlow/Assist/ValueRetrievers/BoolValueRetriever.cs
@@ -7,7 +7,7 @@ namespace TechTalk.SpecFlow.Assist.ValueRetrievers
     {
         public virtual bool GetValue(string value)
         {
-            return value == "True" || value == "true";
+            return value == "True" || value == "true" || value == "1";
         }
 
         public object Retrieve(KeyValuePair<string, string> keyValuePair, Type targetType, Type propertyType)

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/ValueRetrieverTests/BoolValueRetrieverTests.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/ValueRetrieverTests/BoolValueRetrieverTests.cs
@@ -29,6 +29,20 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.ValueRetrieverTests
         }
 
         [Test]
+        public void Returns_true_when_the_value_is_1()
+        {
+            var retriever = new BoolValueRetriever();
+            retriever.GetValue("1").Should().BeTrue();
+        }
+
+        [Test]
+        public void Returns_false_when_the_value_is_0()
+        {
+            var retriever = new BoolValueRetriever();
+            retriever.GetValue("0").Should().BeFalse();
+        }
+
+        [Test]
         public void Returns_false_for_data_that_is_not_bool()
         {
             var retriever = new BoolValueRetriever();

--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
 New Features:
 + Separate addition of default and non-default value comparers https://github.com/techtalk/SpecFlow/pull/1257
 + ComparisonException indicates which value comparer was used for each difference https://github.com/techtalk/SpecFlow/issues/1253
++ BoolValueRetriver can now work with 1s and 0s https://github.com/techtalk/SpecFlow/issues/1216
 
 2.4 - 2018-08-20
 New Features:


### PR DESCRIPTION
This is the PR for #1216.  

As discussed there, this change allows allows the `BoolValueRetriever` to work with `1` and `0`s.

Apologies for the delay in getting this ready - it's been a busy summer!

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added an entry to the changelog
