### PR TITLE
RuntimePlugin Locator looks into TestAssembly folder

### DIFF
--- a/TechTalk.SpecFlow/Infrastructure/ContainerBuilder.cs
+++ b/TechTalk.SpecFlow/Infrastructure/ContainerBuilder.cs
@@ -141,7 +141,7 @@ namespace TechTalk.SpecFlow.Infrastructure
             var pluginLocator = container.Resolve<IRuntimePluginLocator>();
             var pluginLoader = container.Resolve<IRuntimePluginLoader>();
             var traceListener = container.Resolve<ITraceListener>();
-            foreach (var pluginPath in pluginLocator.GetAllRuntimePlugins(Path.GetDirectoryName(testAssembly.Location)))
+            foreach (var pluginPath in pluginLocator.GetAllRuntimePlugins(Path.GetDirectoryName(testAssembly?.Location)))
             {
                 LoadPlugin(pluginPath, pluginLoader, runtimePluginEvents, unitTestProviderConfigration, traceListener);
             }

--- a/TechTalk.SpecFlow/Plugins/IRuntimePluginLocator.cs
+++ b/TechTalk.SpecFlow/Plugins/IRuntimePluginLocator.cs
@@ -8,5 +8,6 @@ namespace TechTalk.SpecFlow.Plugins
     public interface IRuntimePluginLocator
     {
         IReadOnlyList<string> GetAllRuntimePlugins();
+        IReadOnlyList<string> GetAllRuntimePlugins(string testAssemblyLocation);
     }
 }

--- a/TechTalk.SpecFlow/Plugins/RuntimePluginLocator.cs
+++ b/TechTalk.SpecFlow/Plugins/RuntimePluginLocator.cs
@@ -18,12 +18,20 @@ namespace TechTalk.SpecFlow.Plugins
 
         public IReadOnlyList<string> GetAllRuntimePlugins()
         {
+            return GetAllRuntimePlugins(null);
+        }
+
+        public IReadOnlyList<string> GetAllRuntimePlugins(string testAssemblyLocation)
+        {
             var allRuntimePlugins = new List<string>();
 
             allRuntimePlugins.AddRange(SearchPluginsInFolder(Environment.CurrentDirectory));
             allRuntimePlugins.AddRange(SearchPluginsInFolder(_pathToFolderWithSpecFlowAssembly));
 
-
+            if (testAssemblyLocation.IsNotNullOrWhiteSpace())
+            {
+                allRuntimePlugins.AddRange(SearchPluginsInFolder(testAssemblyLocation));
+            }
 
             return _runtimePluginLocationMerger.Merge(allRuntimePlugins.Distinct().ToList());
         }

--- a/TechTalk.SpecFlow/TestRunnerManager.cs
+++ b/TechTalk.SpecFlow/TestRunnerManager.cs
@@ -204,7 +204,7 @@ namespace TechTalk.SpecFlow
         {
             containerBuilder = containerBuilder ?? new ContainerBuilder();
 
-            var container = containerBuilder.CreateGlobalContainer();
+            var container = containerBuilder.CreateGlobalContainer(testAssembly);
             var testRunnerManager = container.Resolve<ITestRunnerManager>();
             testRunnerManager.Initialize(testAssembly);
             return testRunnerManager;

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/Infrastructure/PluginTests.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/Infrastructure/PluginTests.cs
@@ -309,6 +309,7 @@ namespace TechTalk.SpecFlow.RuntimeTests.Infrastructure
 
             var runtimePluginLocator = new Mock<IRuntimePluginLocator>();
             runtimePluginLocator.Setup(m => m.GetAllRuntimePlugins()).Returns(new List<string>() { "aPlugin" });
+            runtimePluginLocator.Setup(m => m.GetAllRuntimePlugins(It.IsAny<string>())).Returns(new List<string>() { "aPlugin" });
 
 
             var pluginLoaderStub = new Mock<IRuntimePluginLoader>();

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/Infrastructure/TestThreadContextTests.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/Infrastructure/TestThreadContextTests.cs
@@ -57,7 +57,7 @@ namespace TechTalk.SpecFlow.RuntimeTests.Infrastructure
             // this basically tests the special registration in DefaultDependencyProvider
 
             var containerBuilder = new ContainerBuilder();
-            var testThreadContainer = containerBuilder.CreateTestThreadContainer(containerBuilder.CreateGlobalContainer());
+            var testThreadContainer = containerBuilder.CreateTestThreadContainer(containerBuilder.CreateGlobalContainer(typeof(TestThreadContextTests).Assembly));
             var contextManager = CreateContextManager(testThreadContainer);
             contextManager.InitializeFeatureContext(new FeatureInfo(FeatureLanguage, "test feature", null));
             contextManager.InitializeScenarioContext(new ScenarioInfo("test scenario", "test_description"));

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/TestObjectFactories.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/TestObjectFactories.cs
@@ -41,7 +41,7 @@ namespace TechTalk.SpecFlow.RuntimeTests
 
         private static IObjectContainer CreateDefaultGlobalContainer(IRuntimeConfigurationProvider configurationProvider, Action<IObjectContainer> registerGlobalMocks, ContainerBuilder instance)
         {
-            var globalContainer = instance.CreateGlobalContainer(configurationProvider);
+            var globalContainer = instance.CreateGlobalContainer(typeof(TestObjectFactories).Assembly, configurationProvider);
             registerGlobalMocks?.Invoke(globalContainer);
             return globalContainer;
         }

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/TestRunnerManagerTest.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/TestRunnerManagerTest.cs
@@ -16,7 +16,7 @@ namespace TechTalk.SpecFlow.RuntimeTests
 
         public TestRunnerManagerTest()
         {
-            var globalContainer = new ContainerBuilder().CreateGlobalContainer();
+            var globalContainer = new ContainerBuilder().CreateGlobalContainer(typeof(TestRunnerManagerTest).Assembly);
             testRunnerManager = globalContainer.Resolve<TestRunnerManager>();
             testRunnerManager.Initialize(anAssembly);
         }


### PR DESCRIPTION
as on .NET Core the SpecFlow.dll is not in the output folder and current directory is set to the TestResults folder, we have to search for runtime plugins in the test assembly folder

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added an entry to the changelog
