### PR TITLE
Add generic overloads to register and unregister value resolvers and comparers

### DIFF
--- a/TechTalk.SpecFlow/Assist/Service.cs
+++ b/TechTalk.SpecFlow/Assist/Service.cs
@@ -89,33 +89,33 @@ namespace TechTalk.SpecFlow.Assist
 
         public void RegisterSpecFlowDefaults()
         {
-            RegisterValueComparer(new DateTimeValueComparer());
-            RegisterValueComparer(new BoolValueComparer());
+            RegisterValueComparer<DateTimeValueComparer>();
+            RegisterValueComparer<BoolValueComparer>();
             RegisterValueComparer(new GuidValueComparer(new GuidValueRetriever()));
-            RegisterValueComparer(new DecimalValueComparer());
-            RegisterValueComparer(new DoubleValueComparer());
-            RegisterValueComparer(new FloatValueComparer());
+            RegisterValueComparer<DecimalValueComparer>();
+            RegisterValueComparer<DoubleValueComparer>();
+            RegisterValueComparer<FloatValueComparer>();
             RegisterDefaultValueComparer(new DefaultValueComparer());
 
-            RegisterValueRetriever(new StringValueRetriever());
-            RegisterValueRetriever(new ByteValueRetriever());
-            RegisterValueRetriever(new SByteValueRetriever());
-            RegisterValueRetriever(new IntValueRetriever());
-            RegisterValueRetriever(new UIntValueRetriever());
-            RegisterValueRetriever(new ShortValueRetriever());
-            RegisterValueRetriever(new UShortValueRetriever());
-            RegisterValueRetriever(new LongValueRetriever());
-            RegisterValueRetriever(new ULongValueRetriever());
-            RegisterValueRetriever(new FloatValueRetriever());
-            RegisterValueRetriever(new DoubleValueRetriever());
-            RegisterValueRetriever(new DecimalValueRetriever());
-            RegisterValueRetriever(new CharValueRetriever());
-            RegisterValueRetriever(new BoolValueRetriever());
-            RegisterValueRetriever(new DateTimeValueRetriever());
-            RegisterValueRetriever(new GuidValueRetriever());
-            RegisterValueRetriever(new EnumValueRetriever());
-            RegisterValueRetriever(new TimeSpanValueRetriever());
-            RegisterValueRetriever(new DateTimeOffsetValueRetriever());
+            RegisterValueRetriever<StringValueRetriever>();
+            RegisterValueRetriever<ByteValueRetriever>();
+            RegisterValueRetriever<SByteValueRetriever>();
+            RegisterValueRetriever<IntValueRetriever>();
+            RegisterValueRetriever<UIntValueRetriever>();
+            RegisterValueRetriever<ShortValueRetriever>();
+            RegisterValueRetriever<UShortValueRetriever>();
+            RegisterValueRetriever<LongValueRetriever>();
+            RegisterValueRetriever<ULongValueRetriever>();
+            RegisterValueRetriever<FloatValueRetriever>();
+            RegisterValueRetriever<DoubleValueRetriever>();
+            RegisterValueRetriever<DecimalValueRetriever>();
+            RegisterValueRetriever<CharValueRetriever>();
+            RegisterValueRetriever<BoolValueRetriever>();
+            RegisterValueRetriever<DateTimeValueRetriever>();
+            RegisterValueRetriever<GuidValueRetriever>();
+            RegisterValueRetriever<EnumValueRetriever>();
+            RegisterValueRetriever<TimeSpanValueRetriever>();
+            RegisterValueRetriever<DateTimeOffsetValueRetriever>();
             RegisterValueRetriever(new NullableGuidValueRetriever());
             RegisterValueRetriever(new NullableDateTimeValueRetriever());
             RegisterValueRetriever(new NullableBoolValueRetriever());
@@ -134,10 +134,10 @@ namespace TechTalk.SpecFlow.Assist
             RegisterValueRetriever(new NullableTimeSpanValueRetriever());
             RegisterValueRetriever(new NullableDateTimeOffsetValueRetriever());
 
-            RegisterValueRetriever(new StringArrayValueRetriever());
-            RegisterValueRetriever(new StringListValueRetriever());
-            RegisterValueRetriever(new EnumArrayValueRetriever());
-            RegisterValueRetriever(new EnumListValueRetriever());
+            RegisterValueRetriever<StringArrayValueRetriever>();
+            RegisterValueRetriever<StringListValueRetriever>();
+            RegisterValueRetriever<EnumArrayValueRetriever>();
+            RegisterValueRetriever<EnumListValueRetriever>();
         }
 
         public IValueRetriever GetValueRetrieverFor(TableRow row, Type targetType, Type propertyType)

--- a/TechTalk.SpecFlow/Assist/Service.cs
+++ b/TechTalk.SpecFlow/Assist/Service.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using TechTalk.SpecFlow.Assist.ValueComparers;
 using TechTalk.SpecFlow.Assist.ValueRetrievers;
 
@@ -38,6 +39,13 @@ namespace TechTalk.SpecFlow.Assist
             _registeredValueComparers.Insert(0, valueComparer);
         }
 
