### PR TITLE
Gherkin6 Scenario with Examples should be treated as a Scenario Outline

### DIFF
--- a/TechTalk.SpecFlow.Parser/SpecFlowGherkinParser.cs
+++ b/TechTalk.SpecFlow.Parser/SpecFlowGherkinParser.cs
@@ -68,10 +68,8 @@ namespace TechTalk.SpecFlow.Parser
             protected override Scenario CreateScenario(Tag[] tags, Location location, string keyword, string name, string description, Step[] steps, Examples[] examples, AstNode node)
             {
                 ResetBlock();
-                var token = node.GetItems<AstNode>(RuleType.Scenario).Single().GetItems<Token>(RuleType._ScenarioLine).Single();
-                
 
-                if (token.MatchedGherkinDialect.ScenarioOutlineKeywords.Contains(keyword))
+                if (examples != null && examples.Length > 0)
                 {
                     return new ScenarioOutline(tags, location, keyword, name, description, steps, examples);
                 }
@@ -98,12 +96,6 @@ namespace TechTalk.SpecFlow.Parser
             {
                 return new SpecFlowDocument((SpecFlowFeature)feature, gherkinDocumentComments, sourceFilePath);
             }
-
-            //protected override ScenarioOutline CreateScenarioOutline(Tag[] tags, Location location, string keyword, string name, string description, Step[] steps, Examples[] examples, AstNode node)
-            //{
-            //    ResetBlock();
-            //    return base.CreateScenarioOutline(tags, location, keyword, name, description, steps, examples, node);
-            //}
 
             protected override Background CreateBackground(Location location, string keyword, string name, string description, Step[] steps, AstNode node)
             {

--- a/Tests/TechTalk.SpecFlow.GeneratorTests/ScenarioOutlineParserTests.cs
+++ b/Tests/TechTalk.SpecFlow.GeneratorTests/ScenarioOutlineParserTests.cs
@@ -13,8 +13,9 @@ namespace TechTalk.SpecFlow.GeneratorTests
     public class ScenarioOutlineParserTests
     {
         [Fact]
-        public void Parser_throws_meaningful_exception_when_Examples_are_missing_in_Scenario_Outline()
+        public void Parser_doesnt_throw_exception_when_Examples_are_missing_in_Scenario_Outline()
         {
+            // this is accepted by Gherkin v6 and treated as Scenario
             var feature = @"Feature: Missing
                             Scenario Outline: No Examples";
 
@@ -22,8 +23,7 @@ namespace TechTalk.SpecFlow.GeneratorTests
 
             Action act = () => parser.Parse(new StringReader(feature), null);
 
-            act.Should().Throw<SemanticParserException>().WithMessage("(2:29): Scenario Outline 'No Examples' has no examples defined")
-                .And.Location.Line.Should().Be(2);
+            act.Should().NotThrow();
         }
 
         [Fact]
@@ -63,8 +63,9 @@ namespace TechTalk.SpecFlow.GeneratorTests
         }
 
         [Fact]
-        public void Parser_throws_meaningful_exception_when_Examples_are_missing_in_multiple_Scenario_Outlines()
+        public void Parser_doesnt_throw_exception_when_Examples_are_missing_in_multiple_Scenario_Outlines()
         {
+            // these are accepted by Gherkin v6 and treated as Scenarios
             var feature = @"Feature: Missing
                             Scenario Outline: No Examples
                             Scenario Outline: Still no Examples";
@@ -73,10 +74,7 @@ namespace TechTalk.SpecFlow.GeneratorTests
 
             Action act = () => parser.Parse(new StringReader(feature), null);
 
-            var expectedErrors = new List<SemanticParserException> { new SemanticParserException("Scenario Outline 'No Examples' has no examples defined", new Location(2, 29)),
-                new SemanticParserException("Scenario Outline 'Still no Examples' has no examples defined", new Location(3, 29))};
-
-            act.Should().Throw<CompositeParserException>().And.Errors.Should().BeEquivalentTo(expectedErrors);
+            act.Should().NotThrow();
         }
 
         [Fact]

--- a/Tests/TechTalk.SpecFlow.Specs/Features/Execution/ScenarioOutlines.feature
+++ b/Tests/TechTalk.SpecFlow.Specs/Features/Execution/ScenarioOutlines.feature
@@ -3,7 +3,7 @@
 Scenario Outline: Should handle scenario outlines
 	Given there is a SpecFlow project
 	And row testing is <row test>
-	Given there is a feature file in the project as
+	And there is a feature file in the project as
 		"""
 			Feature: Simple Feature
 			Scenario Outline: Simple Scenario Outline
@@ -25,3 +25,26 @@ Examples:
 	| case           | row test |
 	| Normal testing | disabled |
 	| Row testing    | enabled  |
+
+@gherkin6
+Scenario: Should support defining scenario outlines with the Scenario keyword
+	A scenario with an "Examples" block should be treated as a Scenario Outline according to Gherkin v6
+	See https://github.com/cucumber/cucumber/blob/master/gherkin/CHANGELOG.md#6013---2018-09-25
+	Given there is a SpecFlow project
+	And there is a feature file in the project as
+		"""
+			Feature: Simple Feature
+			Scenario: Simple Scenario Outline
+				Given there is something
+				When I do <what>
+				Then something should happen
+			Examples: 
+				| what           |
+				| something      |
+				| something else |
+		"""
+	And all steps are bound and pass
+	When I execute the tests
+	Then the execution summary should contain
+		| Succeeded |
+		| 2         |

--- a/changelog.txt
+++ b/changelog.txt
@@ -17,6 +17,7 @@ Fixes:
 + Adjust parameter names generation in scenario outlines https://github.com/techtalk/SpecFlow/issues/1694
 + specflow.json can be used in SpecFlow+Runner with Process test thread isolation https://github.com/techtalk/SpecFlow/issues/1761
 + specflow.json is copied to output directory automatically https://github.com/techtalk/SpecFlow/issues/1315
++ A scenario with an "Examples" block should be treated as a Scenario Outline according to Gherkin v6
 
 
 Changes:


### PR DESCRIPTION
A scenario with an "Examples" block should be treated as a Scenario Outline according to Gherkin v6 according to https://github.com/cucumber/cucumber/blob/master/gherkin/CHANGELOG.md#6013---2018-09-25. This PR fixes this.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

- [x] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added an entry to the changelog
