### PR TITLE
Replace "RegisterDefault" ValueX implementation and use new generics

### DIFF
--- a/TechTalk.SpecFlow/Assist/Service.cs
+++ b/TechTalk.SpecFlow/Assist/Service.cs
@@ -32,12 +32,6 @@ namespace TechTalk.SpecFlow.Assist
             ValueComparers.Register(valueComparer);
         }
 
-        [Obsolete("Use ValueComparers.RegisterDefault")]
-        public void RegisterDefaultValueComparer(IValueComparer valueComparer)
-        {
-            ValueComparers.RegisterDefault(valueComparer);
-        }
-
         [Obsolete("Use ValueComparers.Unregister")]
         public void UnregisterValueComparer(IValueComparer valueComparer)
         {

--- a/TechTalk.SpecFlow/Assist/ServiceComponentList.cs
+++ b/TechTalk.SpecFlow/Assist/ServiceComponentList.cs
@@ -8,9 +8,9 @@ namespace TechTalk.SpecFlow.Assist
     {
         private readonly List<T> components;
 
-        private ValueHolder<T> @default;
+        private ValueHolder<T> defaultComponent;
 
-        private IEnumerable<T> componentsWithDefault => components.Concat(@default);
+        private IEnumerable<T> componentsWithDefault => components.Concat(defaultComponent);
 
         IEnumerator<T> IEnumerable<T>.GetEnumerator() => componentsWithDefault.GetEnumerator();
 
@@ -35,9 +35,9 @@ namespace TechTalk.SpecFlow.Assist
         {
             if (!components.Remove(component))
             {
-                if (@default.Contains(component))
+                if (defaultComponent.Contains(component))
                 {
-                    @default = ValueHolder.Empty<T>();
+                    defaultComponent = ValueHolder.Empty<T>();
                 }
             }
         }
@@ -47,10 +47,10 @@ namespace TechTalk.SpecFlow.Assist
             componentsWithDefault.OfType<TImpl>().ToList().ForEach(component => Unregister(component));
         }
 
-        public void Replace(T old, T @new)
+        public void Replace(T oldComponent, T newComponent)
         {
-            Unregister(old);
-            Register(@new);
+            Unregister(oldComponent);
+            Register(newComponent);
         }
 
         public void Replace<TOld, TNew>() where TOld : T where TNew : T, new()
@@ -59,9 +59,9 @@ namespace TechTalk.SpecFlow.Assist
             Register<TNew>();
         }
 
-        public void SetDefault(T @new)
+        public void SetDefault(T newComponent)
         {
-            @default = ValueHolder.WithValue(@new);
+            defaultComponent = ValueHolder.WithValue(newComponent);
         }
 
         public void SetDefault<TImpl>() where TImpl : T, new()

--- a/TechTalk.SpecFlow/Assist/ServiceComponentList.cs
+++ b/TechTalk.SpecFlow/Assist/ServiceComponentList.cs
@@ -73,5 +73,11 @@ namespace TechTalk.SpecFlow.Assist
         {
             defaultComponent = ValueHolder.Empty<T>();
         }
+
+        public void Clear()
+        {
+            components.Clear();
+            ClearDefault();
+        }
     }
 }

--- a/TechTalk.SpecFlow/Assist/ServiceComponentList.cs
+++ b/TechTalk.SpecFlow/Assist/ServiceComponentList.cs
@@ -47,7 +47,7 @@ namespace TechTalk.SpecFlow.Assist
 
         public void Unregister<TImpl>() where TImpl : T
         {
-            components.OfType<TImpl>().ToList().ForEach(component => Unregister(component));
+            componentsWithDefault.OfType<TImpl>().ToList().ForEach(component => Unregister(component));
         }
 
         public void Replace(T old, T @new)

--- a/TechTalk.SpecFlow/Assist/ServiceComponentList.cs
+++ b/TechTalk.SpecFlow/Assist/ServiceComponentList.cs
@@ -62,15 +62,15 @@ namespace TechTalk.SpecFlow.Assist
             Register<TNew>();
         }
 
-        public void ReplaceDefault(T @new)
+        public void SetDefault(T @new)
         {
             hasDefault = true;
             @default = @new;
         }
 
-        public void ReplaceDefault<TImpl>() where TImpl : T, new()
+        public void SetDefault<TImpl>() where TImpl : T, new()
         {
-            ReplaceDefault(new TImpl());
+            SetDefault(new TImpl());
         }
     }
 }