+        public void RegisterValueComparer<TValueComparer>() where TValueComparer : IValueComparer
+        {
+            var valueComparer = Activator.CreateInstance<TValueComparer>();
+
+            RegisterValueComparer(valueComparer);
+        }
+
         public void RegisterDefaultValueComparer(IValueComparer valueComparer)
         {
             _registeredValueComparers.Add(valueComparer);
@@ -48,14 +56,35 @@ namespace TechTalk.SpecFlow.Assist
             _registeredValueComparers.Remove(valueComparer);
         }
 
+        public void UnregisterValueComparer<TValueComparer>() where TValueComparer : IValueComparer
+        {
+            var valueComparer = _registeredValueComparers.FirstOrDefault(x => x.GetType() == typeof(TValueComparer));
+
+            UnregisterValueComparer(valueComparer);
+        }
+
         public void RegisterValueRetriever(IValueRetriever valueRetriever)
         {
             _registeredValueRetrievers.Add(valueRetriever);
         }
 
+        public void RegisterValueRetriever<TValueRetriever>() where TValueRetriever : IValueRetriever
+        {
+            var valueRetriever = Activator.CreateInstance<TValueRetriever>();
+
+            RegisterValueRetriever(valueRetriever);
+        }
+
         public void UnregisterValueRetriever(IValueRetriever valueRetriever)
         {
             _registeredValueRetrievers.Remove(valueRetriever);
+        }
+
+        public void UnregisterValueRetriever<TValueRetriever>() where TValueRetriever : IValueRetriever
+        {
+            var valueRetriver = _registeredValueRetrievers.FirstOrDefault(x => x.GetType() == typeof(TValueRetriever));
+            
+            UnregisterValueRetriever(valueRetriver);
         }
 
         public void RegisterSpecFlowDefaults()

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/ServiceTests.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/ServiceTests.cs
@@ -97,6 +97,18 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests
         }
 
         [Test]
+        public void Should_allow_the_removal_and_addition_of_new_value_comparers_using_generic_overloads()
+        {
+            var service = new Service();
+
+            service.RegisterValueComparer<IExistsForTestingValueComparing>();
+            Assert.AreEqual(1, service.ValueComparers.Count(x => x.GetType() == typeof(IExistsForTestingValueComparing)));
+
+            service.UnregisterValueComparer<IExistsForTestingValueComparing>();
+            Assert.AreEqual(0, service.ValueComparers.Count(x => x.GetType() == typeof(IExistsForTestingValueComparing)));
+        }
+
+        [Test]
         public void Should_allow_the_addition_of_new_default_value_comparers()
         {
             var service = new Service();
@@ -121,6 +133,18 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests
             service.RegisterValueRetriever(thing);
             Assert.AreEqual(1, service.ValueRetrievers.Count());
             Assert.AreSame(thing, service.ValueRetrievers.First());
+        }
+
+        [Test]
+        public void Should_allow_the_removal_and_addition_of_new_value_retrievers_using_generic_overloads()
+        {
+            var service = new Service();
+
+            service.RegisterValueRetriever<IExistsForTestingValueRetrieving>();
+            Assert.AreEqual(1, service.ValueRetrievers.Count(x => x.GetType() == typeof(IExistsForTestingValueRetrieving)));
+
+            service.UnregisterValueRetriever<IExistsForTestingValueRetrieving>();
+            Assert.AreEqual(0, service.ValueRetrievers.Count(x => x.GetType() == typeof(IExistsForTestingValueRetrieving)));
         }
 
 

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/WorkingExampleOfValueRetrieverAndComparerAddition.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/WorkingExampleOfValueRetrieverAndComparerAddition.cs
@@ -2,8 +2,6 @@
 using System.Linq;
 using NUnit.Framework;
 using TechTalk.SpecFlow.Assist;
-using TechTalk.SpecFlow.Assist.ValueComparers;
-using TechTalk.SpecFlow.Assist.ValueRetrievers;
 using System.Collections.Generic;
 using FluentAssertions;
 
@@ -81,7 +79,7 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests
         public void Should_be_able_to_retrieve_the_fancy_name()
         {
 
-            Service.Instance.RegisterValueRetriever(new FancyNameValueRetriever());
+            Service.Instance.RegisterValueRetriever<FancyNameValueRetriever>();
 
             var table = new Table("Field", "Value");
             table.AddRow("Name", "John Galt");
@@ -95,8 +93,8 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests
         [Test]
         public void Should_be_able_to_compare_the_fancy_name()
         {
-            Service.Instance.RegisterValueRetriever(new FancyNameValueRetriever());
-            Service.Instance.RegisterValueComparer(new FancyNameValueComparer());
+            Service.Instance.RegisterValueRetriever<FancyNameValueRetriever>();
+            Service.Instance.RegisterValueComparer<FancyNameValueComparer>();
 
             var table = new Table("Field", "Value");
             table.AddRow("Name", "John Galt");


### PR DESCRIPTION
This is the PR for #1218.

As discussed there I've added generic overloads to register and unregister value resolvers and comparers.

I also updated:
- the code where the defaults are registered to use the new generic overloads where possible
- the worked example of using value resolvers and comparers.

If you'd prefer not not take the last two changes, I'll drop those commits.

When I was getting ready to push this code, I noticed @szaliszali has already made a start on this in #1260.  I think I prefer the API changes there, but as noted they are breaking changes.

As this code was already done, I thought I may as well open a PR.  If you prefer to go with the changes in  #1260 thanks ok with me. 

If you want to take this version, I'll update the changelog and docs.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've added tests for my code.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added an entry to the changelog
