### PR TITLE
NullValueRetriever implemented

### DIFF
--- a/TechTalk.SpecFlow/Assist/ValueRetrievers/NullValueRetriever.cs
+++ b/TechTalk.SpecFlow/Assist/ValueRetrievers/NullValueRetriever.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace TechTalk.SpecFlow.Assist.ValueRetrievers
+{
+    public class NullValueRetriever : IValueRetriever
+    {
+        private readonly string nullText;
+
+        public NullValueRetriever(string nullText)
+        {
+            this.nullText = nullText;
+        }
+
+        public bool CanRetrieve(KeyValuePair<string, string> keyValuePair, Type targetType, Type propertyType)
+        {
+            return IsNullableType(propertyType) &&
+                   keyValuePair.Value != null &&
+                   string.Compare(keyValuePair.Value.Trim(), nullText, StringComparison.InvariantCultureIgnoreCase) == 0;
+        }
+
+        public object Retrieve(KeyValuePair<string, string> keyValuePair, Type targetType, Type propertyType)
+        {
+            return null;
+        }
+
+        private static bool IsNullableType(Type type)
+        {
+            return !type.IsValueType || 
+                (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(Nullable<>));
+        }
+    }
+}

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/ValueRetrieverTests/NullValueRetrieverTests.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/ValueRetrieverTests/NullValueRetrieverTests.cs
@@ -1,0 +1,105 @@
+﻿using System;
+using FluentAssertions;
+using TechTalk.SpecFlow.Assist.ValueRetrievers;
+using Xunit;
+
+namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.ValueRetrieverTests
+{
+    public class NullValueRetrieverTests
+    {
+        private const string TestNullValue = "MyNullValue";
+
+        [Theory]
+        [InlineData("MyNullValue")]
+        [InlineData(" \tMyNullValue\t ")]
+        [InlineData("MyNuLLValue")]
+        [InlineData("\tMyNuLLValue\t")]
+        public void Can_retrieve_null_value(string value)
+        {
+            var retriever = CreateTestee();
+
+            var actual = retriever.CanRetrieve<object>(value);
+
+            actual.Should().BeTrue();
+        }
+
+        [Theory]
+        [InlineData(typeof(object))]
+        [InlineData(typeof(bool?))]
+        public void Can_retrieve_nullable_types(Type propertyType)
+        {
+            var retriever = CreateTestee();
+
+            var actual = retriever.CanRetrieve(TestNullValue, propertyType);
+
+            actual.Should().BeTrue();
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("Any string")]
+        [InlineData("30.0")]
+        [InlineData("true")]
+        [InlineData(" \t ")]
+        public void Cannot_retrieve_non_null_values(string value)
+        {
+            var retriever = CreateTestee();
+
+            var actual = retriever.CanRetrieve<object>(value);
+
+            actual.Should().BeFalse();
+        }
+
+        [Theory]
+        [InlineData(typeof(bool))]
+        [InlineData(typeof(Guid))]
+        [InlineData(typeof(StringSplitOptions))]
+        public void Cannot_retrieve_non_nullable_types(Type propertyType)
+        {
+            var retriever = CreateTestee();
+
+            var actual = retriever.CanRetrieve(TestNullValue, propertyType);
+
+            actual.Should().BeFalse();
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("Any string")]
+        [InlineData("30.0")]
+        [InlineData("true")]
+        [InlineData(" \t ")]
+        [InlineData(" \tMyNullValue\t ")]
+        [InlineData("MyNuLLValue")]
+        public void Retrieves_null_for_any_value(string value)
+        {
+            var retriever = CreateTestee();
+
+            var actual = retriever.GetValue<object>(value);
+
+            actual.Should().BeNull();
+        }
+
+        [Theory]
+        [InlineData(typeof(object))]
+        [InlineData(typeof(bool?))]
+        [InlineData(typeof(bool))]
+        [InlineData(typeof(Guid))]
+        [InlineData(typeof(StringSplitOptions))]
+        public void Retrieves_null_for_any_type(Type propertyType)
+        {
+            var retriever = CreateTestee();
+
+            var actual = retriever.GetValue("Any value", propertyType);
+
+            actual.Should().BeNull();
+        }
+
+        private NullValueRetriever CreateTestee()
+        {
+            return new NullValueRetriever(TestNullValue);
+        }
+    }
+}

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/ValueRetrieverTests/ValueRetrieverTestsUtils.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/AssistTests/ValueRetrieverTests/ValueRetrieverTestsUtils.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using TechTalk.SpecFlow.Assist;
+
+namespace TechTalk.SpecFlow.RuntimeTests.AssistTests.ValueRetrieverTests
+{
+    internal static class ValueRetrieverTestsUtils
+    {
+        internal static bool CanRetrieve<TProperty>(this IValueRetriever retriever, string value)
+        {
+            return retriever.CanRetrieve(value, typeof(TProperty));
+        }
+
+        internal static bool CanRetrieve(this IValueRetriever retriever, string value, Type propertyType)
+        {
+            return retriever.CanRetrieve(new KeyValuePair<string, string>("Value", value), typeof(object), propertyType);
+        }
+
+        internal static TProperty GetValue<TProperty>(this IValueRetriever retriever, string value)
+        {
+            return (TProperty)retriever.GetValue(value, typeof(TProperty));
+        }
+
+        internal static object GetValue(this IValueRetriever retriever, string value, Type propertyType)
+        {
+            return retriever.Retrieve(new KeyValuePair<string, string>("Value", value), typeof(object), propertyType);
+        }
+    }
+}

--- a/changelog.txt
+++ b/changelog.txt
@@ -17,6 +17,7 @@ New Features:
 + Array & List support for any available item value retriever when instantiating class from Specflow table https://github.com/techtalk/SpecFlow/pull/1385
 + Add CreateInstance<T> support to a TableRow
 + Uri value retriever added https://github.com/techtalk/SpecFlow/pull/1403
++ Null value retriever added https://github.com/techtalk/SpecFlow/pull/1406
 
 Fixes:
 + Visual Studio change detection integration for Net.SDK style projects via SpecFlow.Tools.MSBuild.Generation https://github.com/techtalk/SpecFlow/issues/1319


### PR DESCRIPTION
A NullValueRetriever implemented that can be used to explicitly set null values according to #1389. The retriever is intentionally not added as a default retriever. The target project can add this to default retrievers and specify the null text if the project needs that.

If this will be merged in, the following change to documentation is needed (sorry, I don know how to include wiki change in a pull request). I can update the docs if you decide to merge.

In the end of [SpecFlow-Assist-Helpers](https://github.com/techtalk/SpecFlow/wiki/SpecFlow-Assist-Helpers)
````
### NullValueRetriever

By default, non-specified (empty string) values are considered:
* an empty string for `String` and `System.Uri` values
* a null value for `Nullable<>` primitive types
* an error for non-nullable primitive types

Explicit specification of null values can be achieved by adding a NullValueRetriever to set of registered retrievers and specifying the text that will be considered as a null value like this:

```c#
[Binding]
public static class Hooks1
{
    [BeforeTestRun]
    public static void BeforeTestRun()
    {
        Service.Instance.ValueRetrievers.Register(new NullValueRetriever("<null>"));
    }
}
```
_Note: The text is compared in case-insensitive way._
````

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue).
- [ X ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

- [ X ] I've added tests for my code.
- [ X ] My change requires a change to the documentation.
- [ X ] I have updated the documentation accordingly.
- [ X ] I have added an entry to the changelog
