### PR TITLE
Remove `#if SILVERLIGHT` from code for issue #1502

### DIFF
--- a/TechTalk.SpecFlow/BindingSkeletons/DefaultSkeletonTemplateProvider.cs
+++ b/TechTalk.SpecFlow/BindingSkeletons/DefaultSkeletonTemplateProvider.cs
@@ -28,15 +28,11 @@ namespace TechTalk.SpecFlow.BindingSkeletons
 
         protected override string GetTemplateFileContent()
         {
-#if SILVERLIGHT
-            return "";
-#else
             string templateFilePath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), @"SpecFlow\SkeletonTemplates.sftemplate");
             if (!File.Exists(templateFilePath))
                 return "";
 
             return File.ReadAllText(templateFilePath);
-#endif
         }
 
         protected internal override string GetTemplate(string key)

--- a/TechTalk.SpecFlow/ErrorHandling/BindingException.cs
+++ b/TechTalk.SpecFlow/ErrorHandling/BindingException.cs
@@ -5,10 +5,7 @@ using System.Runtime.Serialization;
 // the exceptions are part of the public API, keep them in TechTalk.SpecFlow namespace
 namespace TechTalk.SpecFlow
 {
-#if !SILVERLIGHT
     [Serializable]
-#endif
-
     public class BindingException : SpecFlowException
     {
         public BindingException()
@@ -23,13 +20,10 @@ namespace TechTalk.SpecFlow
         {
         }
 
-#if !SILVERLIGHT
         protected BindingException(
             SerializationInfo info,
             StreamingContext context) : base(info, context)
         {
         }
-#endif
-
     }
 }

--- a/TechTalk.SpecFlow/ErrorHandling/MissingStepDefinitionException.cs
+++ b/TechTalk.SpecFlow/ErrorHandling/MissingStepDefinitionException.cs
@@ -5,9 +5,7 @@ using System.Runtime.Serialization;
 // the exceptions are part of the public API, keep them in TechTalk.SpecFlow namespace
 namespace TechTalk.SpecFlow
 {
-#if !SILVERLIGHT
     [Serializable]
-#endif
     public class MissingStepDefinitionException : SpecFlowException
     {
         public MissingStepDefinitionException()
@@ -15,14 +13,11 @@ namespace TechTalk.SpecFlow
         {
         }
 
-#if !SILVERLIGHT
         protected MissingStepDefinitionException(
             SerializationInfo info,
             StreamingContext context)
             : base(info, context)
         {
         }
-#endif
-
     }
 }

--- a/TechTalk.SpecFlow/ErrorHandling/PendingStepException.cs
+++ b/TechTalk.SpecFlow/ErrorHandling/PendingStepException.cs
@@ -6,9 +6,7 @@ using System.Runtime.Serialization;
 // ReSharper disable once CheckNamespace
 namespace TechTalk.SpecFlow
 {
-#if !SILVERLIGHT
     [Serializable]
-#endif
     public class PendingStepException : SpecFlowException
     {
         public PendingStepException()
@@ -16,12 +14,10 @@ namespace TechTalk.SpecFlow
         {
         }
 
-#if !SILVERLIGHT
         protected PendingStepException(
             SerializationInfo info,
             StreamingContext context) : base(info, context)
         {
         }
-#endif
     }
 }

--- a/TechTalk.SpecFlow/ErrorHandling/SpecFlowException.cs
+++ b/TechTalk.SpecFlow/ErrorHandling/SpecFlowException.cs
@@ -5,9 +5,7 @@ using System.Runtime.Serialization;
 // the exceptions are part of the public API, keep them in TechTalk.SpecFlow namespace
 namespace TechTalk.SpecFlow
 {
-#if !SILVERLIGHT
     [Serializable]
-#endif
     public class SpecFlowException : Exception
     {
         public SpecFlowException()
@@ -22,12 +20,10 @@ namespace TechTalk.SpecFlow
         {
         }
 
-#if !SILVERLIGHT
         protected SpecFlowException(
             SerializationInfo info,
             StreamingContext context) : base(info, context)
         {
         }
-#endif
     }
 }

--- a/TechTalk.SpecFlow/FeatureContext.cs
+++ b/TechTalk.SpecFlow/FeatureContext.cs
@@ -1,9 +1,6 @@
 using System;
 using System.Diagnostics;
 using System.Globalization;
-#if SILVERLIGHT
-using TechTalk.SpecFlow.Compatibility;
-#endif
 using System.Threading;
 using BoDi;
 using TechTalk.SpecFlow.Configuration;

--- a/TechTalk.SpecFlow/ScenarioContext.cs
+++ b/TechTalk.SpecFlow/ScenarioContext.cs
@@ -7,9 +7,6 @@ using BoDi;
 using TechTalk.SpecFlow.Bindings;
 using TechTalk.SpecFlow.Infrastructure;
 
-#if SILVERLIGHT
-using TechTalk.SpecFlow.Compatibility;
-#endif
 
 namespace TechTalk.SpecFlow
 {

--- a/TechTalk.SpecFlow/TestRunnerManager.cs
+++ b/TechTalk.SpecFlow/TestRunnerManager.cs
@@ -72,11 +72,9 @@ namespace TechTalk.SpecFlow
 
             testRunner.OnTestRunStart();
 
-#if !SILVERLIGHT
             EventHandler domainUnload = delegate { OnDomainUnload(); };
             AppDomain.CurrentDomain.DomainUnload += domainUnload;
             AppDomain.CurrentDomain.ProcessExit += domainUnload;
-#endif
         }
 
         protected virtual Assembly[] GetBindingAssemblies()


### PR DESCRIPTION
Silverlight is dead. Remove `#if SILVERLIGHT` from code.

<!--- Describe your changes in detail -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [] I've added tests for my code.
- [] My change requires a change to the documentation.
- [] I have updated the documentation accordingly.
- [] I have added an entry to the changelog
