### PR TITLE
WIP. xUnit Collection name and Collection fixture class full name tags #1430

### DIFF
--- a/TechTalk.SpecFlow.Generator/UnitTestProvider/XUnitTestGeneratorProvider.cs
+++ b/TechTalk.SpecFlow.Generator/UnitTestProvider/XUnitTestGeneratorProvider.cs
@@ -43,7 +43,7 @@ namespace TechTalk.SpecFlow.Generator.UnitTestProvider
             // xUnit does not use an attribute for the TestFixture, all public classes are potential fixtures
         }
 
-        public void SetTestClassCategories(TestClassGenerationContext generationContext, IEnumerable<string> featureCategories)
+        public virtual void SetTestClassCategories(TestClassGenerationContext generationContext, IEnumerable<string> featureCategories)
         {
             // Set Category trait which can be used with the /trait or /-trait xunit flags to include/exclude tests
             foreach (string str in featureCategories)

--- a/Tests/TechTalk.SpecFlow.Specs/Features/UnitTestProviderSpecific/XUnit/XUnit2Provider.feature
+++ b/Tests/TechTalk.SpecFlow.Specs/Features/UnitTestProviderSpecific/XUnit/XUnit2Provider.feature
@@ -69,7 +69,6 @@ Scenario: Should be able to set collection attribute
         ScenarioContext.Current.ScenarioContainer.Resolve<Xunit.Abstractions.ITestOutputHelper>().WriteLine("hello");
         }
         """
-		When the feature files in the project are generated
     When I execute the tests
     Then the execution summary should contain
         | Succeeded |

--- a/Tests/TechTalk.SpecFlow.Specs/Features/UnitTestProviderSpecific/XUnit/XUnit2Provider.feature
+++ b/Tests/TechTalk.SpecFlow.Specs/Features/UnitTestProviderSpecific/XUnit/XUnit2Provider.feature
@@ -54,3 +54,23 @@ Scenario: Should be able to log custom messages using context injection
     Then the execution summary should contain
          | Succeeded |
          | 1         |
+
+Scenario: Should be able to set collection attribute
+    Given there is a SpecFlow project
+    And a scenario 'Simple Scenario' as with collection attribute 'sample'
+        """
+        When I do something
+        """	
+    And the following step definition
+        """
+        [When(@"I do something")]
+        public void WhenIDoSomething()
+        {
+        ScenarioContext.Current.ScenarioContainer.Resolve<Xunit.Abstractions.ITestOutputHelper>().WriteLine("hello");
+        }
+        """
+		When the feature files in the project are generated
+    When I execute the tests
+    Then the execution summary should contain
+        | Succeeded |
+        | 1         |

--- a/Tests/TechTalk.SpecFlow.Specs/StepDefinitions/FeatureFileSteps.cs
+++ b/Tests/TechTalk.SpecFlow.Specs/StepDefinitions/FeatureFileSteps.cs
@@ -32,6 +32,17 @@ Scenario: {title}
                 ");
         }
 
+        [Given(@"a scenario '(.*)' as with collection attribute '(.*)'")]
+        public void GivenAScenarioAsWithCollectionAttribute(string title,  string collection, string scenarioContent)
+        {
+            _projectsDriver.AddFeatureFile(
+                 $@"@xunit:collection({collection})
+                    Feature: Feature {Guid.NewGuid()}
+                    Scenario: {title}
+{scenarioContent.Replace("'''", "\"\"\"")}
+                ");
+        }
+
         [Given(@"there is a scenario in a feature file")]
         public void GivenThereIsAScenarioInAFeatureFile()
         {


### PR DESCRIPTION
<!--- Describe your changes in detail -->
Namaste!
I tried to solve #1430. But because I can't build NuGet-package and run tests locally I can't validate my work. I'm very new to BDD and SpecFlow. So what I tried to accomplish:
1. The `@xunit:collection` tag is broken. The problem was collection name could be any string not just a valid identifier. I've fixed that. Now I require that tag should be in a form (note the quotes):
```
@xunit:collection("collection name event with spaces and любые национальные символы")
```
2. There is no need to specify `CollectionAttribute` on a text class to make it parallelizable or not. If there is no `CollectionAttribute` on a class it has a virtual one by default, every class is a separate collection.
3. I've added a tag for collection fixture class name: `@xunit:collectionFixtureClassFullName`. Yes it's a bit long but at least self describing. The value of this tag is the full class name of a test collection fixture. I tried to use collection class full name (because collection class has it's name in the attribute and collection fixture class name in type declaration) but realized that I have no access to actual user code during code generation pass. The best user can specify is the collection fixture class full name. Usage (once again quotes are required):
```
@xunit:collectionFixtureClassFullName("Some.User.Namespace.CollectionFixture")
```
The class name can contain any word characters not only Latin. Please don't forget about other languages and cultures. They are and .NET allows to use those characters for valid literals.
4. Collection name and Collection fixture class full name tags are mutually exclusive. The user should one or another or non at all.

Thank you for your attention and I'm ready to discuss the change.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added tests for my code.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added an entry to the changelog
