### PR TITLE
Proper tests for xunit2 collection support

### DIFF
--- a/Tests/TechTalk.SpecFlow.Specs/Features/UnitTestProviderSpecific/XUnit/XUnit2Provider.feature
+++ b/Tests/TechTalk.SpecFlow.Specs/Features/UnitTestProviderSpecific/XUnit/XUnit2Provider.feature
@@ -12,13 +12,14 @@ Scenario: Should be able to log custom messages
         [When(@"I do something")]
         public void WhenIDoSomething()
         {
-        ScenarioContext.Current.ScenarioContainer.Resolve<Xunit.Abstractions.ITestOutputHelper>().WriteLine("hello");
+        ScenarioContext.Current.ScenarioContainer.Resolve<Xunit.Abstractions.ITestOutputHelper>().WriteLine("something");
         }
         """
     When I execute the tests
     Then the execution summary should contain
         | Succeeded |
         | 1         |
+    And the execution log should contain text 'something'
 
 
 Scenario: Should be able to log custom messages using context injection
@@ -54,11 +55,12 @@ Scenario: Should be able to log custom messages using context injection
     Then the execution summary should contain
          | Succeeded |
          | 1         |
+    And the execution log should contain text 'something'
 
-Scenario: Should be able to set collection attribute
+Scenario: Usage of collection attribute adds category
     Given there is a SpecFlow project
-    And a scenario 'Simple Scenario' as with collection attribute 'sample'
-        """
+    And a scenario named 'Simple Scenario' with collection tag 'SampleCollection' as
+       """
         When I do something
         """	
     And the following step definition
@@ -69,7 +71,58 @@ Scenario: Should be able to set collection attribute
         ScenarioContext.Current.ScenarioContainer.Resolve<Xunit.Abstractions.ITestOutputHelper>().WriteLine("hello");
         }
         """
+    When I execute the tests tagged with '@xunit:collection\(SampleCollection\)'
+    Then the execution summary should contain
+        | Succeeded |
+        | 1         |
+
+Scenario: Usage of collection attribute injects collection's TFixture
+    Given there is a SpecFlow project
+    And a scenario named 'Simple Scenario' with collection tag 'SampleCollection' as
+        """
+        Then collection TFixture is initialized
+        """	
+    And the following binding class
+        """
+        using System;
+        using TechTalk.SpecFlow;
+        using Xunit;
+        
+        [CollectionDefinition(nameof(SampleCollection))]
+        public class SampleCollection : ICollectionFixture<SampleFixture>
+        {
+            // This class has no code, and is never created. Its purpose is simply to be the place to apply [CollectionDefinition] and all the ICollectionFixture<> interfaces.
+        }
+        public class SampleFixture
+        {
+            // Will be initialized and added to DI container while collection initialization
+        }
+
+        [Binding]
+        public class StepsWithScenarioContext
+        {
+            private SampleFixture _sampleFixture;
+            private ScenarioContext _scenarioContext;
+            private Xunit.Abstractions.ITestOutputHelper _output;
+            public StepsWithScenarioContext(ScenarioContext scenarioContext, SampleFixture sampleFixture)
+            {
+                _scenarioContext = scenarioContext;
+                _output = _scenarioContext.ScenarioContainer.Resolve<Xunit.Abstractions.ITestOutputHelper>();
+                _sampleFixture = sampleFixture;
+            }
+
+            [Then(@"collection TFixture is initialized")]
+            public void ThenCollectionTFixtureInitialized()
+            {
+                if (_sampleFixture != null) 
+                {
+                    _output.WriteLine("TFixture initialization works");
+                }
+            }
+        }
+        """	
     When I execute the tests
     Then the execution summary should contain
         | Succeeded |
         | 1         |
+    And the execution log should contain text 'TFixture initialization works'

--- a/Tests/TechTalk.SpecFlow.Specs/Features/UnitTestProviderSpecific/XUnit/XUnit2Provider.feature
+++ b/Tests/TechTalk.SpecFlow.Specs/Features/UnitTestProviderSpecific/XUnit/XUnit2Provider.feature
@@ -12,14 +12,14 @@ Scenario: Should be able to log custom messages
         [When(@"I do something")]
         public void WhenIDoSomething()
         {
-        ScenarioContext.Current.ScenarioContainer.Resolve<Xunit.Abstractions.ITestOutputHelper>().WriteLine("something");
+        ScenarioContext.Current.ScenarioContainer.Resolve<Xunit.Abstractions.ITestOutputHelper>().WriteLine("F89FFFA1-88CD-40C8-B0E2-2B167E1F81A2");
         }
         """
     When I execute the tests
     Then the execution summary should contain
         | Succeeded |
         | 1         |
