### PR TITLE
Fix XUnit output (SpecFlow trace information were not displayed in Test Explorer)

### DIFF
--- a/Plugins/TechTalk.SpecFlow.xUnit.SpecFlowPlugin/RuntimePlugin.cs
+++ b/Plugins/TechTalk.SpecFlow.xUnit.SpecFlowPlugin/RuntimePlugin.cs
@@ -14,8 +14,16 @@ namespace TechTalk.SpecFlow.xUnit.SpecFlowPlugin
     {
         public void Initialize(RuntimePluginEvents runtimePluginEvents, RuntimePluginParameters runtimePluginParameters, UnitTestProviderConfiguration unitTestProviderConfiguration)
         {
+            runtimePluginEvents.CustomizeTestThreadDependencies += RuntimePluginEvents_CustomizeTestThreadDependencies;
             runtimePluginEvents.CustomizeScenarioDependencies += RuntimePluginEvents_CustomizeScenarioDependencies;
             unitTestProviderConfiguration.UseUnitTestProvider("xunit");
+        }
+
+        private void RuntimePluginEvents_CustomizeTestThreadDependencies(object sender, CustomizeTestThreadDependenciesEventArgs e)
+        {
+            var container = e.ObjectContainer;
+
+            container.RegisterTypeAs<XUnitTraceListener, ITraceListener>();
         }
 
         private void RuntimePluginEvents_CustomizeScenarioDependencies(object sender, CustomizeScenarioDependenciesEventArgs e)
@@ -23,7 +31,6 @@ namespace TechTalk.SpecFlow.xUnit.SpecFlowPlugin
             var container = e.ObjectContainer;
 
             container.RegisterTypeAs<OutputHelper, ISpecFlowOutputHelper>();
-            container.RegisterTypeAs<XUnitTraceListener, ITraceListener>();
         }
     }
 }

--- a/Plugins/TechTalk.SpecFlow.xUnit.SpecFlowPlugin/XUnitTraceListener.cs
+++ b/Plugins/TechTalk.SpecFlow.xUnit.SpecFlowPlugin/XUnitTraceListener.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using BoDi;
+using TechTalk.SpecFlow.Infrastructure;
 using TechTalk.SpecFlow.Tracing;
 using Xunit.Abstractions;
 
@@ -7,22 +8,34 @@ namespace TechTalk.SpecFlow.xUnit.SpecFlowPlugin
 {
     class XUnitTraceListener : AsyncTraceListener
     {
-        private readonly ITestOutputHelper _testOutputHelper;
+        private readonly Lazy<IContextManager> _contextManager;
 
-        public XUnitTraceListener(ITraceListenerQueue traceListenerQueue, IObjectContainer container, ITestOutputHelper testOutputHelper) : base(traceListenerQueue, container)
+        public XUnitTraceListener(ITraceListenerQueue traceListenerQueue, IObjectContainer container) : base(traceListenerQueue, container)
         {
-            _testOutputHelper = testOutputHelper;
+            _contextManager = new Lazy<IContextManager>(container.Resolve<IContextManager>);
+        }
+
+        private ITestOutputHelper GetTestOutputHelper()
+        {
+            var scenarioContext = _contextManager.Value.ScenarioContext;
+            if (scenarioContext == null)
+                return null;
+
+            if (!scenarioContext.ScenarioContainer.IsRegistered<ITestOutputHelper>())
+                return null;
+
+            return scenarioContext.ScenarioContainer.Resolve<ITestOutputHelper>();
         }
 
         public override void WriteTestOutput(string message)
         {
-            _testOutputHelper.WriteLine(message);
+            GetTestOutputHelper()?.WriteLine(message);
             base.WriteTestOutput(message);
         }
 
         public override void WriteToolOutput(string message)
         {
-            _testOutputHelper.WriteLine("-> " + message);
+            GetTestOutputHelper()?.WriteLine("-> " + message);
             base.WriteToolOutput(message);
         }
     }

--- a/Plugins/TechTalk.SpecFlow.xUnit.SpecFlowPlugin/XUnitTraceListener.cs
+++ b/Plugins/TechTalk.SpecFlow.xUnit.SpecFlowPlugin/XUnitTraceListener.cs
@@ -29,14 +29,20 @@ namespace TechTalk.SpecFlow.xUnit.SpecFlowPlugin
 
         public override void WriteTestOutput(string message)
         {
-            GetTestOutputHelper()?.WriteLine(message);
-            base.WriteTestOutput(message);
+            var testOutputHelper = GetTestOutputHelper();
+            if (testOutputHelper != null)
+                testOutputHelper.WriteLine(message);
+            else
+                base.WriteTestOutput(message);
         }
 
         public override void WriteToolOutput(string message)
         {
-            GetTestOutputHelper()?.WriteLine("-> " + message);
-            base.WriteToolOutput(message);
+            var testOutputHelper = GetTestOutputHelper();
+            if (testOutputHelper != null)
+                testOutputHelper.WriteLine("-> " + message);
+            else
+                base.WriteToolOutput(message);
         }
     }
 }


### PR DESCRIPTION
When tests are executed with xUnit (e.g. with VS Test Explorer), the standard SpecFlow trace information (running steps, etc.) is not included in the output.

The issue is caused by the registration of the XUnitTraceListener, that was registered to the Scenario container, although SpecFlow reads it out from the Test Thread Container. The plugin is changed now to register it to the right container and inside the method it checks if the `ITestOutputHelper` is available and if yes, it forwards the message there. 

Tested manually.

## Types of changes

- [x ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

- [ ] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added an entry to the changelog

