### PR TITLE
SynchronizationContext is not reset if async method throws an exception

### DIFF
--- a/Tests/TechTalk.SpecFlow.RuntimeTests/Bindings/AsyncHelperTests.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/Bindings/AsyncHelperTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
 using TechTalk.SpecFlow.Bindings;
@@ -49,6 +50,71 @@ namespace TechTalk.SpecFlow.RuntimeTests.Bindings
             {
                 ex.StackTrace.Should().StartWith($"   at {GetType().FullName}.{nameof(AsyncMethodThrowsException)}()");
             }
+        }
+
+        [Fact]
+        public void RunSync_WhenExceptionIsThrown_ShouldRestoreSynchronizationContext()
+        {
+            var expectedSynchronizationContext = SynchronizationContext.Current;
+
+            Action action = () => AsyncHelpers.RunSync(AsyncMethodThrowsException);
+            action.Should().Throw<Exception>();
+      
+            SynchronizationContext.Current.Should().BeSameAs(expectedSynchronizationContext);
+        }
+
+        private object NormalMethodReturnValue()
+        {
+            return null;
+        }
+
+        private object ThrowExceptionReturnValue()
+        {
+            throw new Exception("Hi from async");
+        }
+
+        private Task<object> AsyncMethodReturnValueThrowsException()
+        {
+            throw new Exception();
+        }
+
+        [Fact]
+        public void RunSyncReturnValue_NormalMethod()
+        {
+            AsyncHelpers.RunSync(async () => NormalMethodReturnValue());
+        }
+
+        [Fact]
+        public void RunSyncReturnValue_ExceptionIsThrown()
+        {
+
+            Action action = () => AsyncHelpers.RunSync(async () => ThrowExceptionReturnValue());
+
+            action.Should().Throw<Exception>().WithMessage("Hi from async");
+        }
+
+        [Fact]
+        public void RunSyncReturnValue_WhenExceptionIsThrown_ShouldRestoreOriginalStackTrace()
+        {
+            try
+            {
+                AsyncHelpers.RunSync(AsyncMethodReturnValueThrowsException);
+            }
+            catch (Exception ex)
+            {
+                ex.StackTrace.Should().StartWith($"   at {GetType().FullName}.{nameof(AsyncMethodReturnValueThrowsException)}()");
+            }
+        }
+
+        [Fact]
+        public void RunSyncReturnValue_WhenExceptionIsThrown_ShouldRestoreSynchronizationContext()
+        {
+            var expectedSynchronizationContext = SynchronizationContext.Current;
+
+            Action action = () => AsyncHelpers.RunSync(AsyncMethodReturnValueThrowsException);
+            action.Should().Throw<Exception>();
+
+            SynchronizationContext.Current.Should().BeSameAs(expectedSynchronizationContext);
         }
     }
 }


### PR DESCRIPTION
Fixes #1509

Always reset the SynchronizationContext at the end of AsyncHelpers.RunAsync.

Repeated the tests for RunSync against the RunSync<T> overload.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added an entry to the changelog