-    And the execution log should contain text 'something'
+    And the execution log should contain text 'F89FFFA1-88CD-40C8-B0E2-2B167E1F81A2'
 
 
 Scenario: Should be able to log custom messages using context injection
@@ -43,7 +43,7 @@ Scenario: Should be able to log custom messages using context injection
             [When(@"I do something")]
             public void WhenIDoSomething()
             {
-                _output.WriteLine("something");
+                _output.WriteLine("EB7C1291-2C44-417F-ABB7-A5154843BC7B");
             }
         }
         """	
@@ -55,7 +55,7 @@ Scenario: Should be able to log custom messages using context injection
     Then the execution summary should contain
          | Succeeded |
          | 1         |
-    And the execution log should contain text 'something'
+    And the execution log should contain text 'EB7C1291-2C44-417F-ABB7-A5154843BC7B'
 
 Scenario: Usage of collection attribute adds category
     Given there is a SpecFlow project
@@ -116,7 +116,7 @@ Scenario: Usage of collection attribute injects collection's TFixture
             {
                 if (_sampleFixture != null) 
                 {
-                    _output.WriteLine("TFixture initialization works");
+                    _output.WriteLine("TFixture initialization works 5C3548BE-F19C-485C-8A9F-E2BF1C5BF1B3");
                 }
             }
         }
@@ -125,4 +125,4 @@ Scenario: Usage of collection attribute injects collection's TFixture
     Then the execution summary should contain
         | Succeeded |
         | 1         |
-    And the execution log should contain text 'TFixture initialization works'
+    And the execution log should contain text 'TFixture initialization works 5C3548BE-F19C-485C-8A9F-E2BF1C5BF1B3'

--- a/Tests/TechTalk.SpecFlow.Specs/StepDefinitions/FeatureFileSteps.cs
+++ b/Tests/TechTalk.SpecFlow.Specs/StepDefinitions/FeatureFileSteps.cs
@@ -32,14 +32,14 @@ Scenario: {title}
                 ");
         }
 
-        [Given(@"a scenario '(.*)' as with collection attribute '(.*)'")]
+        [Given(@"a scenario named '(.*)' with collection tag '(.*)' as")]
         public void GivenAScenarioAsWithCollectionAttribute(string title,  string collection, string scenarioContent)
         {
             _projectsDriver.AddFeatureFile(
                  $@"@xunit:collection({collection})
-                    Feature: Feature {Guid.NewGuid()}
-                    Scenario: {title}
-{scenarioContent.Replace("'''", "\"\"\"")}
+Feature: Feature {Guid.NewGuid()}
+Scenario: {title}
+                    {scenarioContent.Replace("'''", "\"\"\"")}
                 ");
         }
 


### PR DESCRIPTION
Support of xunit collection , introduced in https://github.com/techtalk/SpecFlow/pull/1380, doesn't have real testing. It just compiles and that's all. Now it's added for two cases:
1) Usage of collection tag in feature file actually makes xunit initialize collections and related TFixture
2) Usage of collection tag in feature adds test category (Traits in xunit terms). Actually, it's not required by xunit, but as I see any tag should be treated as category so let's test it too. 

Also, test output compare is added too.

## Types of changes

- [x ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:
- [x ] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added an entry to the changelog