--- a/TechTalk.SpecFlow/Assist/ServiceComponentList.cs
+++ b/TechTalk.SpecFlow/Assist/ServiceComponentList.cs
@@ -68,5 +68,10 @@ namespace TechTalk.SpecFlow.Assist
         {
             SetDefault(new TImpl());
         }
+
+        public void ClearDefault()
+        {
+            defaultComponent = ValueHolder.Empty<T>();
+        }
     }
 }

--- a/TechTalk.SpecFlow/Assist/ServiceComponentList.cs
+++ b/TechTalk.SpecFlow/Assist/ServiceComponentList.cs
@@ -8,11 +8,9 @@ namespace TechTalk.SpecFlow.Assist
     {
         private readonly List<T> components;
 
-        private bool hasDefault;
+        private ValueHolder<T> @default;
 
-        private T @default;
-
-        private IEnumerable<T> componentsWithDefault => hasDefault ? components.Concat(new[] {@default}) : components;
+        private IEnumerable<T> componentsWithDefault => components.Concat(@default);
 
         IEnumerator<T> IEnumerable<T>.GetEnumerator() => componentsWithDefault.GetEnumerator();
 
@@ -37,10 +35,9 @@ namespace TechTalk.SpecFlow.Assist
         {
             if (!components.Remove(component))
             {
-                if (EqualityComparer<T>.Default.Equals(component, @default))
+                if (@default.Contains(component))
                 {
-                    hasDefault = false;
-                    @default = default(T);
+                    @default = ValueHolder.Empty<T>();
                 }
             }
         }
@@ -64,8 +61,7 @@ namespace TechTalk.SpecFlow.Assist
 
         public void SetDefault(T @new)
         {
-            hasDefault = true;
-            @default = @new;
+            @default = ValueHolder.WithValue(@new);
         }
 
         public void SetDefault<TImpl>() where TImpl : T, new()

--- a/TechTalk.SpecFlow/Assist/SpecFlowDefaultValueComparerList.cs
+++ b/TechTalk.SpecFlow/Assist/SpecFlowDefaultValueComparerList.cs
@@ -12,7 +12,7 @@ namespace TechTalk.SpecFlow.Assist
             Register<DecimalValueComparer>();
             Register<DoubleValueComparer>();
             Register<FloatValueComparer>();
-            ReplaceDefault<DefaultValueComparer>();
+            SetDefault<DefaultValueComparer>();
         }
     }
 }

--- a/TechTalk.SpecFlow/Assist/SpecFlowDefaultValueComparerList.cs
+++ b/TechTalk.SpecFlow/Assist/SpecFlowDefaultValueComparerList.cs
@@ -12,7 +12,7 @@ namespace TechTalk.SpecFlow.Assist
             Register<DecimalValueComparer>();
             Register<DoubleValueComparer>();
             Register<FloatValueComparer>();
-            RegisterDefault(new DefaultValueComparer());
+            ReplaceDefault<DefaultValueComparer>();
         }
     }
 }

--- a/TechTalk.SpecFlow/Assist/ValueHolder.cs
+++ b/TechTalk.SpecFlow/Assist/ValueHolder.cs
@@ -1,0 +1,44 @@
+using System.Collections;
+using System.Collections.Generic;
+
+namespace TechTalk.SpecFlow.Assist
+{
+    internal struct ValueHolder<T> : IEnumerable<T>
+    {
+        private readonly T _value;
+
+        public bool HasValue { get; }
+
+        public ValueHolder(T value)
+        {
+            _value = value;
+            HasValue = true;
+        }
+
+        public IEnumerator<T> GetEnumerator()
+        {
+            if (HasValue)
+            {
+                yield return _value;
+            }
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+
+    internal static class ValueHolder
+    {
+        public static ValueHolder<T> Empty<T>()
+        {
+            return new ValueHolder<T>();
+        }
+
+        public static ValueHolder<T> WithValue<T>(T value)
+        {
+            return new ValueHolder<T>(value);
+        }
+    }
+}

--- a/TechTalk.SpecFlow/TechTalk.SpecFlow.csproj
+++ b/TechTalk.SpecFlow/TechTalk.SpecFlow.csproj
@@ -90,6 +90,7 @@
     <Compile Include="Assist\ValueComparers\DecimalValueComparer.cs" />
     <Compile Include="Assist\ValueComparers\DefaultValueComparer.cs" />
     <Compile Include="Assist\ValueComparers\GuidValueComparer.cs" />
+    <Compile Include="Assist\ValueHolder.cs" />
     <Compile Include="Assist\ValueRetrievers\BoolValueRetriever.cs" />
     <Compile Include="Assist\ValueRetrievers\ByteValueRetriever.cs" />
     <Compile Include="Assist\ValueRetrievers\CharValueRetriever.cs" />

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/ServiceComponentListTests.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/ServiceComponentListTests.cs
@@ -57,7 +57,7 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests
             var @default = new TestComponentImpl();
             sut.Register(registeredFirst);
             sut.Register(registeredLast);
-            sut.ReplaceDefault(@default);
+            sut.SetDefault(@default);
 
             sut.Should().Equal(registeredLast, registeredFirst, @default);
         }
@@ -70,7 +70,7 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests
             var registeredLast = new TestComponentImpl();
             sut.Register(registeredFirst);
             sut.Register(registeredLast);
-            sut.ReplaceDefault<AnotherImpl>();
+            sut.SetDefault<AnotherImpl>();
 
             sut.Last().Should().BeOfType<AnotherImpl>();
         }
