### PR TITLE
Correct props file path case

### DIFF
--- a/SpecFlow.Tools.MsBuild.Generation/build/SpecFlow.Tools.MsBuild.Generation.props
+++ b/SpecFlow.Tools.MsBuild.Generation/build/SpecFlow.Tools.MsBuild.Generation.props
@@ -1,7 +1,7 @@
 ﻿<Project TreatAsLocalProperty="TaskFolder;TaskAssembly">
 
   <PropertyGroup>
-    <SpecFlow_CpsExtensionDesignTimeTargetsPath Condition="'$(SpecFlow_CpsExtensionDesignTimeTargetsPath)' == ''">$(MSBuildThisFileDirectory)CPS\BuildSystem\CpsExtension.DesignTime.targets</SpecFlow_CpsExtensionDesignTimeTargetsPath>
+    <SpecFlow_CpsExtensionDesignTimeTargetsPath Condition="'$(SpecFlow_CpsExtensionDesignTimeTargetsPath)' == ''">$(MSBuildThisFileDirectory)CPS\Buildsystem\CpsExtension.DesignTime.targets</SpecFlow_CpsExtensionDesignTimeTargetsPath>
   </PropertyGroup>
 
   <Import Project="$(SpecFlow_CpsExtensionDesignTimeTargetsPath)" Condition="'$(DesignTimeBuild)' == 'true' " />


### PR DESCRIPTION
SpecFlow.Tools.MsBuild.Generation.props used a different casing to reference the Buildsystem folder than is present in the package. This seems like the smallest change to correct an out of the box failure utilising the MsBuild generation on linux. Is nobody using SpecFlow on linux or macOS at the moment? Anyway this fix isn't a code change and the casing of a path should have no effect on Windows users.

<!--- Describe your changes in detail -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added an entry to the changelog
