### PR TITLE
Make XUnitTestGeneratorProvider consts & method protected & virtual

### DIFF
--- a/TechTalk.SpecFlow.Generator/UnitTestProvider/XUnit2TestGeneratorProvider.cs
+++ b/TechTalk.SpecFlow.Generator/UnitTestProvider/XUnit2TestGeneratorProvider.cs
@@ -11,16 +11,16 @@ namespace TechTalk.SpecFlow.Generator.UnitTestProvider
 {
     public class XUnit2TestGeneratorProvider : XUnitTestGeneratorProvider
     {
-        private new const string THEORY_ATTRIBUTE = "Xunit.TheoryAttribute";
-        private const string INLINEDATA_ATTRIBUTE = "Xunit.InlineDataAttribute";
-        private const string ICLASSFIXTURE_INTERFACE = "Xunit.IClassFixture";
-        private const string COLLECTION_ATTRIBUTE = "Xunit.CollectionAttribute";
-        private const string OUTPUT_INTERFACE = "Xunit.Abstractions.ITestOutputHelper";
-        private const string OUTPUT_INTERFACE_PARAMETER_NAME = "testOutputHelper";
-        private const string OUTPUT_INTERFACE_FIELD_NAME = "_testOutputHelper";
-        private const string FIXTUREDATA_PARAMETER_NAME = "fixtureData";
-        private const string COLLECTION_DEF = "Xunit.Collection";
-        private const string COLLECTION_TAG = "xunit:collection";
+        protected new const string THEORY_ATTRIBUTE = "Xunit.TheoryAttribute";
+        protected new const string INLINEDATA_ATTRIBUTE = "Xunit.InlineDataAttribute";
+        protected const string ICLASSFIXTURE_INTERFACE = "Xunit.IClassFixture";
+        protected const string COLLECTION_ATTRIBUTE = "Xunit.CollectionAttribute";
+        protected const string OUTPUT_INTERFACE = "Xunit.Abstractions.ITestOutputHelper";
+        protected const string OUTPUT_INTERFACE_PARAMETER_NAME = "testOutputHelper";
+        protected const string OUTPUT_INTERFACE_FIELD_NAME = "_testOutputHelper";
+        protected const string FIXTUREDATA_PARAMETER_NAME = "fixtureData";
+        protected const string COLLECTION_DEF = "Xunit.Collection";
+        protected const string COLLECTION_TAG = "xunit:collection";
 
         public XUnit2TestGeneratorProvider(CodeDomHelper codeDomHelper)
             :base(codeDomHelper)

--- a/TechTalk.SpecFlow.Generator/UnitTestProvider/XUnitTestGeneratorProvider.cs
+++ b/TechTalk.SpecFlow.Generator/UnitTestProvider/XUnitTestGeneratorProvider.cs
@@ -13,10 +13,10 @@ namespace TechTalk.SpecFlow.Generator.UnitTestProvider
         private const string DESCRIPTION_PROPERTY_NAME = "Description";
         protected const string FACT_ATTRIBUTE = "Xunit.FactAttribute";
         protected const string FACT_ATTRIBUTE_SKIP_PROPERTY_NAME = "Skip";
-        internal const string THEORY_ATTRIBUTE = "Xunit.Extensions.TheoryAttribute";
-        internal const string THEORY_ATTRIBUTE_SKIP_PROPERTY_NAME = "Skip";
+        protected internal const string THEORY_ATTRIBUTE = "Xunit.Extensions.TheoryAttribute";
+        protected internal const string THEORY_ATTRIBUTE_SKIP_PROPERTY_NAME = "Skip";
         private const string INLINEDATA_ATTRIBUTE = "Xunit.Extensions.InlineDataAttribute";
-        internal const string SKIP_REASON = "Ignored";
+        protected internal const string SKIP_REASON = "Ignored";
         private const string TRAIT_ATTRIBUTE = "Xunit.TraitAttribute";
         private const string IUSEFIXTURE_INTERFACE = "Xunit.IUseFixture";
         private const string CATEGORY_PROPERTY_NAME = "Category";
@@ -139,7 +139,7 @@ namespace TechTalk.SpecFlow.Generator.UnitTestProvider
             CodeDomHelper.AddAttribute(testMethod, INLINEDATA_ATTRIBUTE, args.ToArray());
         }
 
-        public void SetTestMethodCategories(TestClassGenerationContext generationContext, CodeMemberMethod testMethod, IEnumerable<string> scenarioCategories)
+        public virtual void SetTestMethodCategories(TestClassGenerationContext generationContext, CodeMemberMethod testMethod, IEnumerable<string> scenarioCategories)
         {
             foreach (string str in scenarioCategories)
                 SetProperty((CodeTypeMember)testMethod, "Category", str);

--- a/TechTalk.SpecFlow.Generator/UnitTestProvider/XUnitTestGeneratorProvider.cs
+++ b/TechTalk.SpecFlow.Generator/UnitTestProvider/XUnitTestGeneratorProvider.cs
@@ -10,17 +10,17 @@ namespace TechTalk.SpecFlow.Generator.UnitTestProvider
     public class XUnitTestGeneratorProvider : IUnitTestGeneratorProvider
     {
         protected const string FEATURE_TITLE_PROPERTY_NAME = "FeatureTitle";
-        private const string DESCRIPTION_PROPERTY_NAME = "Description";
+        protected const string DESCRIPTION_PROPERTY_NAME = "Description";
         protected const string FACT_ATTRIBUTE = "Xunit.FactAttribute";
         protected const string FACT_ATTRIBUTE_SKIP_PROPERTY_NAME = "Skip";
         protected internal const string THEORY_ATTRIBUTE = "Xunit.Extensions.TheoryAttribute";
         protected internal const string THEORY_ATTRIBUTE_SKIP_PROPERTY_NAME = "Skip";
-        private const string INLINEDATA_ATTRIBUTE = "Xunit.Extensions.InlineDataAttribute";
+        protected const string INLINEDATA_ATTRIBUTE = "Xunit.Extensions.InlineDataAttribute";
         protected internal const string SKIP_REASON = "Ignored";
-        private const string TRAIT_ATTRIBUTE = "Xunit.TraitAttribute";
-        private const string IUSEFIXTURE_INTERFACE = "Xunit.IUseFixture";
-        private const string CATEGORY_PROPERTY_NAME = "Category";
-        private const string IGNORE_TAG = "@Ignore";
+        protected const string TRAIT_ATTRIBUTE = "Xunit.TraitAttribute";
+        protected const string IUSEFIXTURE_INTERFACE = "Xunit.IUseFixture";
+        protected const string CATEGORY_PROPERTY_NAME = "Category";
+        protected const string IGNORE_TAG = "@Ignore";
 
         private CodeTypeDeclaration _currentFixtureDataTypeDeclaration = null;
 


### PR DESCRIPTION
<!--- Describe your changes in detail -->
Hi,
This PR updates the `XUnitTestGeneratorProvider` so that the `internal const`'s are now `protected internal`, so that anyone extending this class can make use of them. It also changes the `SetTestMethodCategories` method to be `virtual`, as I require this for a project I'm working on.  

I am currently working around this by having a copy of this file in my own project, but would rather these changes were upstream so I'm not duplicating your code :)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue).
- [X] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added an entry to the changelog

I don't know if any of the above are required, if so please let me know & I'll happily do them :)
