### PR TITLE
Empty root namespace

### DIFF
--- a/SpecFlow.Tools.MsBuild.Generation/GenerateFeatureFileCodeBehindTask.cs
+++ b/SpecFlow.Tools.MsBuild.Generation/GenerateFeatureFileCodeBehindTask.cs
@@ -21,7 +21,6 @@ namespace SpecFlow.Tools.MsBuild.Generation
         [Required]
         public string ProjectPath { get; set; }
 
-        [Required]
         public string RootNamespace { get; set; }
 
         public string ProjectFolder => Path.GetDirectoryName(ProjectPath);

--- a/TechTalk.SpecFlow.Generator/TestGenerator.cs
+++ b/TechTalk.SpecFlow.Generator/TestGenerator.cs
@@ -137,16 +137,17 @@ namespace TechTalk.SpecFlow.Generator
             if (!string.IsNullOrEmpty(featureFileInput.CustomNamespace))
                 return featureFileInput.CustomNamespace;
 
-            if (projectSettings == null || string.IsNullOrEmpty(projectSettings.DefaultNamespace))
-                return null;
-
-            string targetNamespace = projectSettings.DefaultNamespace;
+            string targetNamespace = projectSettings == null || string.IsNullOrEmpty(projectSettings.DefaultNamespace)
+                ? null
+                : projectSettings.DefaultNamespace;
 
             var directoryName = Path.GetDirectoryName(featureFileInput.ProjectRelativePath);
             string namespaceExtension = string.IsNullOrEmpty(directoryName) ? null :
                 string.Join(".", directoryName.TrimStart('\\', '/', '.').Split('\\', '/').Select(f => f.ToIdentifier()).ToArray());
             if (!string.IsNullOrEmpty(namespaceExtension))
-                targetNamespace += "." + namespaceExtension;
+                targetNamespace = targetNamespace == null
+                    ? namespaceExtension
+                    : targetNamespace + "." + namespaceExtension;
             return targetNamespace;
         }
 

--- a/Tests/TechTalk.SpecFlow.GeneratorTests/MSBuildTask/GenerateFeatureFileCodeBehindTaskTests.cs
+++ b/Tests/TechTalk.SpecFlow.GeneratorTests/MSBuildTask/GenerateFeatureFileCodeBehindTaskTests.cs
@@ -35,7 +35,6 @@ namespace TechTalk.SpecFlow.GeneratorTests.MSBuildTask
 
             var generateFeatureFileCodeBehindTask = new GenerateFeatureFileCodeBehindTask
             {
-                RootNamespace = "RootNamespace",
                 ProjectPath = "ProjectPath",
                 BuildEngine = new MockBuildEngine(_output),
                 CodeBehindGenerator = generatorMock.Object

--- a/Tests/TechTalk.SpecFlow.GeneratorTests/MsBuildProjectReaderTests.cs
+++ b/Tests/TechTalk.SpecFlow.GeneratorTests/MsBuildProjectReaderTests.cs
@@ -36,6 +36,12 @@ namespace TechTalk.SpecFlow.GeneratorTests
         }
 
         [Fact]
