### PR TITLE
Preparation to fix #1348: Expose TestRunnerManager.OnTestRunEnd to be able to call it from plugins

### DIFF
--- a/Tests/TechTalk.SpecFlow.RuntimeTests/RuntimeBindingRegistryBuilderTests.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/RuntimeBindingRegistryBuilderTests.cs
@@ -71,7 +71,7 @@ namespace TechTalk.SpecFlow.RuntimeTests
         }
 
         [Binding]
-        public class PrioritisedHookExample
+        public class PrioritizedHookExample
         {
             [BeforeScenario]
             public void OrderTenThousand()
@@ -149,7 +149,7 @@ namespace TechTalk.SpecFlow.RuntimeTests
         {
             var builder = new RuntimeBindingRegistryBuilder(bindingSourceProcessorStub);
 
-            builder.BuildBindingsFromType(typeof (PrioritisedHookExample));
+            builder.BuildBindingsFromType(typeof (PrioritizedHookExample));
 
             Assert.Equal(1,
                 bindingSourceProcessorStub.HookBindings.Count(

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/TestRunnerManagerStaticApiTest.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/TestRunnerManagerStaticApiTest.cs
@@ -12,7 +12,7 @@ namespace TechTalk.SpecFlow.RuntimeTests
     
     public class TestRunnerManagerStaticApiTest
     {
-        private readonly Assembly anAssembly = Assembly.GetExecutingAssembly();
+        private readonly Assembly thisAssembly = Assembly.GetExecutingAssembly();
         private readonly Assembly anotherAssembly = typeof(TestRunnerManager).Assembly;
 
         public TestRunnerManagerStaticApiTest()
@@ -30,12 +30,96 @@ namespace TechTalk.SpecFlow.RuntimeTests
         }
 
         [Fact]
-        public void Should_return_different_instances_for_different_assemblies()
+        public void GetTestRunner_should_return_different_instances_for_different_assemblies()
         {
-            var testRunner1 = TestRunnerManager.GetTestRunner(anAssembly);
+            var testRunner1 = TestRunnerManager.GetTestRunner(thisAssembly);
             var testRunner2 = TestRunnerManager.GetTestRunner(anotherAssembly);
 
             testRunner1.Should().NotBe(testRunner2);
+        }
+
+        [Fact]
+        public void GetTestRunnerManager_without_arguments_should_return_an_instance_for_the_calling_assembly()
+        {
+            var testRunnerManager = TestRunnerManager.GetTestRunnerManager();
+
+            testRunnerManager.Should().NotBeNull();
+            testRunnerManager.TestAssembly.Should().BeSameAs(thisAssembly);
+        }
+
+        [Fact]
+        public void GetTestRunnerManager_should_return_null_when_called_with_no_create_flag_and_there_was_no_instance_created_yet()
+        {
+            TestRunnerManager.Reset();
+
+            var testRunnerManager = TestRunnerManager.GetTestRunnerManager(createIfMissing: false);
+
+            testRunnerManager.Should().BeNull();
+        }
+
+        [Binding]
+        public class AfterTestRunTestBinding
+        {
+            public static int AfterTestRunCallCount = 0;
+
+            [AfterTestRun]
+            public static void AfterTestRun()
+            {
+                AfterTestRunCallCount++;
+            }
+        }
+
+        [Fact]
+        public void OnTestRunEnd_should_fire_AfterTestRun_events()
+        {
+            // make sure a test runner is initialized
+            TestRunnerManager.GetTestRunner(thisAssembly);
+
+            AfterTestRunTestBinding.AfterTestRunCallCount = 0; //reset
+            TestRunnerManager.OnTestRunEnd(thisAssembly);
+
+            AfterTestRunTestBinding.AfterTestRunCallCount.Should().Be(1);
+        }
+
+        [Fact]
+        public void OnTestRunEnd_without_arguments_should_fire_AfterTestRun_events_for_calling_assembly()
+        {
+            // make sure a test runner is initialized
+            TestRunnerManager.GetTestRunner(thisAssembly);
+
+            AfterTestRunTestBinding.AfterTestRunCallCount = 0; //reset
+            TestRunnerManager.OnTestRunEnd();
+
+            AfterTestRunTestBinding.AfterTestRunCallCount.Should().Be(1);
+        }
+
+        [Fact]
+        public void OnTestRunEnd_should_not_fire_AfterTestRun_events_multiple_times()
+        {
+            // make sure a test runner is initialized
+            TestRunnerManager.GetTestRunner(thisAssembly);
+
+            AfterTestRunTestBinding.AfterTestRunCallCount = 0; //reset
+            TestRunnerManager.OnTestRunEnd(thisAssembly);
+            TestRunnerManager.OnTestRunEnd(thisAssembly);
+
+            AfterTestRunTestBinding.AfterTestRunCallCount.Should().Be(1);
+        }
+
+        [Fact]
+        public void DomainUnload_event_should_not_fire_AfterTestRun_events_multiple_times_after_OnTestRunEnd()
+        {
+            // make sure a test runner is initialized
+            TestRunnerManager.GetTestRunner(thisAssembly);
+
+            AfterTestRunTestBinding.AfterTestRunCallCount = 0; //reset
+            TestRunnerManager.OnTestRunEnd(thisAssembly);
+
+            // simulating DomainUnload event
+            var trm = (TestRunnerManager)TestRunnerManager.GetTestRunnerManager(thisAssembly);
+            trm.OnDomainUnload();
+
+            AfterTestRunTestBinding.AfterTestRunCallCount.Should().Be(1);
         }
     }
 }


### PR DESCRIPTION
In order to fix #1348 in a way as @SabotageAndi suggested, we need an easy way to ensure that the AfterTestRun hooks fired even before AppDomain unload. 

This PR exposes an `OnTestRunEnd` method on the static API of `TestRunnerManager` to support this. The `OnTestRunEnd` method is safe to call multiple times (or call it before domain unload), it will fire the events only once. 

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

- [x] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added an entry to the changelog