@@ -85,8 +85,8 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests
             var @default2 = new AnotherImpl();
             sut.Register(registeredFirst);
             sut.Register(registeredLast);
-            sut.ReplaceDefault(@default);
-            sut.ReplaceDefault(@default2);
+            sut.SetDefault(@default);
+            sut.SetDefault(@default2);
 
             sut.Should().Equal(registeredLast, registeredFirst, @default2);
         }
@@ -99,8 +99,8 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests
             var registeredLast = new TestComponentImpl();
             sut.Register(registeredFirst);
             sut.Register(registeredLast);
-            sut.ReplaceDefault<TestComponentImpl>();
-            sut.ReplaceDefault<AnotherImpl>();
+            sut.SetDefault<TestComponentImpl>();
+            sut.SetDefault<AnotherImpl>();
 
             sut.Last().Should().BeOfType<AnotherImpl>();
         }
@@ -114,7 +114,7 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests
             var @default = new TestComponentImpl();
             sut.Register(registeredFirst);
             sut.Register(registeredLast);
-            sut.ReplaceDefault(@default);
+            sut.SetDefault(@default);
             sut.Unregister(@default);
 
             sut.Should().Equal(registeredLast, registeredFirst);

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/ServiceComponentListTests.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/ServiceComponentListTests.cs
@@ -106,6 +106,18 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests
         }
 
         [Test]
+        public void Should_allow_the_removal_of_default_component_via_generic_unregistration()
+        {
+            var sut = new ServiceComponentList<ITestComponent>();
+            var registeredFirst = new TestComponentImpl();
+            sut.Register(registeredFirst);
+            sut.SetDefault<AnotherImpl>();
+            sut.Unregister<ITestComponent>();
+
+            sut.Should().BeEmpty();
+        }
+
+        [Test]
         public void Should_allow_the_unregistration_of_default_components()
         {
             var sut = new ServiceComponentList<ITestComponent>();

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/ServiceComponentListTests.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/ServiceComponentListTests.cs
@@ -57,9 +57,67 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests
             var @default = new TestComponentImpl();
             sut.Register(registeredFirst);
             sut.Register(registeredLast);
-            sut.RegisterDefault(@default);
+            sut.ReplaceDefault(@default);
 
             sut.Should().Equal(registeredLast, registeredFirst, @default);
+        }
+
+        [Test]
+        public void Should_allow_the_addition_of_default_components_at_the_end_of_the_list_via_generic_overload()
+        {
+            var sut = new ServiceComponentList<ITestComponent>();
+            var registeredFirst = new TestComponentImpl();
+            var registeredLast = new TestComponentImpl();
+            sut.Register(registeredFirst);
+            sut.Register(registeredLast);
+            sut.ReplaceDefault<AnotherImpl>();
+
+            sut.Last().Should().BeOfType<AnotherImpl>();
+        }
+
+        [Test]
+        public void Should_allow_the_replacement_of_default_components_at_the_end_of_the_list()
+        {
+            var sut = new ServiceComponentList<ITestComponent>();
+            var registeredFirst = new TestComponentImpl();
+            var registeredLast = new TestComponentImpl();
+            var @default = new TestComponentImpl();
+            var @default2 = new AnotherImpl();
+            sut.Register(registeredFirst);
+            sut.Register(registeredLast);
+            sut.ReplaceDefault(@default);
+            sut.ReplaceDefault(@default2);
+
+            sut.Should().Equal(registeredLast, registeredFirst, @default2);
+        }
+
+        [Test]
+        public void Should_allow_the_replacement_of_default_components_at_the_end_of_the_list_via_generic_overload()
+        {
+            var sut = new ServiceComponentList<ITestComponent>();
+            var registeredFirst = new TestComponentImpl();
+            var registeredLast = new TestComponentImpl();
+            sut.Register(registeredFirst);
+            sut.Register(registeredLast);
+            sut.ReplaceDefault<TestComponentImpl>();
+            sut.ReplaceDefault<AnotherImpl>();
+
+            sut.Last().Should().BeOfType<AnotherImpl>();
+        }
+
+        [Test]
+        public void Should_allow_the_unregistration_of_default_components()
+        {
+            var sut = new ServiceComponentList<ITestComponent>();
+            var registeredFirst = new TestComponentImpl();
+            var registeredLast = new TestComponentImpl();
+            var @default = new TestComponentImpl();
+            sut.Register(registeredFirst);
+            sut.Register(registeredLast);
+            sut.ReplaceDefault(@default);
+            sut.Unregister(@default);
+
+            sut.Should().Equal(registeredLast, registeredFirst);
         }
 
         [Test]

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/ServiceComponentListTests.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/ServiceComponentListTests.cs
@@ -106,6 +106,21 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests
         }
 
         [Test]
