### PR TITLE
Fix1544 - Change search path for specflow.json and update configuration tests

### DIFF
--- a/TechTalk.SpecFlow/Configuration/ConfigurationLoader.cs
+++ b/TechTalk.SpecFlow/Configuration/ConfigurationLoader.cs
@@ -183,9 +183,7 @@ namespace TechTalk.SpecFlow.Configuration
 
         private string GetSpecflowJsonFilePath()
         {
-            //var directory = Path.GetDirectoryName(typeof(ConfigurationLoader).Assembly.Location);
-            //var directory = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
-            var specflowJsonFile = Path.Combine(Environment.CurrentDirectory, "specflow.json"); //todo: check if this works in real project
+            var specflowJsonFile = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "specflow.json");
             return specflowJsonFile;
         }
     }

--- a/Tests/TechTalk.SpecFlow.Specs/Features/Execution/Configuration.feature
+++ b/Tests/TechTalk.SpecFlow.Specs/Features/Execution/Configuration.feature
@@ -1,6 +1,4 @@
-﻿@ignore
-@xUnit @MSTest
-Feature: Configuration
+﻿Feature: Configuration
 	
 Background: 
 	Given there is a feature file in the project as
@@ -19,7 +17,6 @@ Scenario: Generation configuration in app.config
 	When I execute the tests
 	Then the app.config is used for configuration
 
-@ignore
 Scenario: Generation configuration in specflow.json
 	Given SpecFlow is configured in the specflow.json
 	When I execute the tests
@@ -30,7 +27,6 @@ Scenario: Runtime configuration in app.config
 	When I execute the tests
 	Then the app.config is used for configuration
 
-@ignore
 Scenario: Runtime configuration in specflow.json
 	Given SpecFlow is configured in the specflow.json
 	When I execute the tests

--- a/Tests/TechTalk.SpecFlow.Specs/StepDefinitions/ConfigurationSteps.cs
+++ b/Tests/TechTalk.SpecFlow.Specs/StepDefinitions/ConfigurationSteps.cs
@@ -12,31 +12,27 @@ namespace TechTalk.SpecFlow.Specs.StepDefinitions
         private readonly VSTestExecutionDriver _vstestExecutionDriver;
         private readonly ConfigurationDriver _configurationDriver;
         private readonly TestRunConfiguration _testRunConfiguration;
+        private readonly SolutionDriver _solutionDriver;
 
-        public ConfigurationSteps(VSTestExecutionDriver vstestExecutionDriver, ConfigurationDriver configurationDriver, TestRunConfiguration testRunConfiguration)
+        public ConfigurationSteps(VSTestExecutionDriver vstestExecutionDriver, ConfigurationDriver configurationDriver, TestRunConfiguration testRunConfiguration, SolutionDriver solutionDriver)
         {
             _vstestExecutionDriver = vstestExecutionDriver;
             _configurationDriver = configurationDriver;
             _testRunConfiguration = testRunConfiguration;
+            _solutionDriver = solutionDriver;
         }
+
 
         [Then(@"the app\.config is used for configuration")]
         public void ThenTheApp_ConfigIsUsedForConfiguration()
         {
-            if (_testRunConfiguration.UnitTestProvider == TestProjectGenerator.UnitTestProvider.MSTest)
-            {
-                _vstestExecutionDriver.LastTestExecutionResult.TestResults.Where(tr => tr.StdOut.Contains("Using app.config")).Should().NotBeEmpty();
-            }
-            else
-            {
-                _vstestExecutionDriver.LastTestExecutionResult.Output.Should().Contain("Using app.config");
-            }
+            _solutionDriver._compileResult.Output.Should().Contain("Using app.config");
         }
 
         [Then(@"the specflow\.json is used for configuration")]
         public void ThenTheSpecflow_JsonIsUsedForConfiguration()
         {
-            _vstestExecutionDriver.LastTestExecutionResult.Output.Should().Contain("Using specflow.json");
+            _solutionDriver._compileResult.Output.Should().Contain("Using specflow.json");
         }
 
         [Given(@"the feature language is '(.*)'")]

--- a/Tests/TechTalk.SpecFlow.Specs/StepDefinitions/ConfigurationSteps.cs
+++ b/Tests/TechTalk.SpecFlow.Specs/StepDefinitions/ConfigurationSteps.cs
@@ -26,13 +26,13 @@ namespace TechTalk.SpecFlow.Specs.StepDefinitions
         [Then(@"the app\.config is used for configuration")]
         public void ThenTheApp_ConfigIsUsedForConfiguration()
         {
-            _solutionDriver._compileResult.Output.Should().Contain("Using app.config");
+            _solutionDriver.CheckCompileOutputForString("Using app.config");
         }
 
         [Then(@"the specflow\.json is used for configuration")]
         public void ThenTheSpecflow_JsonIsUsedForConfiguration()
         {
-            _solutionDriver._compileResult.Output.Should().Contain("Using specflow.json");
+            _solutionDriver.CheckCompileOutputForString("Using specflow.json");
         }
 
         [Given(@"the feature language is '(.*)'")]

--- a/Tests/TechTalk.SpecFlow.Specs/StepDefinitions/ConfigurationSteps.cs
+++ b/Tests/TechTalk.SpecFlow.Specs/StepDefinitions/ConfigurationSteps.cs
@@ -26,13 +26,13 @@ namespace TechTalk.SpecFlow.Specs.StepDefinitions
         [Then(@"the app\.config is used for configuration")]
         public void ThenTheApp_ConfigIsUsedForConfiguration()
         {
-            _solutionDriver.CheckCompileOutputForString("Using app.config");
+            _solutionDriver.CheckCompileOutputForString("Using app.config").Should().BeTrue();
         }
 
         [Then(@"the specflow\.json is used for configuration")]
         public void ThenTheSpecflow_JsonIsUsedForConfiguration()
         {
-            _solutionDriver.CheckCompileOutputForString("Using specflow.json");
+            _solutionDriver.CheckCompileOutputForString("Using specflow.json").Should().BeTrue();
         }
 
         [Given(@"the feature language is '(.*)'")]

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,9 @@
+3.0 - 2019-06-27
+
+Fixes:
++ Changed search path for specflow.json config file from Environment.CurrentDirectory to AppDomain.CurrentDomain.BaseDirectory (project directory)
++ Changed tests regarding configuration to look for expected strings such as "Using specflow.json" in the solution output rather then the test results output
+
 3.0
 
 Fixes:


### PR DESCRIPTION
The GetSpecflowJsonFilePath method was looking for the specflow.json file in Environment.CurrentDirectory which may not be set to the same paths for all test frameworks. This was changed to AppDomain.CurrentDomain.BaseDirectory (the same directory as the project file).

I have also changed the assertions for the configuration tests to look for strings such as "Using specflow.json" in the compile results output instead of the test results output.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added an entry to the changelog
