### PR TITLE
Use default constructor parameters when calling CreateInstance

### DIFF
--- a/TechTalk.SpecFlow/Assist/TEHelpers.cs
+++ b/TechTalk.SpecFlow/Assist/TEHelpers.cs
@@ -29,12 +29,15 @@ namespace TechTalk.SpecFlow.Assist
             var parameterValues = new object[constructorParameters.Length];
             for (var parameterIndex = 0; parameterIndex < constructorParameters.Length; parameterIndex++)
             {
-                var parameterName = constructorParameters[parameterIndex].Name;
+                var parameter = constructorParameters[parameterIndex];
+                var parameterName = parameter.Name;
                 var member = (from m in membersThatNeedToBeSet
                               where string.Equals(m.MemberName, parameterName, StringComparison.OrdinalIgnoreCase)
                               select m).FirstOrDefault();
                 if (member != null)
                     parameterValues[parameterIndex] = member.GetValue();
+                else if (parameter.HasDefaultValue)
+                    parameterValues[parameterIndex] = parameter.DefaultValue;
             }
             return (T)constructor.Invoke(parameterValues);
         }

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/TableHelperExtensionMethods/CreateInstanceHelperMethodTests.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/TableHelperExtensionMethods/CreateInstanceHelperMethodTests.cs
@@ -51,6 +51,19 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.TableHelperExtensionMethods
             @class.Field2.Should().Be("Entry2");
         }
 
+        [Test]
+        public void Can_create_an_instance_with_a_constructor_with_default_parameters()
+        {
+            var table = new Table("Field", "Value");
+            table.AddRow("Field1", "Entry1");
+
+            var @class = table.CreateInstance<AClassWithAConstructorWithDefaultParameters>();
+
+            @class.Field1.Should().Be("Entry1");
+            @class.Field2.Should().BeNull();
+            @class.Field3.Should().Be("Value3");
+        }
+
         public class AClassWithMultipleEnums
         {
             public Color FirstColor { get; set; }
@@ -72,6 +85,20 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.TableHelperExtensionMethods
 
             public string Field1 { get; }
             public string Field2 { get; }
+        }
+
+        public class AClassWithAConstructorWithDefaultParameters
+        {
+            public AClassWithAConstructorWithDefaultParameters(string field1, string field2, string field3 = "Value3")
+            {
+                Field1 = field1;
+                Field2 = field2;
+                Field3 = field3;
+            }
+
+            public string Field1 { get; }
+            public string Field2 { get; }
+            public string Field3 { get; }
         }
     }
 }

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 3.0 - 2018-??-??
 Breaking changes:
 + Registration of value retrievers and comparers changes from `RegisterValueComparer(___)` to `ValueComparers.Register(___)`
++ Calling CreateInstance on an object with a constructor with default parameters populates the object using the default parameters instead of nulls https://github.com/techtalk/SpecFlow/pull/1279
 
 New Features:
 + Separate addition of default and non-default value comparers https://github.com/techtalk/SpecFlow/pull/1257


### PR DESCRIPTION
When CreateInstance uses a non-default constructor, it passes in null to all parameters not set by the table. This change modifies that behaviour to use a default if one exists.

One use-case of ours this supports is having a model object with a constructor where all the parameters have defaults (for use in non-SpecFlow component tests, for example): SpecFlow now creates the object similarly to a constructor call that passes in the table parameters using keywords.

This is technically breaking in that previously null would be passed for all non-table parameters, and now the default is used if it exists.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added an entry to the changelog
