### PR TITLE
Add CreateInstance<T> support to a TableRow

### DIFF
--- a/TechTalk.SpecFlow/Assist/RowExtensionMethods.cs
+++ b/TechTalk.SpecFlow/Assist/RowExtensionMethods.cs
@@ -166,7 +166,7 @@ namespace TechTalk.SpecFlow.Assist
         }
 
 		/// <summary>
-		/// Creates an new instance of <typeparamref name="T"/> from the <see cref="TableRow"/>.
+		/// Creates a new instance of <typeparamref name="T"/> from the <see cref="TableRow"/>.
 		/// </summary>
 		/// <typeparam name="T">The type of the instance to be created.</typeparam>
 		/// <param name="row">The table row.</param>
@@ -178,7 +178,7 @@ namespace TechTalk.SpecFlow.Assist
 		}
 		
 		/// <summary>
-		/// Creates an new instance of <typeparamref name="T"/> from the <see cref="TableRow"/>.
+		/// Creates a new instance of <typeparamref name="T"/> from the <see cref="TableRow"/>.
 		/// </summary>
 		/// <typeparam name="T">The type of the instance to be created.</typeparam>
 		/// <param name="row">The table row.</param>

--- a/TechTalk.SpecFlow/Assist/RowExtensionMethods.cs
+++ b/TechTalk.SpecFlow/Assist/RowExtensionMethods.cs
@@ -164,5 +164,39 @@ namespace TechTalk.SpecFlow.Assist
         {
             return row.Any(x => x.Key == id);
         }
-    }
+
+		/// <summary>
+		/// Creates an new instance of <typeparamref name="T"/> from the <see cref="TableRow"/>.
+		/// </summary>
+		/// <typeparam name="T">The type of the instance to be created.</typeparam>
+		/// <param name="row">The table row.</param>
+		/// <returns>A new instance of <typeparamref name="T"/> filled with the data from the <see cref="TableRow"/>.</returns>
+		public static T CreateInstance<T>(this TableRow row)
+		{
+			var instanceTable = row.ToTable();
+			return instanceTable.CreateInstance<T>();
+		}
+		
+		/// <summary>
+		/// Creates an new instance of <typeparamref name="T"/> from the <see cref="TableRow"/>.
+		/// </summary>
+		/// <typeparam name="T">The type of the instance to be created.</typeparam>
+		/// <param name="row">The table row.</param>
+		/// <param name="methodToCreateTheInstance">The method to create a new instance.</param>
+		/// <returns>A new instance of <typeparamref name="T"/> filled with the data from the <see cref="TableRow"/>.</returns>
+		public static T CreateInstance<T>(this TableRow row, Func<T> methodToCreateTheInstance)
+		{
+			var instanceTable = row.ToTable();
+			return instanceTable.CreateInstance<T>(methodToCreateTheInstance);
+		}
+
+		private static Table ToTable(this TableRow row)
+		{
+			var instanceTable = new Table("Field", "Value");
+			foreach (var kvp in row)
+				instanceTable.AddRow(kvp.Key, kvp.Value);
+
+			return instanceTable;
+		}
+	}
 }

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/RowExtensionMethodTests.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/RowExtensionMethodTests.cs
@@ -316,5 +316,37 @@ namespace TechTalk.SpecFlow.RuntimeTests.AssistTests
 
             act.Should().Throw<IndexOutOfRangeException>();
         }
-    }
+
+		[Fact]
+		public void Create_instance_fills_a_new_instance()
+		{
+			var expectedPerson = new Person() { FirstName = "Max", LastName = "Mustermann", BirthDate = new DateTime(1980, 3, 31) };
+
+			var table = new Table("FirstName", "LastName", "BirthDate");
+			table.AddRow(expectedPerson.FirstName, expectedPerson.LastName, expectedPerson.BirthDate.ToString("yyyy-MM-dd"));
+
+			var row = table.Rows[0];
+			var person = row.CreateInstance(() => new Person());
+
+			person.FirstName.Should().Be(expectedPerson.FirstName);
+			person.LastName.Should().Be(expectedPerson.LastName);
+			person.BirthDate.Should().Be(expectedPerson.BirthDate);
+		}
+
+		[Fact]
+		public void Create_instance_creates_a_new_instance()
+		{
+			var expectedPerson = new Person() { FirstName = "Max", LastName = "Mustermann", BirthDate = new DateTime(1978, 9, 27) };
+
+			var table = new Table("FirstName", "LastName", "BirthDate");
+			table.AddRow(expectedPerson.FirstName, expectedPerson.LastName, expectedPerson.BirthDate.ToString("yyyy-MM-dd"));
+
+			var row = table.Rows[0];
+			var person = row.CreateInstance<Person>();
+
+			person.FirstName.Should().Be(expectedPerson.FirstName);
+			person.LastName.Should().Be(expectedPerson.LastName);
+			person.BirthDate.Should().Be(expectedPerson.BirthDate);
+		}
+	}
 }

--- a/changelog.txt
+++ b/changelog.txt
@@ -14,7 +14,7 @@ New Features:
 + Add utility to get enum field value from TableRow.
 + Gherkin language data is used instead of an obsolete copy https://github.com/techtalk/SpecFlow/pull/1288
 + Loader exceptions are appended to the exception message https://github.com/techtalk/SpecFlow/issues/1293
-+ Add CreateItem<T> support to a TableRow
++ Add CreateInstance<T> support to a TableRow
 
 Fixes:
 + Visual Studio change detection integration for Net.SDK style projects via SpecFlow.Tools.MSBuild.Generation https://github.com/techtalk/SpecFlow/issues/1319

--- a/changelog.txt
+++ b/changelog.txt
@@ -14,6 +14,7 @@ New Features:
 + Add utility to get enum field value from TableRow.
 + Gherkin language data is used instead of an obsolete copy https://github.com/techtalk/SpecFlow/pull/1288
 + Loader exceptions are appended to the exception message https://github.com/techtalk/SpecFlow/issues/1293
++ Add CreateItem<T> support to a TableRow
 
 Fixes:
 + Visual Studio change detection integration for Net.SDK style projects via SpecFlow.Tools.MSBuild.Generation https://github.com/techtalk/SpecFlow/issues/1319


### PR DESCRIPTION
Extended the RowExtensionMethods class with two CreateInstance<T> methods for a TableRow.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've added tests for my code.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added an entry to the changelog