+        public void Should_allow_the_clearing_of_default_components()
+        {
+            var sut = new ServiceComponentList<ITestComponent>();
+            var registeredFirst = new TestComponentImpl();
+            var registeredLast = new TestComponentImpl();
+            var @default = new TestComponentImpl();
+            sut.Register(registeredFirst);
+            sut.Register(registeredLast);
+            sut.SetDefault(@default);
+            sut.ClearDefault();
+
+            sut.Should().Equal(registeredLast, registeredFirst);
+        }
+
+        [Test]
         public void Should_allow_the_removal_of_default_component_via_generic_unregistration()
         {
             var sut = new ServiceComponentList<ITestComponent>();

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/ServiceComponentListTests.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/ServiceComponentListTests.cs
@@ -159,6 +159,21 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests
         }
 
         [Test]
+        public void Should_allow_clearing_all_components()
+        {
+            var sut = new ServiceComponentList<ITestComponent>();
+            var registeredFirst = new TestComponentImpl();
+            var registeredLast = new TestComponentImpl();
+            var @default = new TestComponentImpl();
+            sut.Register(registeredFirst);
+            sut.Register(registeredLast);
+            sut.SetDefault(@default);
+            sut.Clear();
+
+            sut.Should().BeEmpty();
+        }
+
+        [Test]
         public void Should_allow_unregistration_of_existing_component_via_generic_overload()
         {
             var sut = new ServiceComponentList<ITestComponent>();

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/ServiceTests.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/ServiceTests.cs
@@ -97,16 +97,6 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests
         }
 
         [Test]
-        public void Should_allow_the_addition_of_new_default_value_comparers()
-        {
-            var service = new Service();
-
-            var thing = new IExistsForTestingValueComparing();
-            service.RegisterDefaultValueComparer(thing);
-            Assert.AreSame(thing, service.ValueComparers.Last());
-        }
-
-        [Test]
         public void Should_allow_the_removal_and_addition_of_new_value_retrievers()
         {
             var service = new Service();

--- a/changelog.txt
+++ b/changelog.txt
@@ -3,7 +3,7 @@ Breaking changes:
 + Registration of value retrievers and comparers changes from `RegisterValueComparer(___)` to `ValueComparers.Register(___)`
 
 New Features:
-+ Separate addition of default and non-default value comparers https://github.com/techtalk/SpecFlow/pull/1257
++ Separate addition of default and non-default value comparers https://github.com/techtalk/SpecFlow/pull/1257, https://github.com/techtalk/SpecFlow/pull/1277
 + ComparisonException indicates which value comparer was used for each difference https://github.com/techtalk/SpecFlow/issues/1253
 + BoolValueRetriver can now work with 1s and 0s https://github.com/techtalk/SpecFlow/issues/1216
 + Check for non-default constructors using case-insensitive comparison https://github.com/techtalk/SpecFlow/pull/1265


### PR DESCRIPTION
Following on from #1257, this pull request puts in a slightly more sensible contract of only having one default at any time, and takes advantage of the newly added generics.

I've deleted the old implementation as it was never part of a released version, so it didn't seem to make much sense to include it (same for the obsoleted method). I can add it back if you'd like.

I'm not completely sold on the "SetDefault" naming.

It's a breaking change for the existing functionality, but not since the last release.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added an entry to the changelog
