### PR TITLE
append loader exceptions to error output

### DIFF
--- a/TechTalk.SpecFlow/TestRunnerManager.cs
+++ b/TechTalk.SpecFlow/TestRunnerManager.cs
@@ -181,10 +181,19 @@ namespace TechTalk.SpecFlow
 
         public static ITestRunner GetTestRunner(Assembly testAssembly = null, int? managedThreadId = null)
         {
-            testAssembly = testAssembly ?? Assembly.GetCallingAssembly();
-            managedThreadId = GetLogicalThreadId(managedThreadId);
-            var testRunnerManager = GetTestRunnerManager(testAssembly);
-            return testRunnerManager.GetTestRunner(managedThreadId.Value);
+            try
+            {
+                testAssembly = testAssembly ?? Assembly.GetCallingAssembly();
+                managedThreadId = GetLogicalThreadId(managedThreadId);
+                var testRunnerManager = GetTestRunnerManager(testAssembly);
+                return testRunnerManager.GetTestRunner(managedThreadId.Value);
+            }
+            catch (ReflectionTypeLoadException ex)
+            {
+                throw new Exception(
+                    "Loader exceptions: " + Environment.NewLine +
+                    string.Join(Environment.NewLine, ex.LoaderExceptions.Select(lex => lex.ToString())), ex);
+            }
         }
 
         private static int GetLogicalThreadId(int? managedThreadId)

--- a/TechTalk.SpecFlow/TestRunnerManager.cs
+++ b/TechTalk.SpecFlow/TestRunnerManager.cs
@@ -27,6 +27,7 @@ namespace TechTalk.SpecFlow
         protected readonly Configuration.SpecFlowConfiguration specFlowConfiguration;
         protected readonly IRuntimeBindingRegistryBuilder bindingRegistryBuilder;
 
+        private readonly ITestTracer testTracer;
         private readonly Dictionary<int, ITestRunner> testRunnerRegistry = new Dictionary<int, ITestRunner>();
         private readonly object syncRoot = new object();
         private bool isTestRunInitialized;
@@ -36,12 +37,14 @@ namespace TechTalk.SpecFlow
 
         public bool IsMultiThreaded { get { return testRunnerRegistry.Count > 1; } }
 
-        public TestRunnerManager(IObjectContainer globalContainer, IContainerBuilder containerBuilder, Configuration.SpecFlowConfiguration specFlowConfiguration, IRuntimeBindingRegistryBuilder bindingRegistryBuilder)
+        public TestRunnerManager(IObjectContainer globalContainer, IContainerBuilder containerBuilder, Configuration.SpecFlowConfiguration specFlowConfiguration, IRuntimeBindingRegistryBuilder bindingRegistryBuilder,
+            ITestTracer testTracer)
         {
             this.globalContainer = globalContainer;
             this.containerBuilder = containerBuilder;
             this.specFlowConfiguration = specFlowConfiguration;
             this.bindingRegistryBuilder = bindingRegistryBuilder;
+            this.testTracer = testTracer;
         }
 
         public virtual ITestRunner CreateTestRunner(int threadId)

--- a/TechTalk.SpecFlow/TestRunnerManager.cs
+++ b/TechTalk.SpecFlow/TestRunnerManager.cs
@@ -181,19 +181,10 @@ namespace TechTalk.SpecFlow
 
         public static ITestRunner GetTestRunner(Assembly testAssembly = null, int? managedThreadId = null)
         {
-            try
-            {
-                testAssembly = testAssembly ?? Assembly.GetCallingAssembly();
-                managedThreadId = GetLogicalThreadId(managedThreadId);
-                var testRunnerManager = GetTestRunnerManager(testAssembly);
-                return testRunnerManager.GetTestRunner(managedThreadId.Value);
-            }
-            catch (ReflectionTypeLoadException ex)
-            {
-                throw new Exception(
-                    "Loader exceptions: " + Environment.NewLine +
-                    string.Join(Environment.NewLine, ex.LoaderExceptions.Select(lex => lex.ToString())), ex);
-            }
+            testAssembly = testAssembly ?? Assembly.GetCallingAssembly();
+            managedThreadId = GetLogicalThreadId(managedThreadId);
+            var testRunnerManager = GetTestRunnerManager(testAssembly);
+            return testRunnerManager.GetTestRunner(managedThreadId.Value);
         }
 
         private static int GetLogicalThreadId(int? managedThreadId)