+        public void Should_parse_CSProj_New_csproj_file_correctly_when_RootNamespace_empty()
+        {
+            Should_parse_csproj_file_correctly(PathHelper.SanitizeDirectorySeparatorChar(@"Data\CSProj_New\sampleCsProjectfile.csproj"), GenerationTargetLanguage.CSharp, "sampleCsProjectfile", null, "sampleCsProjectfile");
+        }
+
+        [Fact]
         public void Should_parse_CSProj_NewComplex_csproj_file_correctly()
         {
             Should_parse_csproj_file_correctly(PathHelper.SanitizeDirectorySeparatorChar(@"Data\CSProj_NewComplex\sampleCsProjectfile.csproj"), GenerationTargetLanguage.CSharp, "Hacapp.Web.Tests.UI", "Hacapp.Web.Tests.UI", "sampleCsProjectfile");

--- a/Tests/TechTalk.SpecFlow.GeneratorTests/TestGeneratorBasicsTests.cs
+++ b/Tests/TechTalk.SpecFlow.GeneratorTests/TestGeneratorBasicsTests.cs
@@ -13,11 +13,11 @@ namespace TechTalk.SpecFlow.GeneratorTests
     
     public class TestGeneratorBasicsTests : TestGeneratorTestsBase
     {
-        private string GenerateTestFromSimpleFeature(ProjectSettings projectSettings)
+        private string GenerateTestFromSimpleFeature(ProjectSettings projectSettings, string projectRelativeFolderPath = null)
         {
             var testGenerator = CreateTestGenerator(projectSettings);
 
-            var result = testGenerator.GenerateTestFile(CreateSimpleValidFeatureFileInput(), defaultSettings);
+            var result = testGenerator.GenerateTestFile(CreateSimpleValidFeatureFileInput(projectRelativeFolderPath), defaultSettings);
             result.Success.Should().Be(true);
             return result.GeneratedTestCode;
         }
@@ -56,6 +56,38 @@ namespace TechTalk.SpecFlow.GeneratorTests
         {
             string outputFile = GenerateTestFromSimpleFeature(net35CSProjectSettings);
             outputFile.Should().Contain(string.Format("SpecFlow Generator Version:{0}", TestGeneratorFactory.GeneratorVersion));
+        }
+
+        [Fact]
+        public void Should_include_namespace_declaration_using_default_namespace_when_file_in_project_root()
+        {
+            net35CSProjectSettings.DefaultNamespace = "Default.TestNamespace";
+            string outputFile = GenerateTestFromSimpleFeature(net35CSProjectSettings);
+            outputFile.Should().Contain(string.Format("namespace {0}", net35CSProjectSettings.DefaultNamespace));
+        }
+
+        [Fact]
+        public void Should_include_namespace_declaration_using_default_namespace_and_folder_path_when_file_in_subfolder()
+        {
+            net35CSProjectSettings.DefaultNamespace = "Default.TestNamespace";
+            string outputFile = GenerateTestFromSimpleFeature(net35CSProjectSettings, @"Folder1\Folder2");
+            outputFile.Should().Contain(string.Format("namespace {0}.Folder1.Folder2", net35CSProjectSettings.DefaultNamespace));
+        }
+
+        [Fact]
+        public void Should_include_namespace_declaration_using_fallback_namespace_when_default_namespace_not_set_and_file_in_project_root()
+        {
+            net35CSProjectSettings.DefaultNamespace = null;
+            string outputFile = GenerateTestFromSimpleFeature(net35CSProjectSettings);
+            outputFile.Should().Contain("namespace SpecFlow.GeneratedTests");
+        }
+
+        [Fact]
+        public void Should_include_namespace_declaration_using_folder_path_when_default_namespace_not_set_and_file_in_subfolder()
+        {
+            net35CSProjectSettings.DefaultNamespace = null;
+            string outputFile = GenerateTestFromSimpleFeature(net35CSProjectSettings, @"Folder1\Folder2");
+            outputFile.Should().Contain(string.Format("namespace Folder1.Folder2", net35CSProjectSettings.DefaultNamespace));
         }
 
         [Fact]

--- a/Tests/TechTalk.SpecFlow.GeneratorTests/TestGeneratorTestsBase.cs
+++ b/Tests/TechTalk.SpecFlow.GeneratorTests/TestGeneratorTestsBase.cs
@@ -49,7 +49,7 @@ namespace TechTalk.SpecFlow.GeneratorTests
             TestUpToDateCheckerStub = new Mock<ITestUpToDateChecker>();
         }
 
-        protected FeatureFileInput CreateSimpleValidFeatureFileInput()
+        protected FeatureFileInput CreateSimpleValidFeatureFileInput(string projectRelativeFolderPath = null)
         {
             return CreateSimpleFeatureFileInput(@"
 Feature: Addition
@@ -60,12 +60,17 @@ Scenario: Add two numbers
 	And I have entered 70 into the calculator
 	When I press add
 	Then the result should be 120 on the screen
-");
+",
+projectRelativeFolderPath);
         }
 
-        protected FeatureFileInput CreateSimpleFeatureFileInput(string featureFileContent)
+        protected FeatureFileInput CreateSimpleFeatureFileInput(string featureFileContent, string projectRelativeFolderPath = null)
         {
-            return new FeatureFileInput(@"Dummy.feature") {FeatureFileContent = featureFileContent};
+            const string FeatureFileName = @"Dummy.feature";
+            string projectRelativeFilePath = projectRelativeFolderPath == null
+                ? FeatureFileName
+                : Path.Combine(projectRelativeFolderPath, FeatureFileName);
+            return new FeatureFileInput(projectRelativeFilePath) {FeatureFileContent = featureFileContent};
         }
 
         protected FeatureFileInput CreateSimpleInvalidFeatureFileInput()

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,8 @@
+3.0
+
+Fixes:
+ + Empty root namespaces now work when generating feature codebehind files with the MSBuild task
+
 3.0 - 2019-04-24
 
 Changes:


### PR DESCRIPTION
 * Remove [Required] from build task RootNamespace
 * Take folder paths into account when root namespace absent
 * Add tests for previously supported and new scenarois

This fixes https://github.com/techtalk/SpecFlow/issues/1605

It also makes the behaviour in empty-root-namespace scenarios more consistent with when the root namespace is specified. Back when empty root namespaces worked (which they did if you used the custom tool to generate codebehind) the folder path to the class wasn't taken into account like it is in non-empty cases. You just ended up with the same default namespace for everything. With this change, files in subfolders go in namespaces based on that file structure, exactly like they do when the root namespace is non-empty, and exactly as happens when you ask VS to add a new file to a subfolder (whether or not the root namespace is empty).

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

- [x] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added an entry to the changelog
