### PR TITLE
Reduce the file system "load" in Azure Pipelines

### DIFF
--- a/Tests/TechTalk.SpecFlow.Specs/Support/Hooks.cs
+++ b/Tests/TechTalk.SpecFlow.Specs/Support/Hooks.cs
@@ -14,13 +14,15 @@ namespace TechTalk.SpecFlow.Specs.Support
         private readonly CurrentVersionDriver _currentVersionDriver;
         private readonly RuntimeInformationProvider _runtimeInformationProvider;
         private readonly IUnitTestRuntimeProvider _unitTestRuntimeProvider;
+        private readonly TestProjectFolders _testProjectFolders;
 
-        public Hooks(ScenarioContext scenarioContext, CurrentVersionDriver currentVersionDriver, RuntimeInformationProvider runtimeInformationProvider, IUnitTestRuntimeProvider unitTestRuntimeProvider)
+        public Hooks(ScenarioContext scenarioContext, CurrentVersionDriver currentVersionDriver, RuntimeInformationProvider runtimeInformationProvider, IUnitTestRuntimeProvider unitTestRuntimeProvider, TestProjectFolders testProjectFolders)
         {
             _scenarioContext = scenarioContext;
             _currentVersionDriver = currentVersionDriver;
             _runtimeInformationProvider = runtimeInformationProvider;
             _unitTestRuntimeProvider = unitTestRuntimeProvider;
+            _testProjectFolders = testProjectFolders;
         }
 
         [BeforeScenario("WindowsOnly")]
@@ -38,6 +40,22 @@ namespace TechTalk.SpecFlow.Specs.Support
             _currentVersionDriver.NuGetVersion = NuGetPackageVersion.Version;
             _currentVersionDriver.SpecFlowNuGetVersion = NuGetPackageVersion.Version;
             _scenarioContext.ScenarioContainer.RegisterTypeAs<OutputConnector, IOutputWriter>();
+        }
+
+        [AfterScenario]
+        public void AfterScenario()
+        {
+            if (_scenarioContext.TestError == null && _testProjectFolders.IsPathToSolutionFileSet)
+            {
+                try
+                {
+                    FileSystemHelper.DeleteFolder(_testProjectFolders.PathToSolutionDirectory);
+                }
+                catch (Exception)
+                {
+                    // ignored
+                }
+            }
         }
 
         [BeforeTestRun]


### PR DESCRIPTION
Currently the XUnit stage fails with the error: "There is not enough space on the disk"

The PR improves the following things:
 - the MSBuild verbosity level is reduced to minimal in the `VSTestExecutionDriver`
 - the generated test projects are deleted after the scenario is succeed and not kept around until the end of the whole test run