--- a/TechTalk.SpecFlow/TestRunnerManager.cs
+++ b/TechTalk.SpecFlow/TestRunnerManager.cs
@@ -121,6 +121,20 @@ namespace TechTalk.SpecFlow
 
         public virtual ITestRunner GetTestRunner(int threadId)
         {
+            try
+            {
+                return GetTestRunnerWithoutExceptionHandling(threadId);
+
+            }
+            catch (Exception ex)
+            {
+                testTracer.TraceError(ex);
+                throw;
+            }
+        }
+
+        private ITestRunner GetTestRunnerWithoutExceptionHandling(int threadId)
+        {
             ITestRunner testRunner;
             if (!testRunnerRegistry.TryGetValue(threadId, out testRunner))
             {

--- a/TechTalk.SpecFlow/Tracing/TestTracer.cs
+++ b/TechTalk.SpecFlow/Tracing/TestTracer.cs
@@ -2,12 +2,10 @@
 using System.Globalization;
 using System.Linq;
 using System.Collections.Generic;
-using System.Reflection;
 using System.Text;
 using TechTalk.SpecFlow.BindingSkeletons;
 using TechTalk.SpecFlow.Bindings;
 using TechTalk.SpecFlow.Bindings.Reflection;
-using TechTalk.SpecFlow.Configuration;
 
 namespace TechTalk.SpecFlow.Tracing
 {
@@ -53,7 +51,7 @@ namespace TechTalk.SpecFlow.Tracing
 
         public void TraceStepDone(BindingMatch match, object[] arguments, TimeSpan duration)
         {
-            traceListener.WriteToolOutput("done: {0} ({1:F1}s)", 
+            traceListener.WriteToolOutput("done: {0} ({1:F1}s)",
                 stepFormatter.GetMatchText(match, arguments), duration.TotalSeconds);
         }
 
@@ -85,7 +83,7 @@ namespace TechTalk.SpecFlow.Tracing
                 message.AppendLine("No matching step definition found for the step. Use the following code to create one:");
             else
             {
-                string preMessage = string.Format("No matching step definition found for the step. There are matching step definitions, but none of them have matching scope for this step: {0}.", 
+                string preMessage = string.Format("No matching step definition found for the step. There are matching step definitions, but none of them have matching scope for this step: {0}.",
                     string.Join(", ", matchesWithoutScopeCheck.Select(m => stepFormatter.GetMatchText(m, null)).ToArray()));
                 traceListener.WriteToolOutput(preMessage);
                 message.AppendLine("Change the scope or use the following code to create a new step definition:");
@@ -99,7 +97,7 @@ namespace TechTalk.SpecFlow.Tracing
 
         public void TraceDuration(TimeSpan elapsed, IBindingMethod method, object[] arguments)
         {
-            traceListener.WriteToolOutput("duration: {0}: {1:F1}s", 
+            traceListener.WriteToolOutput("duration: {0}: {1:F1}s",
                 stepFormatter.GetMatchText(method, arguments), elapsed.TotalSeconds);
         }
 

--- a/TechTalk.SpecFlow/Tracing/TestTracer.cs
+++ b/TechTalk.SpecFlow/Tracing/TestTracer.cs
@@ -74,7 +74,7 @@ namespace TechTalk.SpecFlow.Tracing
 
         public void TraceError(Exception ex)
         {
-            traceListener.WriteToolOutput("error: {0}", ex.Message);
+            WriteErrorMessage(ex.Message);
             WriteLoaderExceptionsIfAny(ex);
         }
 
@@ -86,7 +86,7 @@ namespace TechTalk.SpecFlow.Tracing
                     WriteLoaderExceptionsIfAny(typeInitializationException.InnerException);
                     break;
                 case ReflectionTypeLoadException reflectionTypeLoadException:
-                    traceListener.WriteToolOutput("error: {0}", "Type Loader exceptions:");
+                    WriteErrorMessage("Type Loader exceptions:");
                     FormatLoaderExceptions(reflectionTypeLoadException);
                     break;
             }
@@ -100,8 +100,13 @@ namespace TechTalk.SpecFlow.Tracing
                 .Select(x => $"LoaderException: {x}");
             foreach (var ex in exceptions)
             {
-                traceListener.WriteToolOutput("error: {0}", ex);
+                WriteErrorMessage(ex);
             }
+        }
+
+        private void WriteErrorMessage(string ex)
+        {
+            traceListener.WriteToolOutput("error: {0}", ex);
         }
 
         public void TraceNoMatchingStepDefinition(StepInstance stepInstance, ProgrammingLanguage targetLanguage, CultureInfo bindingCulture, List<BindingMatch> matchesWithoutScopeCheck)

--- a/Tests/TechTalk.SpecFlow.IntegrationTests/Features/Tracing.feature
+++ b/Tests/TechTalk.SpecFlow.IntegrationTests/Features/Tracing.feature
@@ -13,3 +13,69 @@ Scenario: Preserves step keywords in trace
 	When I execute the tests
 	Then the execution log should contain text 'Angenommen ich Knopf 1 drücke'
 	And the execution log should contain text 'Gegeben sei ich Knopf 2 drücke'
+
+Scenario: ReflectionTypeLoaderException in a step binding
+	Given there is a feature file in the project as
+		 """
+			Feature: f
+			Scenario: s
+				When ...
+		 """
+	And the following step definition
+		"""
+		[When(@".*")]
+		public void When___()
+		{
+			throw new System.Reflection.ReflectionTypeLoadException(
+				new System.Type[3],
+				new[]
+				{
+					new System.Exception("crash"),
+					new System.Exception("boom"),
+					new System.Exception("bang"),
+				});
+		}
+		"""
+	When I execute the tests
+	Then the execution log should contain text '-> error: Type Loader exceptions:'
+	And the execution log should contain text '-> error: LoaderException: System.Exception: crash'
+	And the execution log should contain text '-> error: LoaderException: System.Exception: boom'
+	And the execution log should contain text '-> error: LoaderException: System.Exception: bang'
+
+Scenario: ReflectionTypeLoaderException in a static constructor
+	Given the following class
+		"""
+			public class Class1
+			{
+				static Class1()
+				{
+					throw new System.Reflection.ReflectionTypeLoadException(
+						new System.Type[3],
+						new[]
+						{
+							new System.Exception("crash"),
+							new System.Exception("boom"),
+							new System.Exception("bang"),
+						});
+				}
+			}
+		"""
+	And there is a feature file in the project as
+		 """
+			Feature: f
+			Scenario: s
+				When ...
+		 """
+	And the following step definition
+		"""
+		[When(@".*")]
+		public void When___()
+		{
+			System.Runtime.CompilerServices.RuntimeHelpers.RunClassConstructor(typeof(Class1).TypeHandle);
+		}
+		"""
+	When I execute the tests
+	Then the execution log should contain text '-> error: Type Loader exceptions:'
+	And the execution log should contain text '-> error: LoaderException: System.Exception: crash'
+	And the execution log should contain text '-> error: LoaderException: System.Exception: boom'
+	And the execution log should contain text '-> error: LoaderException: System.Exception: bang'

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/TestRunnerManagerRunnerCreationTests.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/TestRunnerManagerRunnerCreationTests.cs
@@ -34,7 +34,8 @@ namespace TechTalk.SpecFlow.RuntimeTests
 
             var runtimeBindingRegistryBuilderMock = new Mock<IRuntimeBindingRegistryBuilder>();
 
-            var testRunnerManager = new TestRunnerManager(globalObjectContainerStub.Object, testRunContainerBuilderStub.Object, _specFlowConfigurationStub, runtimeBindingRegistryBuilderMock.Object);
+            var testRunnerManager = new TestRunnerManager(globalObjectContainerStub.Object, testRunContainerBuilderStub.Object, _specFlowConfigurationStub, runtimeBindingRegistryBuilderMock.Object,
+                Mock.Of<ITestTracer>());
             testRunnerManager.Initialize(anAssembly);
             return testRunnerManager;
         }

--- a/changelog.txt
+++ b/changelog.txt
@@ -9,6 +9,7 @@ New Features:
 + Check for non-default constructors using case-insensitive comparison https://github.com/techtalk/SpecFlow/pull/1265
 + Syntax and structural changes in value retriever/comparer registration https://github.com/techtalk/SpecFlow/pull/1260
 + Add utility to get enum field value from TableRow.
++ Loader exceptions are appended to the exception message https://github.com/techtalk/SpecFlow/issues/1293
 
 2.4 - 2018-08-20
 New Features:


### PR DESCRIPTION
Fixes #1293

extend `TestTracer.TraceError`
- check if caught exception is a `ReflectionTypeLoadException`
- append the loader exceptions to SpecFlow output

![image](https://user-images.githubusercontent.com/1851369/46556069-c8feae00-c8e5-11e8-8084-8f83823ed41e.png)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added an entry to the changelog
