### PR TITLE
Fix1544

### DIFF
--- a/TechTalk.SpecFlow/Configuration/ConfigurationLoader.cs
+++ b/TechTalk.SpecFlow/Configuration/ConfigurationLoader.cs
@@ -183,9 +183,7 @@ namespace TechTalk.SpecFlow.Configuration
 
         private string GetSpecflowJsonFilePath()
         {
-            //var directory = Path.GetDirectoryName(typeof(ConfigurationLoader).Assembly.Location);
-            //var directory = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
-            var specflowJsonFile = Path.Combine(Environment.CurrentDirectory, "specflow.json"); //todo: check if this works in real project
+            var specflowJsonFile = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "specflow.json");
             return specflowJsonFile;
         }
     }

--- a/Tests/TechTalk.SpecFlow.Specs/StepDefinitions/ConfigurationSteps.cs
+++ b/Tests/TechTalk.SpecFlow.Specs/StepDefinitions/ConfigurationSteps.cs
@@ -12,31 +12,27 @@ namespace TechTalk.SpecFlow.Specs.StepDefinitions
         private readonly VSTestExecutionDriver _vstestExecutionDriver;
         private readonly ConfigurationDriver _configurationDriver;
         private readonly TestRunConfiguration _testRunConfiguration;
+        private readonly SolutionDriver _solutionDriver;
 
-        public ConfigurationSteps(VSTestExecutionDriver vstestExecutionDriver, ConfigurationDriver configurationDriver, TestRunConfiguration testRunConfiguration)
+        public ConfigurationSteps(VSTestExecutionDriver vstestExecutionDriver, ConfigurationDriver configurationDriver, TestRunConfiguration testRunConfiguration, SolutionDriver solutionDriver)
         {
             _vstestExecutionDriver = vstestExecutionDriver;
             _configurationDriver = configurationDriver;
             _testRunConfiguration = testRunConfiguration;
+            _solutionDriver = solutionDriver;
         }
+
 
         [Then(@"the app\.config is used for configuration")]
         public void ThenTheApp_ConfigIsUsedForConfiguration()
         {
-            if (_testRunConfiguration.UnitTestProvider == TestProjectGenerator.UnitTestProvider.MSTest)
-            {
-                _vstestExecutionDriver.LastTestExecutionResult.TestResults.Where(tr => tr.StdOut.Contains("Using app.config")).Should().NotBeEmpty();
-            }
-            else
-            {
-                _vstestExecutionDriver.LastTestExecutionResult.Output.Should().Contain("Using app.config");
-            }
+            _solutionDriver._compileResult.Output.Should().Contain("Using app.config");
         }
 
         [Then(@"the specflow\.json is used for configuration")]
         public void ThenTheSpecflow_JsonIsUsedForConfiguration()
         {
-            _vstestExecutionDriver.LastTestExecutionResult.Output.Should().Contain("Using specflow.json");
+            _solutionDriver._compileResult.Output.Should().Contain("Using specflow.json");
         }
 
         [Given(@"the feature language is '(.*)'")]


### PR DESCRIPTION
The GetSpecflowJsonFilePath method was looking for the specflow.json file in Environment.CurrentDirectory which may not be set to the same paths for all test frameworks. This was changed to AppDomain.CurrentDomain.BaseDirectory (the same directory as the project file).

I have also changed the assertions for the configuration tests to look for strings such as "Using specflow.json" in the compile results output instead of the test results output.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added an entry to the changelog
