### PR TITLE
Support discovering step definitions from attributes that are derived from Given,When,Then or StepDefinition attributes (related to #1745)

### DIFF
--- a/TechTalk.SpecFlow/Bindings/Discovery/BindingSourceProcessor.cs
+++ b/TechTalk.SpecFlow/Bindings/Discovery/BindingSourceProcessor.cs
@@ -75,10 +75,10 @@ namespace TechTalk.SpecFlow.Bindings.Discovery
         private bool IsStepDefinitionAttribute(BindingSourceAttribute attribute)
         {
             return
-                attribute.AttributeType.TypeEquals(typeof(GivenAttribute)) ||
-                attribute.AttributeType.TypeEquals(typeof(WhenAttribute)) ||
-                attribute.AttributeType.TypeEquals(typeof(ThenAttribute)) ||
-                attribute.AttributeType.TypeEquals(typeof(StepDefinitionAttribute));
+                typeof(GivenAttribute).IsAssignableFrom(attribute.AttributeType) ||
+                typeof(WhenAttribute).IsAssignableFrom(attribute.AttributeType) ||
+                typeof(ThenAttribute).IsAssignableFrom(attribute.AttributeType) ||
+                typeof(StepDefinitionAttribute).IsAssignableFrom(attribute.AttributeType);
         }
 
         private bool IsHookAttribute(BindingSourceAttribute attribute)
@@ -301,13 +301,13 @@ namespace TechTalk.SpecFlow.Bindings.Discovery
 
         private IEnumerable<StepDefinitionType> GetStepDefinitionTypes(BindingSourceAttribute stepDefinitionAttribute)
         {
-            if (stepDefinitionAttribute.AttributeType.TypeEquals(typeof(GivenAttribute)))
+            if (typeof(GivenAttribute).IsAssignableFrom(stepDefinitionAttribute.AttributeType))
                 return new[] { StepDefinitionType.Given };
-            if (stepDefinitionAttribute.AttributeType.TypeEquals(typeof(WhenAttribute)))
+            if (typeof(WhenAttribute).IsAssignableFrom(stepDefinitionAttribute.AttributeType))
                 return new[] { StepDefinitionType.When };
-            if (stepDefinitionAttribute.AttributeType.TypeEquals(typeof(ThenAttribute)))
+            if (typeof(ThenAttribute).IsAssignableFrom(stepDefinitionAttribute.AttributeType))
                 return new[] { StepDefinitionType.Then };
-            if (stepDefinitionAttribute.AttributeType.TypeEquals(typeof(StepDefinitionAttribute)))
+            if (typeof(StepDefinitionAttribute).IsAssignableFrom(stepDefinitionAttribute.AttributeType))
                 return new[] { StepDefinitionType.Given, StepDefinitionType.When, StepDefinitionType.Then };
 
             return new StepDefinitionType[0];

--- a/TechTalk.SpecFlow/Bindings/Reflection/BindingReflectionExtensions.cs
+++ b/TechTalk.SpecFlow/Bindings/Reflection/BindingReflectionExtensions.cs
@@ -12,7 +12,7 @@ namespace TechTalk.SpecFlow.Bindings.Reflection
             return string.Format("{2}.{0}({1})", bindingMethod.Name, string.Join(", ", bindingMethod.Parameters.Select(p => p.Type.Name).ToArray()), bindingMethod.Type.Name);
         }
 
-        public static bool IsAssignableToFixed(this Type type, IBindingType baseType)
+        public static bool IsAssignableTo(this Type type, IBindingType baseType)
         {
             if (baseType is RuntimeBindingType runtimeBindingType)
                 return runtimeBindingType.Type.IsAssignableFrom(type);
@@ -20,10 +20,10 @@ namespace TechTalk.SpecFlow.Bindings.Reflection
             if (type.FullName == baseType.FullName)
                 return true;
 
-            if (type.BaseType != null && IsAssignableToFixed(type.BaseType, baseType))
+            if (type.BaseType != null && IsAssignableTo(type.BaseType, baseType))
                 return true;
 
-            return type.GetInterfaces().Any(_if => IsAssignableToFixed(_if, baseType));
+            return type.GetInterfaces().Any(_if => IsAssignableTo(_if, baseType));
         }
 
         public static bool IsAssignableFrom(this Type baseType, IBindingType type)

--- a/TechTalk.SpecFlow/Bindings/Reflection/BindingReflectionExtensions.cs
+++ b/TechTalk.SpecFlow/Bindings/Reflection/BindingReflectionExtensions.cs
@@ -12,20 +12,6 @@ namespace TechTalk.SpecFlow.Bindings.Reflection
             return string.Format("{2}.{0}({1})", bindingMethod.Name, string.Join(", ", bindingMethod.Parameters.Select(p => p.Type.Name).ToArray()), bindingMethod.Type.Name);
         }
 
