### PR TITLE
Remove necessity of adding the "AfterUpdateFeatureFilesInProject" target when using the classic project format and MSBuild generation

### DIFF
--- a/SpecFlow.Tools.MsBuild.Generation/build/SpecFlow.Tools.MsBuild.Generation.targets
+++ b/SpecFlow.Tools.MsBuild.Generation/build/SpecFlow.Tools.MsBuild.Generation.targets
@@ -121,6 +121,10 @@
   </Target>
 
   <Target Name="AfterUpdateFeatureFilesInProject" DependsOnTargets="UpdateFeatureFilesInProject">
+    <!-- include any generated SpecFlow files in the compilation of the project if not included yet -->
+    <ItemGroup>
+      <Compile Include="@(SpecFlowGeneratedFiles)" Exclude="@(Compile)" />
+    </ItemGroup>
   </Target>
 
   <Target Name="CleanFeatureFilesInProject" Condition="'$(SpecFlow_DeleteCodeBehindFilesOnCleanRebuild)' == 'true'">

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,9 @@
-3.0 - 2018-03-28
+3.0 - 2019-04-24
+
+Changes:
++ Adding the "AfterUpdateFeatureFile" target manually in the classic project format is not required anymore.
+
+3.0 - 2019-03-28
 
 Breaking changes:
 + Registration of value retrievers and comparers changes from `RegisterValueComparer(___)` to `ValueComparers.Register(___)`


### PR DESCRIPTION
See Issue #1492 