### PR TITLE
Gherkin v6 Rule keyword support

### DIFF
--- a/TechTalk.SpecFlow.Parser/SpecFlowFeature.cs
+++ b/TechTalk.SpecFlow.Parser/SpecFlowFeature.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using Gherkin.Ast;
 
@@ -13,7 +14,12 @@ namespace TechTalk.SpecFlow.Parser
 
             if (Children != null)
             {
-                ScenarioDefinitions = Children.Where(child => child is StepsContainer).Cast<StepsContainer>().Where(child => !(child is Background)).ToList();
+                Func<IEnumerable<IHasLocation>, IEnumerable<StepsContainer>> getScenarioDefinitions =
+                    items => items.OfType<StepsContainer>().Where(child => !(child is Background));
+                ScenarioDefinitions = 
+                    getScenarioDefinitions(Children)
+                        .Concat(Children.OfType<Rule>().SelectMany(rule => getScenarioDefinitions(rule.Children)))
+                        .ToList();
 
                 var background = Children.SingleOrDefault(child => child is Background);
 

--- a/Tests/TechTalk.SpecFlow.Specs/Features/Parser/RuleSupport.feature
+++ b/Tests/TechTalk.SpecFlow.Specs/Features/Parser/RuleSupport.feature
@@ -1,0 +1,34 @@
+﻿@wipgn
+Feature: Rule Support
+
+The (optional) Rule keyword has been added in Gherkin v6.  
+A Rule block is used to group together several scenarios that belong to this 
+business rule. The scenarios before the first Rule keyword so not belong to any rule.
+See more: https://cucumber.io/docs/gherkin/reference/#rule
+
+Scenario: Should be able to execute a simple passing scenario
+    Given there is a feature file in the project as
+        """
+            Feature: Simple Feature
+            Scenario: Scenario without a rule
+                When I do something
+
+			Rule: First rule
+            Scenario: Scenario for the first rule
+                When I do something
+
+			Rule: Second rule
+            Scenario: Scenario for the second rule
+                When I do something
+            Scenario Outline: Scenario Outline for the second rule
+                When I do <what>
+			Examples:
+				| what           |
+				| something      |
+				| something else |
+        """
+    Given all steps are bound and pass
+    When I execute the tests
+    Then the execution summary should contain
+        | Total | 
+        | 5     | 

--- a/Tests/TechTalk.SpecFlow.Specs/Features/Parser/RuleSupport.feature
+++ b/Tests/TechTalk.SpecFlow.Specs/Features/Parser/RuleSupport.feature
@@ -1,4 +1,4 @@
-﻿@wipgn
+﻿@gherkin6
 Feature: Rule Support
 
 The (optional) Rule keyword has been added in Gherkin v6.  

--- a/changelog.txt
+++ b/changelog.txt
@@ -11,6 +11,7 @@ Features:
 
 + cucumber-messages can be enabled via specflow.json and app.config
 + file sinks for cucumber-messages can be configured
++ support for Gherkin v6 "Rule" keyword
 
 Fixes: 
 + AfterTestRun hook can take longer than 100ms on .NET Core https://github.com/techtalk/SpecFlow/issues/1348


### PR DESCRIPTION
Gherkin v6 introduced a new "Rule" keyword that can be used to group scenarios. This PR adds a basic support for this syntax element: SpecFlow will execute the scenarios also within Rule blocks in feature files (these scenarios were ignored in SpecFlow v3.0).

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

- [x] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added an entry to the changelog