-        public static bool IsAssignableTo(this IBindingType baseType, Type type)
-        {
-            if (baseType is RuntimeBindingType)
-                return type.IsAssignableFrom(((RuntimeBindingType)baseType).Type); //TODO: this is wrong! IsAssignableFrom have to be used in baseType.IsAssignableFrom(derivedType) form!
-
-            if (type.FullName == baseType.FullName)
-                return true;
-
-            if (type.BaseType != null && IsAssignableTo(baseType, type.BaseType))
-                return true;
-
-            return type.GetInterfaces().Any(_if => IsAssignableTo(baseType, _if));
-        }
-
         public static bool IsAssignableToFixed(this Type type, IBindingType baseType)
         {
             if (baseType is RuntimeBindingType runtimeBindingType)

--- a/TechTalk.SpecFlow/Bindings/Reflection/BindingReflectionExtensions.cs
+++ b/TechTalk.SpecFlow/Bindings/Reflection/BindingReflectionExtensions.cs
@@ -15,7 +15,7 @@ namespace TechTalk.SpecFlow.Bindings.Reflection
         public static bool IsAssignableTo(this IBindingType baseType, Type type)
         {
             if (baseType is RuntimeBindingType)
-                return type.IsAssignableFrom(((RuntimeBindingType)baseType).Type);
+                return type.IsAssignableFrom(((RuntimeBindingType)baseType).Type); //TODO: this is wrong! IsAssignableFrom have to be used in baseType.IsAssignableFrom(derivedType) form!
 
             if (type.FullName == baseType.FullName)
                 return true;
@@ -24,6 +24,31 @@ namespace TechTalk.SpecFlow.Bindings.Reflection
                 return true;
 
             return type.GetInterfaces().Any(_if => IsAssignableTo(baseType, _if));
+        }
+
+        public static bool IsAssignableToFixed(this Type type, IBindingType baseType)
+        {
+            if (baseType is RuntimeBindingType runtimeBindingType)
+                return runtimeBindingType.Type.IsAssignableFrom(type);
+
+            if (type.FullName == baseType.FullName)
+                return true;
+
+            if (type.BaseType != null && IsAssignableToFixed(type.BaseType, baseType))
+                return true;
+
+            return type.GetInterfaces().Any(_if => IsAssignableToFixed(_if, baseType));
+        }
+
+        public static bool IsAssignableFrom(this Type baseType, IBindingType type)
+        {
+            if (type is IPolymorphicBindingType polymorphicBindingType)
+                return polymorphicBindingType.IsAssignableTo(new RuntimeBindingType(baseType));
+
+            if (type.FullName == baseType.FullName)
+                return true;
+
+            return false;
         }
 
         public static bool MethodEquals(this IBindingMethod method1, IBindingMethod method2)

--- a/TechTalk.SpecFlow/Bindings/Reflection/IPolymorphicBindingType.cs
+++ b/TechTalk.SpecFlow/Bindings/Reflection/IPolymorphicBindingType.cs
@@ -1,0 +1,7 @@
+﻿namespace TechTalk.SpecFlow.Bindings.Reflection
+{
+    public interface IPolymorphicBindingType : IBindingType
+    {
+        bool IsAssignableTo(IBindingType baseType);
+    }
+}

--- a/TechTalk.SpecFlow/Bindings/Reflection/RuntimeBindingType.cs
+++ b/TechTalk.SpecFlow/Bindings/Reflection/RuntimeBindingType.cs
@@ -19,7 +19,7 @@ namespace TechTalk.SpecFlow.Bindings.Reflection
 
         public bool IsAssignableTo(IBindingType baseType)
         {
-            return Type.IsAssignableToFixed(baseType);
+            return Type.IsAssignableTo(baseType);
         }
 
         public override string ToString()

--- a/TechTalk.SpecFlow/Bindings/Reflection/RuntimeBindingType.cs
+++ b/TechTalk.SpecFlow/Bindings/Reflection/RuntimeBindingType.cs
@@ -2,7 +2,7 @@ using System;
 
 namespace TechTalk.SpecFlow.Bindings.Reflection
 {
-    public class RuntimeBindingType : IBindingType
+    public class RuntimeBindingType : IPolymorphicBindingType
     {
         public readonly Type Type;
 
@@ -15,6 +15,11 @@ namespace TechTalk.SpecFlow.Bindings.Reflection
         public RuntimeBindingType(Type type)
         {
             this.Type = type;
+        }
+
+        public bool IsAssignableTo(IBindingType baseType)
+        {
+            return Type.IsAssignableToFixed(baseType);
         }
 
         public override string ToString()

--- a/TechTalk.SpecFlow/Infrastructure/StepDefinitionMatchService.cs
+++ b/TechTalk.SpecFlow/Infrastructure/StepDefinitionMatchService.cs
@@ -49,7 +49,7 @@ namespace TechTalk.SpecFlow.Infrastructure
 
         private bool CanConvertArg(object value, IBindingType typeToConvertTo, CultureInfo bindingCulture)
         {
-            if (value.GetType().IsAssignableToFixed(typeToConvertTo))
+            if (value.GetType().IsAssignableTo(typeToConvertTo))
                 return true;
 
             return stepArgumentTypeConverter.CanConvert(value, typeToConvertTo, bindingCulture);

--- a/TechTalk.SpecFlow/Infrastructure/StepDefinitionMatchService.cs
+++ b/TechTalk.SpecFlow/Infrastructure/StepDefinitionMatchService.cs
@@ -49,8 +49,7 @@ namespace TechTalk.SpecFlow.Infrastructure
 
         private bool CanConvertArg(object value, IBindingType typeToConvertTo, CultureInfo bindingCulture)
         {
-            //TODO: fix IsAssignableTo usage
-            if (typeToConvertTo.IsAssignableTo(value.GetType()))
+            if (value.GetType().IsAssignableToFixed(typeToConvertTo))
                 return true;
 
             return stepArgumentTypeConverter.CanConvert(value, typeToConvertTo, bindingCulture);

--- a/TechTalk.SpecFlow/Infrastructure/StepDefinitionMatchService.cs
+++ b/TechTalk.SpecFlow/Infrastructure/StepDefinitionMatchService.cs
@@ -49,6 +49,7 @@ namespace TechTalk.SpecFlow.Infrastructure
 
         private bool CanConvertArg(object value, IBindingType typeToConvertTo, CultureInfo bindingCulture)
         {
+            //TODO: fix IsAssignableTo usage
             if (typeToConvertTo.IsAssignableTo(value.GetType()))
                 return true;
 

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/Infrastructure/StepDefinitionMatchServiceTest.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/Infrastructure/StepDefinitionMatchServiceTest.cs
@@ -40,9 +40,19 @@ namespace TechTalk.SpecFlow.RuntimeTests.Infrastructure
             return new BindingMethod(new BindingType("dummy", "dummy", "dummy"), name, new IBindingParameter[0], null);
         }
 
-        private static BindingMethod CreateBindingMethodWithStrignParam(string name = "dummy")
+        private static BindingMethod CreateBindingMethodWithStringParam(string name = "dummy")
         {
             return new BindingMethod(new BindingType("dummy", "dummy", "dummy"), name, new IBindingParameter[] { new BindingParameter(new RuntimeBindingType(typeof(string)), "param1") }, null);
+        }
+
+        private static BindingMethod CreateBindingMethodWithDataTableParam(string name = "dummy")
+        {
+            return new BindingMethod(new BindingType("dummy", "dummy", "dummy"), name, new IBindingParameter[] { new BindingParameter(new RuntimeBindingType(typeof(Table)), "param1") }, null);
+        }
+
+        private static BindingMethod CreateBindingMethodWithObjectParam(string name = "dummy")
+        {
+            return new BindingMethod(new BindingType("dummy", "dummy", "dummy"), name, new IBindingParameter[] { new BindingParameter(new RuntimeBindingType(typeof(object)), "param1") }, null);
         }
 
         private StepInstance CreateSimpleWhen(string text = "I do something")
@@ -84,7 +94,52 @@ namespace TechTalk.SpecFlow.RuntimeTests.Infrastructure
         [Fact]
         public void Should_GetBestMatch_succeed_when_proper_match_with_parameters()
         {
-            whenStepDefinitions.Add(new StepDefinitionBinding(StepDefinitionType.When, "(.*)", CreateBindingMethodWithStrignParam(), null));
+            whenStepDefinitions.Add(new StepDefinitionBinding(StepDefinitionType.When, "(.*)", CreateBindingMethodWithStringParam(), null));
+
+            var sut = CreateSUT();
+
+            StepDefinitionAmbiguityReason ambiguityReason;
+            List<BindingMatch> candidatingMatches;
+            var result = sut.GetBestMatch(CreateSimpleWhen(), bindingCulture, out ambiguityReason, out candidatingMatches);
+
+            result.Success.Should().BeTrue();
+        }
+
+        [Fact]
+        public void Should_GetBestMatch_succeed_when_proper_match_with_parameters_even_if_there_is_a_DataTable_overload()
+        {
+            whenStepDefinitions.Add(new StepDefinitionBinding(StepDefinitionType.When, "(.*)", CreateBindingMethodWithStringParam(), null));
+            whenStepDefinitions.Add(new StepDefinitionBinding(StepDefinitionType.When, ".*", CreateBindingMethodWithDataTableParam(), null));
+
+            var sut = CreateSUT();
+
+            StepDefinitionAmbiguityReason ambiguityReason;
+            List<BindingMatch> candidatingMatches;
+            var result = sut.GetBestMatch(CreateSimpleWhen(), bindingCulture, out ambiguityReason, out candidatingMatches);
+
+            result.Success.Should().BeTrue();
+        }
+
+        [Fact]
+        public void Should_GetBestMatch_succeed_when_proper_match_with_object_parameters()
+        {
+            whenStepDefinitions.Add(new StepDefinitionBinding(StepDefinitionType.When, "(.*)", CreateBindingMethodWithObjectParam(), null));
+
+            var sut = CreateSUT();
+
+            StepDefinitionAmbiguityReason ambiguityReason;
+            List<BindingMatch> candidatingMatches;
+            var result = sut.GetBestMatch(CreateSimpleWhen(), bindingCulture, out ambiguityReason, out candidatingMatches);
+
+            result.Success.Should().BeTrue();
+        }
+
+
+        [Fact]
+        public void Should_GetBestMatch_succeed_when_proper_match_with_object_parameters_even_if_there_is_a_DataTable_overload()
+        {
+            whenStepDefinitions.Add(new StepDefinitionBinding(StepDefinitionType.When, "(.*)", CreateBindingMethodWithObjectParam(), null));
+            whenStepDefinitions.Add(new StepDefinitionBinding(StepDefinitionType.When, ".*", CreateBindingMethodWithDataTableParam(), null));
 
             var sut = CreateSUT();
 

--- a/Tests/TechTalk.SpecFlow.RuntimeTests/RuntimeBindingRegistryBuilderTests.cs
+++ b/Tests/TechTalk.SpecFlow.RuntimeTests/RuntimeBindingRegistryBuilderTests.cs
@@ -134,6 +134,63 @@ namespace TechTalk.SpecFlow.RuntimeTests
             }
         }
 
+        [Binding]
+        public class BindingClassWithStepDefinitionAttributes
+        {
+            [Given("I have done something")]
+            public void GivenIHaveDoneSomething()
+            {
+            }
+
+            [When("I do something")]
+            public void WhenIDoSomething()
+            {
+            }
+
+            [Then("something should happen")]
+            public void ThenSomethingShouldHappen()
+            {
+            }
+        }
+
+        [Binding]
+        public class BindingClassWithTranslatedStepDefinitionAttributes
+        {
+            public class AngenommenAttribute : GivenAttribute
+            {
+                public AngenommenAttribute(string regex) : base(regex, "de-DE")
+                {
+                }
+            }
+            public class WennAttribute : WhenAttribute
+            {
+                public WennAttribute(string regex) : base(regex, "de-DE")
+                {
+                }
+            }
+            public class DannAttribute : ThenAttribute
+            {
+                public DannAttribute(string regex) : base(regex, "de-DE")
+                {
+                }
+            }
+
+            [Angenommen("mache ich was")]
+            public void AngenommenMacheIchWas()
+            {
+            }
+
+            [Wenn("ich etwas mache")]
+            public void WennIchEtwasMache()
+            {
+            }
+
+            [Dann("sollte etwas passieren")]
+            public void DannSollteEtwasPassieren()
+            {
+            }
+        }
+
         [Fact]
         public void ShouldFindBinding_WithDefaultOrder()
         {
@@ -277,6 +334,32 @@ namespace TechTalk.SpecFlow.RuntimeTests
 
             Assert.Equal(1,
                 bindingSourceProcessorStub.HookBindings.Count(s => s.Method.Name == "Tag1BeforeScenario" && s.IsScoped));
+        }
+
+        [Fact]
+        public void ShouldFindStepDefinitionsWithStepDefinitionAttributes()
+        {
+            var builder = new RuntimeBindingRegistryBuilder(bindingSourceProcessorStub, new SpecFlowAttributesFilter());
+
+            builder.BuildBindingsFromType(typeof(BindingClassWithStepDefinitionAttributes));
+
+            Assert.Equal(3, bindingSourceProcessorStub.StepDefinitionBindings.Count);
+            Assert.Equal(1, bindingSourceProcessorStub.StepDefinitionBindings.Count(b => b.StepDefinitionType == StepDefinitionType.Given));
+            Assert.Equal(1, bindingSourceProcessorStub.StepDefinitionBindings.Count(b => b.StepDefinitionType == StepDefinitionType.When));
+            Assert.Equal(1, bindingSourceProcessorStub.StepDefinitionBindings.Count(b => b.StepDefinitionType == StepDefinitionType.Then));
+        }
+
+        [Fact]
+        public void ShouldFindStepDefinitionsWithTranslatedAttributes()
+        {
+            var builder = new RuntimeBindingRegistryBuilder(bindingSourceProcessorStub, new SpecFlowAttributesFilter());
+
+            builder.BuildBindingsFromType(typeof(BindingClassWithTranslatedStepDefinitionAttributes));
+
+            Assert.Equal(3, bindingSourceProcessorStub.StepDefinitionBindings.Count);
+            Assert.Equal(1, bindingSourceProcessorStub.StepDefinitionBindings.Count(b => b.StepDefinitionType == StepDefinitionType.Given));
+            Assert.Equal(1, bindingSourceProcessorStub.StepDefinitionBindings.Count(b => b.StepDefinitionType == StepDefinitionType.When));
+            Assert.Equal(1, bindingSourceProcessorStub.StepDefinitionBindings.Count(b => b.StepDefinitionType == StepDefinitionType.Then));
         }
     }
 }

--- a/changelog.txt
+++ b/changelog.txt
@@ -11,12 +11,14 @@ Features:
 
 + cucumber-messages can be enabled via specflow.json and app.config
 + file sinks for cucumber-messages can be configured
++ Support discovering step definitions from attributes that are derived from Given,When,Then or StepDefinition attributes (related to https://github.com/techtalk/SpecFlow/issues/1745)
 
 Fixes: 
 + AfterTestRun hook can take longer than 100ms on .NET Core https://github.com/techtalk/SpecFlow/issues/1348
 + Adjust parameter names generation in scenario outlines https://github.com/techtalk/SpecFlow/issues/1694
 + specflow.json can be used in SpecFlow+Runner with Process test thread isolation https://github.com/techtalk/SpecFlow/issues/1761
 + specflow.json is copied to output directory automatically https://github.com/techtalk/SpecFlow/issues/1315
++ step definition method with "object" parameter type might not match
 
 
 Changes:


### PR DESCRIPTION
This issue is related to #1745. Although it will not fix it but provides the necessary infrastructure for a good workaround.

SpecFlow finds step definitions if they are attributed with Given, When, Then or StepDefinition attributes only but not when a derived attribute is used. This might be a problem for non-English projects, where the attribute name might be misleading (e.g. `[Then("sollte etwas passieren")]` for step `Dann sollte etwas passieren`). 

This PR provides support for using derived attributes, so one can create a language-specific attribute, like 

```
public class DannAttribute : ThenAttribute
{
  public DannAttribute(string regex) : base(regex, "de-DE") {}
}
```

Later we might provide these translated attributes as additional packages (at least for commonly used languages).

*Note:* During the implementation I have discovered a bug in `BindingReflectionExtensions.IsAssignableTo`. This method is only used for finding the matching step definition, but because of the nature of the bug and the context, it practically never affects the user. The only case when the bug can be effective if you have two step definitions matching to the same text, one has an object parameter and another has a Table parameter. So it is super rare, but I have fixed the issue to avoid problems later. The bug fix cannot be separated easily from the PR, but from the commits it is visible. There are unit tests added to reproduce the bug and prove the fix.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

- [x] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added an entry to the changelog
