### PR TITLE
Added support for TypeConverter attributes.

### DIFF
--- a/Tests/TechTalk.SpecFlow.RuntimeTests/StepArgumentTypeConverterTest.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/StepArgumentTypeConverterTest.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
+using System.Diagnostics;
 using System.Globalization;
 using FluentAssertions;
 using Moq;
@@ -108,5 +110,35 @@ namespace TechTalk.SpecFlow.RuntimeTests
             var result = _stepArgumentTypeConverter.Convert("1", typeof (Guid), _enUSCulture);
             result.Should().Be(new Guid("10000000-0000-0000-0000-000000000000"));
         }
+        
+        [Fact]
+        public void ShouldUseATypeConverterWhenAvailable()
+        {
+            var originalValue = new DateTimeOffset(2019, 7, 29, 0, 0, 0, TimeSpan.Zero);
+            var result = _stepArgumentTypeConverter.Convert(originalValue, typeof (TestClass), _enUSCulture);
+            result.Should().BeOfType(typeof(TestClass));
+            result.As<TestClass>().Time.Should().Be(originalValue);
+        }
+
+        [TypeConverter(typeof(TessClassTypeConverter))]
+        class TestClass
+        {
+            public DateTimeOffset Time { get; set; }
+            
+            class TessClassTypeConverter : TypeConverter
+            {
+                public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
+                {
+                    return sourceType == typeof(DateTimeOffset);
+                }
+
+                public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
+                {
+                    return new TestClass { Time = (DateTimeOffset) value };
+                }
+            }
+        }
+
+   
     }
 }

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,11 @@
+3.0 - 2019-07-29
+
+Changes:
++ Added support for TypeConverter attributes.
+
+Changes:
++ Adding the "AfterUpdateFeatureFile" target manually in the classic project format is not required anymore.
+
 3.0 - 2019-06-27
 
 Fixes:


### PR DESCRIPTION
I added support for TypeConverter attributes in an effort to support my scenario. I have type called VariableDouble that supports a type conversion from string via TypeConverterAttribute. It's different from a regular double in the sense that it supports notation for tolerance, such as "1.5 +/- 0.2", therefore it needs custom conversion from string. It can be used as follows:

```
// Class definition
[TypeConverter(typeof(VariableDoubleConverter))]
public class VariableDouble { }

// Usage
[Then(@"the value should be (.+)")]
public void TheValueShouldBe(VariableDouble expectedValue);
```

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue).
- [X] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added an entry to the changelog
